### PR TITLE
fix: Align database migrations with SQLAlchemy models

### DIFF
--- a/backend/app/db/migrations/env.py
+++ b/backend/app/db/migrations/env.py
@@ -41,7 +41,11 @@ def run_migrations_offline() -> None:
 
 
 def do_run_migrations(connection):
-    context.configure(connection=connection, target_metadata=target_metadata)
+    context.configure(
+        connection=connection,
+        target_metadata=target_metadata,
+        render_as_batch=True,
+    )
     with context.begin_transaction():
         context.run_migrations()
 
@@ -56,6 +60,12 @@ async def run_async_migrations() -> None:
 
 def run_migrations_online() -> None:
     """Run migrations in 'online' mode."""
+    # If a connection was injected (e.g., from init_db or tests), use it directly
+    connection = config.attributes.get("connection", None)
+    if connection is not None:
+        do_run_migrations(connection)
+        return
+
     asyncio.run(run_async_migrations())
 
 

--- a/backend/app/db/migrations/versions/001_initial_schema.py
+++ b/backend/app/db/migrations/versions/001_initial_schema.py
@@ -1,4 +1,4 @@
-"""Initial schema.
+"""Initial schema — aligned with SQLAlchemy models.
 
 Revision ID: 001
 Revises: None
@@ -21,35 +21,46 @@ def upgrade() -> None:
         "tenants",
         sa.Column("id", sa.String(36), primary_key=True),
         sa.Column("name", sa.String(255), nullable=False),
-        sa.Column("azure_tenant_id", sa.String(36), unique=True),
-        sa.Column("created_at", sa.DateTime, server_default=sa.func.now()),
-        sa.Column("updated_at", sa.DateTime, server_default=sa.func.now(), onupdate=sa.func.now()),
+        sa.Column("azure_tenant_id", sa.String(36), nullable=True),
+        sa.Column("is_active", sa.Boolean, server_default=sa.text("1"), nullable=True),
+        sa.Column("created_at", sa.DateTime, server_default=sa.func.now(), nullable=False),
+        sa.Column(
+            "updated_at", sa.DateTime, server_default=sa.func.now(),
+            onupdate=sa.func.now(), nullable=False,
+        ),
     )
 
     # Users
     op.create_table(
         "users",
         sa.Column("id", sa.String(36), primary_key=True),
-        sa.Column("tenant_id", sa.String(36), sa.ForeignKey("tenants.id")),
-        sa.Column("email", sa.String(255), nullable=False, unique=True),
-        sa.Column("name", sa.String(255)),
+        sa.Column("entra_object_id", sa.String(36), unique=True, nullable=False),
+        sa.Column("email", sa.String(255), nullable=False),
+        sa.Column("display_name", sa.String(255), nullable=False),
         sa.Column("role", sa.String(50), server_default="viewer"),
-        sa.Column("azure_oid", sa.String(36)),
-        sa.Column("created_at", sa.DateTime, server_default=sa.func.now()),
-        sa.Column("updated_at", sa.DateTime, server_default=sa.func.now(), onupdate=sa.func.now()),
+        sa.Column("is_active", sa.Boolean, server_default=sa.text("1"), nullable=True),
+        sa.Column("tenant_id", sa.String(36), sa.ForeignKey("tenants.id"), nullable=False),
+        sa.Column("created_at", sa.DateTime, server_default=sa.func.now(), nullable=False),
+        sa.Column(
+            "updated_at", sa.DateTime, server_default=sa.func.now(),
+            onupdate=sa.func.now(), nullable=False,
+        ),
     )
 
     # Projects
     op.create_table(
         "projects",
         sa.Column("id", sa.String(36), primary_key=True),
-        sa.Column("tenant_id", sa.String(36), sa.ForeignKey("tenants.id")),
         sa.Column("name", sa.String(255), nullable=False),
-        sa.Column("description", sa.Text),
+        sa.Column("description", sa.Text, nullable=True),
         sa.Column("status", sa.String(50), server_default="draft"),
-        sa.Column("created_by", sa.String(36), sa.ForeignKey("users.id")),
-        sa.Column("created_at", sa.DateTime, server_default=sa.func.now()),
-        sa.Column("updated_at", sa.DateTime, server_default=sa.func.now(), onupdate=sa.func.now()),
+        sa.Column("tenant_id", sa.String(36), sa.ForeignKey("tenants.id"), nullable=False),
+        sa.Column("created_by", sa.String(36), sa.ForeignKey("users.id"), nullable=False),
+        sa.Column("created_at", sa.DateTime, server_default=sa.func.now(), nullable=False),
+        sa.Column(
+            "updated_at", sa.DateTime, server_default=sa.func.now(),
+            onupdate=sa.func.now(), nullable=False,
+        ),
     )
 
     # Question categories
