### PR TITLE
fix: add .dockerignore files to frontend and backend

### DIFF
--- a/backend/.dockerignore
+++ b/backend/.dockerignore
@@ -1,0 +1,31 @@
+# Python bytecode
+__pycache__/
+*.pyc
+*.pyo
+
+# Tests & coverage
+tests/
+.pytest_cache/
+coverage/
+htmlcov/
+.coverage
+
+# Linting & type checking
+.ruff_cache/
+.mypy_cache/
+
+# Environment
+.env
+.env.*
+
+# Git
+.git/
+.gitignore
+
+# IDE
+.vscode/
+.idea/
+
+# Virtual environments
+.venv/
+venv/

--- a/frontend/.dockerignore
+++ b/frontend/.dockerignore
@@ -1,0 +1,24 @@
+# Dependencies
+node_modules/
+
+# Build output
+dist/
+
+# Test & coverage
+*.test.*
+coverage/
+
+# Environment
+.env
+.env.*
+
+# Git
+.git/
+.gitignore
+
+# IDE
+.vscode/
+.idea/
+
+# Docs
+README.md


### PR DESCRIPTION
## Summary

Adds \.dockerignore\ files to both \rontend/\ and \ackend/\ per #49.

### What's excluded

**Frontend:** \
ode_modules/\, \dist/\, \*.test.*\, \coverage/\, \.env*\, \.git/\
**Backend:** \__pycache__/\, \*.pyc\, \	ests/\, \.pytest_cache/\, \.ruff_cache/\, \.mypy_cache/\, \.env*\, \coverage/\, \.git/\, \.venv/\

### Benefits
- Smaller Docker build context and image sizes
- Prevents \.env\ files (which now contain generated passwords per #48) from leaking into images
- Excludes test/coverage artifacts from production images

All 245 backend tests pass.

Closes #49