### PR TITLE
fix: remove hardcoded credentials from source-controlled files

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,8 +11,11 @@ ONRAMP_AI_FOUNDRY_ENDPOINT=
 ONRAMP_AI_FOUNDRY_KEY=
 ONRAMP_AI_FOUNDRY_DEPLOYMENT=gpt-4o
 
-# Database (default uses local SQL Server from docker-compose)
-ONRAMP_DATABASE_URL=mssql+pyodbc://sa:OnRamp_Dev_P@ss1@localhost:1433/onramp?driver=ODBC+Driver+18+for+SQL+Server&TrustServerCertificate=yes
+# Database (leave empty for dev mode with SQLite, or set for MSSQL)
+ONRAMP_DATABASE_URL=
+
+# SQL Server SA password (used by docker-compose "full" profile)
+MSSQL_SA_PASSWORD=<generate-a-strong-password>
 
 # CORS
 ONRAMP_CORS_ORIGINS=http://localhost:5173,http://localhost:3000

--- a/.env.example
+++ b/.env.example
@@ -18,7 +18,7 @@ ONRAMP_DATABASE_URL=
 MSSQL_SA_PASSWORD=<generate-a-strong-password>
 
 # CORS
-ONRAMP_CORS_ORIGINS=http://localhost:5173,http://localhost:3000
+ONRAMP_CORS_ORIGINS=["http://localhost:5173","http://localhost:3000"]
 
 # Key Vault (optional)
 ONRAMP_KEY_VAULT_URL=

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -5,8 +5,8 @@ class Settings(BaseSettings):
     app_name: str = "OnRamp API"
     debug: bool = False
 
-    # Database
-    database_url: str = "mssql+aioodbc://sa:Password123!@localhost:1433/onramp?driver=ODBC+Driver+18+for+SQL+Server&TrustServerCertificate=yes"
+    # Database (empty = dev mode with SQLite)
+    database_url: str = ""
 
     # Azure AD / Entra ID
     azure_tenant_id: str = ""

--- a/backend/tests/test_config.py
+++ b/backend/tests/test_config.py
@@ -14,8 +14,9 @@ def test_env_prefix():
 def test_settings_singleton():
     assert settings.app_name == "OnRamp API"
 
-def test_database_url_defaults_empty():
+def test_database_url_defaults_empty(monkeypatch):
     """Database URL defaults to empty string (dev mode uses SQLite fallback)."""
+    monkeypatch.setenv("ONRAMP_DATABASE_URL", "")
     s = Settings()
     assert s.database_url == ""
 

--- a/backend/tests/test_config.py
+++ b/backend/tests/test_config.py
@@ -14,9 +14,10 @@ def test_env_prefix():
 def test_settings_singleton():
     assert settings.app_name == "OnRamp API"
 
-def test_database_url_has_default():
+def test_database_url_defaults_empty():
+    """Database URL defaults to empty string (dev mode uses SQLite fallback)."""
     s = Settings()
-    assert "onramp" in s.database_url
+    assert s.database_url == ""
 
 def test_azure_defaults_empty():
     s = Settings()

--- a/backend/tests/test_database.py
+++ b/backend/tests/test_database.py
@@ -10,9 +10,9 @@ def test_database_module_importable():
 
 
 def test_database_url_construction_default():
-    """Default database URL is MSSQL."""
+    """Default database URL is empty (dev mode — SQLite fallback handled by session.py)."""
     from app.config import settings
-    assert "mssql" in settings.database_url or "sqlite" in settings.database_url
+    assert settings.database_url == "" or "mssql" in settings.database_url or "sqlite" in settings.database_url
 
 
 def test_session_get_database_url_helper():

--- a/dev.sh
+++ b/dev.sh
@@ -40,6 +40,23 @@ banner() {
     echo "─────────────────────────────────"
 }
 
+bootstrap_env() {
+    if [ ! -f .env ]; then
+        echo -e "${YELLOW}No .env file found — generating from .env.example...${NC}"
+        cp .env.example .env
+        # Generate a random SA password for local SQL Server
+        local sa_pass
+        sa_pass="OnRamp_$(openssl rand -base64 16 | tr -dc 'A-Za-z0-9' | head -c 16)!"
+        if [[ "$OSTYPE" == "darwin"* ]]; then
+            sed -i '' "s|<generate-a-strong-password>|${sa_pass}|g" .env
+        else
+            sed -i "s|<generate-a-strong-password>|${sa_pass}|g" .env
+        fi
+        echo -e "${GREEN}.env created with generated MSSQL_SA_PASSWORD.${NC}"
+        echo -e "${YELLOW}Review .env and customize as needed.${NC}"
+    fi
+}
+
 check_prereqs() {
     local missing=()
     if ! command -v docker &>/dev/null; then missing+=("docker"); fi
@@ -94,6 +111,7 @@ wait_for_health() {
 cmd_up() {
     banner
     check_prereqs
+    bootstrap_env
 
     echo -e "${BLUE}Building and starting containers...${NC}"
     $COMPOSE build --quiet 2>&1 | tail -1 || true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -51,14 +51,14 @@ services:
     profiles: ["full"]
     environment:
       ACCEPT_EULA: "Y"
-      MSSQL_SA_PASSWORD: "OnRamp_Dev_P@ss1"
+      MSSQL_SA_PASSWORD: "${MSSQL_SA_PASSWORD:?Set MSSQL_SA_PASSWORD in .env}"
       MSSQL_PID: "Developer"
     ports:
       - "1433:1433"
     volumes:
       - sqldata:/var/opt/mssql
     healthcheck:
-      test: /opt/mssql-tools18/bin/sqlcmd -S localhost -U sa -P "OnRamp_Dev_P@ss1" -Q "SELECT 1" -C -b
+      test: /opt/mssql-tools18/bin/sqlcmd -S localhost -U sa -P "$$MSSQL_SA_PASSWORD" -Q "SELECT 1" -C -b
       interval: 10s
       timeout: 5s
       retries: 5


### PR DESCRIPTION
## Summary

Removes all hardcoded credentials from source-controlled files per #48.

### Changes

| File | What Changed |
|------|-------------|
| \ackend/app/config.py\ | Removed \Password123!\ default from \database_url\ — now defaults to empty string (dev mode uses SQLite fallback) |
| \docker-compose.yml\ | Replaced hardcoded \OnRamp_Dev_P@ss1\ with \\\ env var interpolation |
| \.env.example\ | Replaced real credentials with \<generate-a-strong-password>\ placeholder |
| \dev.sh\ | Added \ootstrap_env\ — auto-generates \.env\ with random SA password on first run |
| \	ests/test_config.py\ | Updated test to assert empty default database_url |
| \	ests/test_database.py\ | Updated test to accept empty default |

### How to test

1. Delete any local \.env\ file
2. Run \./dev.sh up\ — should auto-generate \.env\ with a random password
3. Backend starts in dev mode (SQLite, mock auth) with no credentials in source

### Post-merge action required

Create GitHub **Environment secrets** on \dev\ and \prod\ environments:

| Secret | Source |
|--------|--------|
| \AZURE_CLIENT_ID\ | Entra ID app registration → Application (client) ID |
| \AZURE_TENANT_ID\ | Entra ID → Directory (tenant) ID |
| \AZURE_SUBSCRIPTION_ID\ | Azure Portal → Subscriptions |
| \SQL_ADMIN_PASSWORD\ | Choose a strong password for Azure SQL admin |

Closes #48