@@ -57,78 +68,152 @@ def upgrade() -> None:
         "question_categories",
         sa.Column("id", sa.String(36), primary_key=True),
         sa.Column("name", sa.String(255), nullable=False),
-        sa.Column("description", sa.Text),
-        sa.Column("order", sa.Integer, server_default="0"),
+        sa.Column("caf_design_area", sa.String(100), nullable=False),
+        sa.Column("display_order", sa.Integer, server_default="0"),
+        sa.Column("description", sa.Text, nullable=True),
+        sa.Column("created_at", sa.DateTime, server_default=sa.func.now(), nullable=False),
+        sa.Column(
+            "updated_at", sa.DateTime, server_default=sa.func.now(),
+            onupdate=sa.func.now(), nullable=False,
+        ),
     )
 
     # Questions
     op.create_table(
         "questions",
         sa.Column("id", sa.String(36), primary_key=True),
-        sa.Column("category_id", sa.String(36), sa.ForeignKey("question_categories.id")),
         sa.Column("text", sa.Text, nullable=False),
+        sa.Column("help_text", sa.Text, nullable=True),
         sa.Column("question_type", sa.String(50), nullable=False),
-        sa.Column("options", sa.JSON),
-        sa.Column("required", sa.Boolean, server_default="1"),
-        sa.Column("order", sa.Integer, server_default="0"),
-        sa.Column("conditions", sa.JSON),
+        sa.Column("options", sa.JSON, nullable=True),
+        sa.Column("display_order", sa.Integer, server_default="0"),
+        sa.Column("is_required", sa.Boolean, server_default=sa.text("1"), nullable=True),
+        sa.Column(
+            "category_id", sa.String(36),
+            sa.ForeignKey("question_categories.id"), nullable=False,
+        ),
+        sa.Column(
+            "depends_on_question_id", sa.String(36),
+            sa.ForeignKey("questions.id"), nullable=True,
+        ),
+        sa.Column("depends_on_answer", sa.String(255), nullable=True),
+        sa.Column("min_org_size", sa.String(20), nullable=True),
+        sa.Column("created_at", sa.DateTime, server_default=sa.func.now(), nullable=False),
+        sa.Column(
+            "updated_at", sa.DateTime, server_default=sa.func.now(),
+            onupdate=sa.func.now(), nullable=False,
+        ),
     )
 
     # Questionnaire responses
     op.create_table(
         "questionnaire_responses",
         sa.Column("id", sa.String(36), primary_key=True),
-        sa.Column("project_id", sa.String(36), sa.ForeignKey("projects.id")),
-        sa.Column("answers", sa.JSON, nullable=False),
-        sa.Column("completed", sa.Boolean, server_default="0"),
-        sa.Column("created_at", sa.DateTime, server_default=sa.func.now()),
-        sa.Column("updated_at", sa.DateTime, server_default=sa.func.now(), onupdate=sa.func.now()),
+        sa.Column("answer_value", sa.Text, nullable=False),
+        sa.Column("answer_data", sa.JSON, nullable=True),
+        sa.Column(
+            "project_id", sa.String(36),
+            sa.ForeignKey("projects.id"), nullable=False,
+        ),
+        sa.Column(
+            "question_id", sa.String(36),
+            sa.ForeignKey("questions.id"), nullable=False,
+        ),
+        sa.Column("created_at", sa.DateTime, server_default=sa.func.now(), nullable=False),
+        sa.Column(
+            "updated_at", sa.DateTime, server_default=sa.func.now(),
+            onupdate=sa.func.now(), nullable=False,
+        ),
     )
 
     # Architectures
     op.create_table(
         "architectures",
         sa.Column("id", sa.String(36), primary_key=True),
-        sa.Column("project_id", sa.String(36), sa.ForeignKey("projects.id")),
-        sa.Column("archetype", sa.String(50)),
-        sa.Column("definition", sa.JSON, nullable=False),
-        sa.Column("ai_generated", sa.Boolean, server_default="0"),
         sa.Column("version", sa.Integer, server_default="1"),
-        sa.Column("created_at", sa.DateTime, server_default=sa.func.now()),
+        sa.Column("status", sa.String(50), server_default="draft"),
+        sa.Column("architecture_data", sa.JSON, nullable=False),
+        sa.Column("management_groups", sa.JSON, nullable=True),
+        sa.Column("subscriptions", sa.JSON, nullable=True),
+        sa.Column("network_topology", sa.JSON, nullable=True),
+        sa.Column("policies", sa.JSON, nullable=True),
+        sa.Column("compliance_frameworks", sa.JSON, nullable=True),
+        sa.Column("ai_reasoning", sa.Text, nullable=True),
+        sa.Column(
+            "project_id", sa.String(36),
+            sa.ForeignKey("projects.id"), unique=True, nullable=False,
+        ),
+        sa.Column("created_at", sa.DateTime, server_default=sa.func.now(), nullable=False),
+        sa.Column(
+            "updated_at", sa.DateTime, server_default=sa.func.now(),
+            onupdate=sa.func.now(), nullable=False,
+        ),
     )
 
     # Deployments
     op.create_table(
         "deployments",
         sa.Column("id", sa.String(36), primary_key=True),
-        sa.Column("project_id", sa.String(36), sa.ForeignKey("projects.id")),
-        sa.Column("architecture_id", sa.String(36), sa.ForeignKey("architectures.id")),
         sa.Column("status", sa.String(50), server_default="pending"),
-        sa.Column("subscription_ids", sa.JSON),
-        sa.Column("deployment_data", sa.JSON),
-        sa.Column("started_at", sa.DateTime),
-        sa.Column("completed_at", sa.DateTime),
-        sa.Column("created_at", sa.DateTime, server_default=sa.func.now()),
+        sa.Column("target_subscription_id", sa.String(36), nullable=False),
+        sa.Column("target_subscription_name", sa.String(255), nullable=True),
+        sa.Column("bicep_templates", sa.JSON, nullable=True),
+        sa.Column("azure_deployment_id", sa.String(255), nullable=True),
+        sa.Column("azure_deployment_url", sa.Text, nullable=True),
+        sa.Column("deployed_resources", sa.JSON, nullable=True),
+        sa.Column("error_details", sa.Text, nullable=True),
+        sa.Column("started_at", sa.DateTime, nullable=True),
+        sa.Column("completed_at", sa.DateTime, nullable=True),
+        sa.Column(
+            "project_id", sa.String(36),
+            sa.ForeignKey("projects.id"), nullable=False,
+        ),
+        sa.Column(
+            "initiated_by", sa.String(36),
+            sa.ForeignKey("users.id"), nullable=False,
+        ),
+        sa.Column("created_at", sa.DateTime, server_default=sa.func.now(), nullable=False),
+        sa.Column(
+            "updated_at", sa.DateTime, server_default=sa.func.now(),
+            onupdate=sa.func.now(), nullable=False,
+        ),
     )
 
     # Compliance frameworks
     op.create_table(
         "compliance_frameworks",
         sa.Column("id", sa.String(36), primary_key=True),
-        sa.Column("name", sa.String(100), nullable=False, unique=True),
-        sa.Column("description", sa.Text),
-        sa.Column("version", sa.String(20)),
+        sa.Column("name", sa.String(255), nullable=False, unique=True),
+        sa.Column("short_name", sa.String(50), nullable=False, unique=True),
+        sa.Column("description", sa.Text, nullable=True),
+        sa.Column("version", sa.String(50), nullable=True),
+        sa.Column("is_active", sa.Boolean, server_default=sa.text("1"), nullable=True),
+        sa.Column("created_at", sa.DateTime, server_default=sa.func.now(), nullable=False),
+        sa.Column(
+            "updated_at", sa.DateTime, server_default=sa.func.now(),
+            onupdate=sa.func.now(), nullable=False,
+        ),
     )
 
     # Compliance controls
     op.create_table(
         "compliance_controls",
         sa.Column("id", sa.String(36), primary_key=True),
-        sa.Column("framework_id", sa.String(36), sa.ForeignKey("compliance_frameworks.id")),
         sa.Column("control_id", sa.String(50), nullable=False),
-        sa.Column("name", sa.String(255), nullable=False),
-        sa.Column("description", sa.Text),
-        sa.Column("category", sa.String(100)),
+        sa.Column("title", sa.String(255), nullable=False),
+        sa.Column("description", sa.Text, nullable=True),
+        sa.Column("category", sa.String(255), nullable=True),
+        sa.Column("severity", sa.String(50), server_default="medium"),
+        sa.Column("azure_policy_definitions", sa.JSON, nullable=True),
+        sa.Column(
+            "framework_id", sa.String(36),
+            sa.ForeignKey("compliance_frameworks.id"), nullable=False,
+        ),
+        sa.Column("created_at", sa.DateTime, server_default=sa.func.now(), nullable=False),
+        sa.Column(
+            "updated_at", sa.DateTime, server_default=sa.func.now(),
+            onupdate=sa.func.now(), nullable=False,
+        ),
     )
 
 

--- a/backend/app/db/migrations/versions/003_add_audit_entries.py
+++ b/backend/app/db/migrations/versions/003_add_audit_entries.py
@@ -1,0 +1,60 @@
+"""Add audit_entries table for tracking changes and deployment events.
+
+Revision ID: 003
+Revises: 002
+Create Date: 2026-07-14
+"""
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "003"
+down_revision: str | None = "002"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "audit_entries",
+        sa.Column("id", sa.String(36), primary_key=True),
+        sa.Column(
+            "tenant_id", sa.String(36),
+            sa.ForeignKey("tenants.id"), nullable=True,
+        ),
+        sa.Column(
+            "project_id", sa.String(36),
+            sa.ForeignKey("projects.id"), nullable=True,
+        ),
+        sa.Column("deployment_id", sa.String(36), nullable=True),
+        sa.Column("entity_type", sa.String(100), nullable=False),
+        sa.Column("entity_id", sa.String(36), nullable=False),
+        sa.Column("action", sa.String(50), nullable=False),
+        sa.Column(
+            "actor_user_id", sa.String(36),
+            sa.ForeignKey("users.id"), nullable=True,
+        ),
+        sa.Column("actor_identifier", sa.String(255), nullable=True),
+        sa.Column("details", sa.JSON, nullable=True),
+        sa.Column("old_values", sa.JSON, nullable=True),
+        sa.Column("new_values", sa.JSON, nullable=True),
+        sa.Column("created_at", sa.DateTime, server_default=sa.func.now(), nullable=False),
+    )
+
+    op.create_index(
+        "ix_audit_entity_time",
+        "audit_entries",
+        ["entity_type", "entity_id", "created_at"],
+    )
+    op.create_index(
+        "ix_audit_project_time",
+        "audit_entries",
+        ["project_id", "created_at"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_audit_project_time", table_name="audit_entries")
+    op.drop_index("ix_audit_entity_time", table_name="audit_entries")
+    op.drop_table("audit_entries")

--- a/backend/app/db/session.py
+++ b/backend/app/db/session.py
@@ -71,7 +71,7 @@ async def get_db() -> AsyncSession:
 
 
 async def init_db():
-    """Initialize database - create tables if needed."""
+    """Initialize database — run Alembic migrations to create/update schema."""
     import asyncio
     import logging
     logger = logging.getLogger(__name__)
@@ -82,24 +82,51 @@ async def init_db():
     db_url = get_database_url()
     if "mssql" in db_url and "aioodbc" in db_url:
         await _ensure_mssql_database(db_url)
-    # Create tables with retry logic for slow-starting databases
+    # Run Alembic migrations with retry logic for slow-starting databases
     max_retries = 3
     for attempt in range(1, max_retries + 1):
         try:
-            from app.models import Base
-            async with engine.begin() as conn:
-                await conn.run_sync(Base.metadata.create_all)
-            logger.info("Database tables initialized")
+            await _run_migrations(engine)
+            logger.info("Database schema initialized via Alembic migrations")
             return
         except Exception as e:
             if attempt < max_retries:
-                logger.info("Table creation attempt %d/%d failed: %s — retrying in %ds",
+                logger.info("Migration attempt %d/%d failed: %s — retrying in %ds",
                             attempt, max_retries, e, attempt * 2)
                 await asyncio.sleep(attempt * 2)
             else:
                 logger.warning("Database initialization failed after %d attempts: %s",
                                max_retries, e)
                 logger.warning("Continuing without database — routes will return mock data")
+
+
+async def _run_migrations(engine):
+    """Run Alembic migrations using the given async engine."""
+    import os
+
+    from alembic.config import Config
+
+    # Find the alembic.ini relative to this file
+    backend_dir = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+    alembic_ini = os.path.join(backend_dir, "alembic.ini")
+
+    alembic_cfg = Config(alembic_ini)
+    # Override the script_location to use our migrations directory
+    migrations_dir = os.path.join(os.path.dirname(os.path.abspath(__file__)), "migrations")
+    alembic_cfg.set_main_option("script_location", migrations_dir)
+
+    # Run migrations synchronously inside an async connection
+    async with engine.connect() as conn:
+        await conn.run_sync(lambda sync_conn: _do_upgrade(alembic_cfg, sync_conn))
+        await conn.commit()
+
+
+def _do_upgrade(alembic_cfg, connection):
+    """Execute Alembic upgrade head using the provided connection."""
+    from alembic import command
+
+    alembic_cfg.attributes["connection"] = connection
+    command.upgrade(alembic_cfg, "head")
 
 
 async def _ensure_mssql_database(db_url: str):

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -1,4 +1,5 @@
 from app.models.architecture import Architecture
+from app.models.audit_entry import AuditEntry
 from app.models.base import Base
 from app.models.bicep_file import BicepFile
 from app.models.compliance import ComplianceControl, ComplianceFramework
@@ -23,4 +24,5 @@ __all__ = [
     "ComplianceControl",
     "BicepFile",
     "ComplianceResult",
+    "AuditEntry",
 ]

--- a/backend/app/models/audit_entry.py
+++ b/backend/app/models/audit_entry.py
@@ -1,0 +1,43 @@
+"""AuditEntry model — event log for tracking changes and deployment events."""
+
+from datetime import datetime
+
+from sqlalchemy import JSON, DateTime, ForeignKey, Index, String, func
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.models.base import Base, generate_uuid
+
+
+class AuditEntry(Base):
+    __tablename__ = "audit_entries"
+    __table_args__ = (
+        Index("ix_audit_entity_time", "entity_type", "entity_id", "created_at"),
+        Index("ix_audit_project_time", "project_id", "created_at"),
+    )
+
+    id: Mapped[str] = mapped_column(String(36), primary_key=True, default=generate_uuid)
+
+    tenant_id: Mapped[str | None] = mapped_column(
+        String(36), ForeignKey("tenants.id"), nullable=True
+    )
+    project_id: Mapped[str | None] = mapped_column(
+        String(36), ForeignKey("projects.id"), nullable=True
+    )
+    deployment_id: Mapped[str | None] = mapped_column(String(36), nullable=True)
+
+    entity_type: Mapped[str] = mapped_column(String(100), nullable=False)
+    entity_id: Mapped[str] = mapped_column(String(36), nullable=False)
+    action: Mapped[str] = mapped_column(String(50), nullable=False)
+
+    actor_user_id: Mapped[str | None] = mapped_column(
+        String(36), ForeignKey("users.id"), nullable=True
+    )
+    actor_identifier: Mapped[str | None] = mapped_column(String(255), nullable=True)
+
+    details: Mapped[dict | None] = mapped_column(JSON, nullable=True)
+    old_values: Mapped[dict | None] = mapped_column(JSON, nullable=True)
+    new_values: Mapped[dict | None] = mapped_column(JSON, nullable=True)
+
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime, server_default=func.now(), nullable=False
+    )

--- a/backend/tests/test_migrations.py
+++ b/backend/tests/test_migrations.py
@@ -1,0 +1,157 @@
+"""Tests for Alembic migrations — verifies migrations produce a schema that
+matches the SQLAlchemy models (no drift).
+"""
+
+import pytest
+from sqlalchemy import inspect, text
+from sqlalchemy.ext.asyncio import create_async_engine
+
+from app.models import Base
+
+SQLITE_URL = "sqlite+aiosqlite://"
+
+
+@pytest.mark.asyncio
+async def test_migrations_run_cleanly():
+    """Running upgrade head on a fresh DB should not raise."""
+    engine = create_async_engine(SQLITE_URL, echo=False)
+
+    async with engine.begin() as conn:
+        await conn.run_sync(_run_upgrade_head)
+
+    # Verify we can query alembic_version
+    async with engine.connect() as conn:
+        result = await conn.execute(text("SELECT version_num FROM alembic_version"))
+        versions = [row[0] for row in result]
+        assert "003" in versions
+
+    await engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_migration_creates_all_model_tables():
+    """After upgrade head, every model table should exist in the migration DB."""
+    engine = create_async_engine(SQLITE_URL, echo=False)
+
+    async with engine.begin() as conn:
+        await conn.run_sync(_run_upgrade_head)
+
+    expected_tables = set(Base.metadata.tables.keys())
+
+    async with engine.connect() as conn:
+        actual_tables = set(await conn.run_sync(
+            lambda sync_conn: inspect(sync_conn).get_table_names()
+        ))
+
+    # Exclude alembic's own table
+    actual_tables.discard("alembic_version")
+    assert expected_tables == actual_tables, (
+        f"Missing: {expected_tables - actual_tables}, "
+        f"Extra: {actual_tables - expected_tables}"
+    )
+
+    await engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_migration_columns_match_models():
+    """Every column in the models should exist in the migration-created tables."""
+    engine = create_async_engine(SQLITE_URL, echo=False)
+
+    async with engine.begin() as conn:
+        await conn.run_sync(_run_upgrade_head)
+
+    mismatches = []
+
+    async with engine.connect() as conn:
+        for table_name, table in Base.metadata.tables.items():
+            expected_cols = {col.name for col in table.columns}
+            actual_cols = set(await conn.run_sync(
+                lambda sync_conn, tn=table_name: {
+                    c["name"] for c in inspect(sync_conn).get_columns(tn)
+                }
+            ))
+            missing = expected_cols - actual_cols
+            extra = actual_cols - expected_cols
+            if missing or extra:
+                mismatches.append(
+                    f"{table_name}: missing={missing}, extra={extra}"
+                )
+
+    assert not mismatches, "Column mismatches:\n" + "\n".join(mismatches)
+
+    await engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_audit_entries_table_has_indexes():
+    """The audit_entries table should have the expected indexes."""
+    engine = create_async_engine(SQLITE_URL, echo=False)
+
+    async with engine.begin() as conn:
+        await conn.run_sync(_run_upgrade_head)
+
+    async with engine.connect() as conn:
+        indexes = await conn.run_sync(
+            lambda sync_conn: inspect(sync_conn).get_indexes("audit_entries")
+        )
+
+    index_names = {idx["name"] for idx in indexes}
+    assert "ix_audit_entity_time" in index_names
+    assert "ix_audit_project_time" in index_names
+
+    await engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_downgrade_003_drops_audit_entries():
+    """Downgrading from 003 to 002 should remove audit_entries."""
+    engine = create_async_engine(SQLITE_URL, echo=False)
+
+    async with engine.begin() as conn:
+        await conn.run_sync(_run_upgrade_head)
+
+    # Downgrade to 002
+    async with engine.begin() as conn:
+        await conn.run_sync(lambda sync_conn: _run_downgrade(sync_conn, "002"))
+
+    async with engine.connect() as conn:
+        tables = set(await conn.run_sync(
+            lambda sync_conn: inspect(sync_conn).get_table_names()
+        ))
+
+    assert "audit_entries" not in tables
+
+    await engine.dispose()
+
+
+def _run_upgrade_head(connection):
+    """Run Alembic upgrade to head using a sync connection."""
+    import os
+
+    from alembic import command
+    from alembic.config import Config
+
+    backend_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+    alembic_ini = os.path.join(backend_dir, "alembic.ini")
+    cfg = Config(alembic_ini)
+    migrations_dir = os.path.join(backend_dir, "app", "db", "migrations")
+    cfg.set_main_option("script_location", migrations_dir)
+    cfg.attributes["connection"] = connection
+    command.upgrade(cfg, "head")
+
+
+def _run_downgrade(connection, target):
+    """Run Alembic downgrade to a specific revision using a sync connection."""
+    import os
+
+    from alembic import command
+    from alembic.config import Config
+
+    backend_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+    alembic_ini = os.path.join(backend_dir, "alembic.ini")
+    cfg = Config(alembic_ini)
+    migrations_dir = os.path.join(backend_dir, "app", "db", "migrations")
+    cfg.set_main_option("script_location", migrations_dir)
+    cfg.attributes["connection"] = connection
+    command.downgrade(cfg, target)

--- a/backend/tests/test_models.py
+++ b/backend/tests/test_models.py
@@ -29,7 +29,7 @@ def test_all_models_importable():
 
     # Verify all tables are registered in metadata
     table_names = Base.metadata.tables.keys()
-    assert len(list(table_names)) == 12
+    assert len(list(table_names)) == 13
 
 
 def test_all_schemas_importable():


### PR DESCRIPTION
## Summary

Fixes #63 - Sync database migrations with models
Fixes #64 - Add audit trail migration

### Changes

- **Migration 001 rewrite**: Fixed 25+ missing columns, 8 name mismatches, type fixes across all tables (tenants, users, questions, architectures, deployments, compliance)
- **Migration 003**: Event-log style audit_entries table with entity/project indexes
- **Runtime**: Replaced create_all() with Alembic upgrade head to prevent drift
- **Tests**: 5 new migration tests (clean run, table parity, column match, indexes, downgrade)
- All 342 tests pass, 75.24% coverage, ruff lint clean
