### PR TITLE
feat: Security middleware — CSP, rate limiting, request validation, CORS lockdown

### DIFF
--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -22,7 +22,21 @@ class Settings(BaseSettings):
     # CORS
     cors_origins: list[str] = ["http://localhost:5173"]
 
+    # Content Security Policy (empty = use default CSP)
+    csp_policy: str = ""
+
+    # Rate limiting (requests per minute)
+    rate_limit_default: int = 60
+    rate_limit_ai: int = 5
+    rate_limit_deploy: int = 3
+    rate_limit_auth: int = 10
+
     model_config = {"env_prefix": "ONRAMP_", "env_file": ".env"}
+
+    @property
+    def is_dev_mode(self) -> bool:
+        """True when running without Azure tenant (local dev)."""
+        return not self.azure_tenant_id
 
 
 settings = Settings()

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -29,14 +29,13 @@ class Settings(BaseSettings):
     rate_limit_default: int = 60
     rate_limit_ai: int = 5
     rate_limit_deploy: int = 3
-    rate_limit_auth: int = 10
 
     model_config = {"env_prefix": "ONRAMP_", "env_file": ".env"}
 
     @property
     def is_dev_mode(self) -> bool:
-        """True when running without Azure tenant (local dev)."""
-        return not self.azure_tenant_id
+        """True when Azure production settings are not fully configured."""
+        return not (self.azure_tenant_id and self.azure_client_id)
 
 
 settings = Settings()

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -49,6 +49,12 @@ _cors_headers = (
     else ["Authorization", "Content-Type", "Accept", "X-Requested-With"]
 )
 
+# Middleware ordering: Starlette applies middleware in reverse add order.
+# Add rate-limit/validation first so CORS and security headers wrap ALL responses
+# (including 429/413/400 early returns).
+app.add_middleware(RateLimitMiddleware)
+app.add_middleware(RequestValidationMiddleware)
+app.add_middleware(SecurityHeadersMiddleware)
 app.add_middleware(
     CORSMiddleware,
     allow_origins=settings.cors_origins,
@@ -56,9 +62,6 @@ app.add_middleware(
     allow_methods=_cors_methods,
     allow_headers=_cors_headers,
 )
-app.add_middleware(SecurityHeadersMiddleware)
-app.add_middleware(RequestValidationMiddleware)
-app.add_middleware(RateLimitMiddleware)
 
 app.include_router(users_router)
 app.include_router(questionnaire_router)

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -15,7 +15,11 @@ from app.api.routes.users import router as users_router
 from app.config import settings
 from app.db.seed import seed_database
 from app.db.session import close_db, init_db
-from app.security import SecurityHeadersMiddleware
+from app.security import (
+    RateLimitMiddleware,
+    RequestValidationMiddleware,
+    SecurityHeadersMiddleware,
+)
 from app.startup import get_startup_status, validate_environment
 
 
@@ -35,14 +39,26 @@ app = FastAPI(
     lifespan=lifespan,
 )
 
+# CORS — restrict methods/headers in production
+_cors_methods = (
+    ["*"] if settings.is_dev_mode
+    else ["GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"]
+)
+_cors_headers = (
+    ["*"] if settings.is_dev_mode
+    else ["Authorization", "Content-Type", "Accept", "X-Requested-With"]
+)
+
 app.add_middleware(
     CORSMiddleware,
     allow_origins=settings.cors_origins,
     allow_credentials=True,
-    allow_methods=["*"],
-    allow_headers=["*"],
+    allow_methods=_cors_methods,
+    allow_headers=_cors_headers,
 )
 app.add_middleware(SecurityHeadersMiddleware)
+app.add_middleware(RequestValidationMiddleware)
+app.add_middleware(RateLimitMiddleware)
 
 app.include_router(users_router)
 app.include_router(questionnaire_router)
@@ -57,12 +73,15 @@ app.include_router(questionnaire_state_router)
 
 @app.get("/health")
 async def health_check():
+    """Health endpoint — minimal in production, verbose in dev mode."""
     status = get_startup_status()
-    return {
-        "status": "healthy",
-        "service": "onramp-api",
-        "mode": status["mode"],
-        "auth": status["auth"],
-        "ai": status["ai"],
-        "database": status["database"],
-    }
+    if settings.is_dev_mode:
+        return {
+            "status": "healthy",
+            "service": "onramp-api",
+            "mode": status["mode"],
+            "auth": status["auth"],
+            "ai": status["ai"],
+            "database": status["database"],
+        }
+    return {"status": "healthy"}

--- a/backend/app/security.py
+++ b/backend/app/security.py
@@ -1,11 +1,51 @@
 """Security configuration and middleware."""
 
-from fastapi import Request
+import logging
+import time
+from collections import defaultdict
+
+from fastapi import Request, Response
 from starlette.middleware.base import BaseHTTPMiddleware
+
+from app.config import settings
+
+logger = logging.getLogger(__name__)
+
+# Default CSP for React SPA with Fluent UI v9
+_DEFAULT_CSP_PROD = (
+    "default-src 'self'; "
+    "script-src 'self'; "
+    "style-src 'self' 'unsafe-inline'; "
+    "img-src 'self' data:; "
+    "font-src 'self' data:; "
+    "connect-src 'self'; "
+    "frame-ancestors 'none'; "
+    "base-uri 'self'; "
+    "form-action 'self'"
+)
+
+_DEFAULT_CSP_DEV = (
+    "default-src 'self'; "
+    "script-src 'self' 'unsafe-inline'; "
+    "style-src 'self' 'unsafe-inline'; "
+    "img-src 'self' data:; "
+    "font-src 'self' data:; "
+    "connect-src 'self' ws: wss:; "
+    "frame-ancestors 'none'; "
+    "base-uri 'self'; "
+    "form-action 'self'"
+)
+
+
+def get_csp_policy() -> str:
+    """Return the CSP policy string, using config override or sensible default."""
+    if settings.csp_policy:
+        return settings.csp_policy
+    return _DEFAULT_CSP_DEV if settings.is_dev_mode else _DEFAULT_CSP_PROD
 
 
 class SecurityHeadersMiddleware(BaseHTTPMiddleware):
-    """Add security headers to all responses."""
+    """Add security headers to all responses, including CSP."""
 
     async def dispatch(self, request: Request, call_next):
         response = await call_next(request)
@@ -19,4 +59,95 @@ class SecurityHeadersMiddleware(BaseHTTPMiddleware):
         response.headers["Permissions-Policy"] = (
             "camera=(), microphone=(), geolocation=()"
         )
+        response.headers["Content-Security-Policy"] = get_csp_policy()
         return response
+
+
+class RequestValidationMiddleware(BaseHTTPMiddleware):
+    """Validate incoming requests — reject oversized bodies and suspicious paths."""
+
+    MAX_CONTENT_LENGTH = 10 * 1024 * 1024  # 10 MB
+
+    async def dispatch(self, request: Request, call_next):
+        content_length = request.headers.get("content-length")
+        if content_length and int(content_length) > self.MAX_CONTENT_LENGTH:
+            return Response(
+                content='{"detail":"Request body too large"}',
+                status_code=413,
+                media_type="application/json",
+            )
+
+        if ".." in request.url.path:
+            return Response(
+                content='{"detail":"Invalid request path"}',
+                status_code=400,
+                media_type="application/json",
+            )
+
+        return await call_next(request)
+
+
+class RateLimitMiddleware(BaseHTTPMiddleware):
+    """Simple in-memory rate limiter with path-based tiers.
+
+    Uses a sliding window counter per client IP. Tiers:
+    - AI generation endpoints: rate_limit_ai/min
+    - Deployment endpoints: rate_limit_deploy/min
+    - Default API endpoints: rate_limit_default/min
+    """
+
+    WINDOW_SECONDS = 60
+
+    def __init__(self, app, **kwargs):
+        super().__init__(app, **kwargs)
+        # {client_key: [(timestamp, ...)] }
+        self._requests: dict[str, list[float]] = defaultdict(list)
+
+    def _get_limit_for_path(self, path: str) -> int:
+        """Return the rate limit for a given path."""
+        if path.startswith("/api/architecture/generate") or path.startswith("/api/architecture/refine"):
+            return settings.rate_limit_ai
+        if path.startswith("/api/deployment"):
+            return settings.rate_limit_deploy
+        return settings.rate_limit_default
+
+    def _get_client_key(self, request: Request, path: str) -> str:
+        """Build a key from client IP + path tier."""
+        client_ip = request.client.host if request.client else "unknown"
+        if path.startswith("/api/architecture/generate") or path.startswith("/api/architecture/refine"):
+            return f"{client_ip}:ai"
+        if path.startswith("/api/deployment"):
+            return f"{client_ip}:deploy"
+        return f"{client_ip}:default"
+
+    async def dispatch(self, request: Request, call_next):
+        # Skip rate limiting in dev mode
+        if settings.is_dev_mode:
+            return await call_next(request)
+
+        # Skip health checks
+        if request.url.path == "/health":
+            return await call_next(request)
+
+        path = request.url.path
+        limit = self._get_limit_for_path(path)
+        key = self._get_client_key(request, path)
+        now = time.monotonic()
+        window_start = now - self.WINDOW_SECONDS
+
+        # Prune old entries and count recent requests
+        self._requests[key] = [
+            ts for ts in self._requests[key] if ts > window_start
+        ]
+
+        if len(self._requests[key]) >= limit:
+            retry_after = int(self.WINDOW_SECONDS - (now - self._requests[key][0])) + 1
+            return Response(
+                content='{"detail":"Rate limit exceeded. Try again later."}',
+                status_code=429,
+                media_type="application/json",
+                headers={"Retry-After": str(max(1, retry_after))},
+            )
+
+        self._requests[key].append(now)
+        return await call_next(request)

--- a/backend/app/security.py
+++ b/backend/app/security.py
@@ -70,12 +70,27 @@ class RequestValidationMiddleware(BaseHTTPMiddleware):
 
     async def dispatch(self, request: Request, call_next):
         content_length = request.headers.get("content-length")
-        if content_length and int(content_length) > self.MAX_CONTENT_LENGTH:
-            return Response(
-                content='{"detail":"Request body too large"}',
-                status_code=413,
-                media_type="application/json",
-            )
+        if content_length:
+            try:
+                parsed = int(content_length)
+            except ValueError:
+                return Response(
+                    content='{"detail":"Invalid Content-Length header"}',
+                    status_code=400,
+                    media_type="application/json",
+                )
+            if parsed < 0:
+                return Response(
+                    content='{"detail":"Invalid Content-Length header"}',
+                    status_code=400,
+                    media_type="application/json",
+                )
+            if parsed > self.MAX_CONTENT_LENGTH:
+                return Response(
+                    content='{"detail":"Request body too large"}',
+                    status_code=413,
+                    media_type="application/json",
+                )
 
         if ".." in request.url.path:
             return Response(
@@ -112,8 +127,16 @@ class RateLimitMiddleware(BaseHTTPMiddleware):
         return settings.rate_limit_default
 
     def _get_client_key(self, request: Request, path: str) -> str:
-        """Build a key from client IP + path tier."""
-        client_ip = request.client.host if request.client else "unknown"
+        """Build a key from client IP + path tier.
+
+        Uses X-Forwarded-For when behind a reverse proxy, falling back to
+        request.client.host.
+        """
+        forwarded = request.headers.get("x-forwarded-for")
+        if forwarded:
+            client_ip = forwarded.split(",")[0].strip()
+        else:
+            client_ip = request.client.host if request.client else "unknown"
         if path.startswith("/api/architecture/generate") or path.startswith("/api/architecture/refine"):
             return f"{client_ip}:ai"
         if path.startswith("/api/deployment"):
@@ -125,8 +148,8 @@ class RateLimitMiddleware(BaseHTTPMiddleware):
         if settings.is_dev_mode:
             return await call_next(request)
 
-        # Skip health checks
-        if request.url.path == "/health":
+        # Skip health checks and CORS preflight requests
+        if request.url.path == "/health" or request.method == "OPTIONS":
             return await call_next(request)
 
         path = request.url.path
@@ -136,12 +159,16 @@ class RateLimitMiddleware(BaseHTTPMiddleware):
         window_start = now - self.WINDOW_SECONDS
 
         # Prune old entries and count recent requests
-        self._requests[key] = [
-            ts for ts in self._requests[key] if ts > window_start
-        ]
+        recent = [ts for ts in self._requests[key] if ts > window_start]
+        if recent:
+            self._requests[key] = recent
+        else:
+            # Evict empty keys to prevent unbounded memory growth
+            self._requests.pop(key, None)
+            recent = []
 
-        if len(self._requests[key]) >= limit:
-            retry_after = int(self.WINDOW_SECONDS - (now - self._requests[key][0])) + 1
+        if len(recent) >= limit:
+            retry_after = int(self.WINDOW_SECONDS - (now - recent[0])) + 1
             return Response(
                 content='{"detail":"Rate limit exceeded. Try again later."}',
                 status_code=429,
@@ -149,5 +176,5 @@ class RateLimitMiddleware(BaseHTTPMiddleware):
                 headers={"Retry-After": str(max(1, retry_after))},
             )
 
-        self._requests[key].append(now)
+        self._requests[key] = recent + [now]
         return await call_next(request)

--- a/backend/tests/test_security.py
+++ b/backend/tests/test_security.py
@@ -1,6 +1,8 @@
 """Tests for security headers middleware, CSP, request validation, and rate limiting."""
 
-from unittest.mock import patch
+import asyncio
+import time
+from unittest.mock import AsyncMock, MagicMock, patch
 
 from fastapi.testclient import TestClient
 
@@ -88,9 +90,6 @@ def test_csp_production_no_ws():
 
 def test_request_validation_blocks_path_traversal():
     """Requests with .. in path should be rejected with 400."""
-    # TestClient normalizes '..' in URLs, so test the middleware directly
-    from unittest.mock import AsyncMock, MagicMock
-    import asyncio
     from app.security import RequestValidationMiddleware
 
     mw = RequestValidationMiddleware(app=None)
@@ -108,8 +107,6 @@ def test_request_validation_blocks_path_traversal():
 
 def test_request_validation_blocks_oversized_body():
     """Requests with Content-Length exceeding limit should get 413."""
-    from unittest.mock import AsyncMock, MagicMock
-    import asyncio
     from app.security import RequestValidationMiddleware
 
     mw = RequestValidationMiddleware(app=None)
@@ -123,6 +120,40 @@ def test_request_validation_blocks_oversized_body():
     )
     assert response.status_code == 413
     call_next.assert_not_called()
+
+
+def test_request_validation_rejects_invalid_content_length():
+    """Non-numeric Content-Length should be rejected with 400."""
+    from app.security import RequestValidationMiddleware
+
+    mw = RequestValidationMiddleware(app=None)
+    request = MagicMock()
+    request.url.path = "/api/test"
+    request.headers = {"content-length": "not-a-number"}
+    call_next = AsyncMock()
+
+    response = asyncio.get_event_loop().run_until_complete(
+        mw.dispatch(request, call_next)
+    )
+    assert response.status_code == 400
+    assert b"Invalid Content-Length" in response.body
+
+
+def test_request_validation_rejects_negative_content_length():
+    """Negative Content-Length should be rejected with 400."""
+    from app.security import RequestValidationMiddleware
+
+    mw = RequestValidationMiddleware(app=None)
+    request = MagicMock()
+    request.url.path = "/api/test"
+    request.headers = {"content-length": "-1"}
+    call_next = AsyncMock()
+
+    response = asyncio.get_event_loop().run_until_complete(
+        mw.dispatch(request, call_next)
+    )
+    assert response.status_code == 400
+    assert b"Invalid Content-Length" in response.body
 
 
 def test_request_validation_allows_normal_requests():
@@ -149,16 +180,16 @@ def test_health_dev_mode_verbose():
 
 
 def test_health_production_minimal():
-    """Production health should return only status."""
+    """Production health should return ONLY status — no dev-only keys."""
     with patch("app.main.settings") as mock_settings:
         mock_settings.is_dev_mode = False
         mock_settings.cors_origins = ["https://example.com"]
-        # Re-call the endpoint — settings.is_dev_mode is checked at call time
         r = client.get("/health")
         data = r.json()
         assert data["status"] == "healthy"
-        # In dev mode the test client still runs dev settings at module level,
-        # but the health function checks settings.is_dev_mode dynamically
+        # Dev-only keys must be absent in production
+        for key in ("service", "mode", "auth", "ai", "database"):
+            assert key not in data, f"Dev-only key '{key}' found in production health"
 
 
 # --------------------------------------------------------------------------- #
@@ -167,10 +198,11 @@ def test_health_production_minimal():
 
 
 def test_rate_limiting_disabled_in_dev_mode():
-    """Rate limiting should be disabled in dev mode — no 429s."""
+    """Rate limiting should be disabled in dev mode — no 429s on API endpoints."""
     for _ in range(100):
-        r = client.get("/health")
-        assert r.status_code == 200
+        r = client.get("/api/questionnaire/categories")
+        # Should never get 429 in dev mode (404 or 200 are both fine)
+        assert r.status_code != 429
 
 
 def test_rate_limit_middleware_exists():
@@ -183,15 +215,62 @@ def test_rate_limit_returns_429_when_exceeded():
     """Rate limiter should return 429 with Retry-After when limit exceeded."""
     from app.security import RateLimitMiddleware
 
-    # Test the middleware logic directly
     mw = RateLimitMiddleware(app=None)
-    import time
-    key = "test-client:default"
     now = time.monotonic()
-    # Fill up the bucket
-    mw._requests[key] = [now] * 100
-    # Check that the bucket is full
-    assert len(mw._requests[key]) >= 60
+    call_next = AsyncMock(return_value=MagicMock())
+
+    # Simulate production mode
+    with patch("app.security.settings") as mock_settings:
+        mock_settings.is_dev_mode = False
+        mock_settings.rate_limit_default = 2
+        mock_settings.rate_limit_ai = 5
+        mock_settings.rate_limit_deploy = 3
+
+        # Build a mock request for a non-exempt endpoint
+        request = MagicMock()
+        request.url.path = "/api/questionnaire/next"
+        request.method = "POST"
+        request.headers = {}
+        request.client.host = "10.0.0.1"
+
+        # First two requests should succeed
+        for _ in range(2):
+            resp = asyncio.get_event_loop().run_until_complete(
+                mw.dispatch(request, call_next)
+            )
+        assert call_next.call_count == 2
+
+        # Third request should be rate limited
+        resp = asyncio.get_event_loop().run_until_complete(
+            mw.dispatch(request, call_next)
+        )
+        assert resp.status_code == 429
+        assert "Retry-After" in resp.headers
+
+
+def test_rate_limit_skips_options_preflight():
+    """OPTIONS (CORS preflight) requests should bypass rate limiting."""
+    from app.security import RateLimitMiddleware
+
+    mw = RateLimitMiddleware(app=None)
+    call_next = AsyncMock(return_value=MagicMock())
+
+    with patch("app.security.settings") as mock_settings:
+        mock_settings.is_dev_mode = False
+
+        request = MagicMock()
+        request.url.path = "/api/architecture/generate"
+        request.method = "OPTIONS"
+        request.headers = {}
+        request.client.host = "10.0.0.2"
+
+        # OPTIONS should always pass through
+        for _ in range(20):
+            asyncio.get_event_loop().run_until_complete(
+                mw.dispatch(request, call_next)
+            )
+        # All 20 should have been forwarded (no 429)
+        assert call_next.call_count == 20
 
 
 def test_rate_limit_config_settings():
@@ -200,7 +279,6 @@ def test_rate_limit_config_settings():
     assert settings.rate_limit_default == 60
     assert settings.rate_limit_ai == 5
     assert settings.rate_limit_deploy == 3
-    assert settings.rate_limit_auth == 10
 
 
 def test_rate_limit_path_tiers():
@@ -216,6 +294,50 @@ def test_rate_limit_path_tiers():
     assert mw._get_limit_for_path("/health") == settings.rate_limit_default
 
 
+def test_rate_limit_uses_x_forwarded_for():
+    """Rate limiter should use X-Forwarded-For header when present."""
+    from app.security import RateLimitMiddleware
+
+    mw = RateLimitMiddleware(app=None)
+    request = MagicMock()
+    request.url.path = "/api/test"
+    request.headers = {"x-forwarded-for": "1.2.3.4, 10.0.0.1"}
+    request.client.host = "10.0.0.1"
+
+    key = mw._get_client_key(request, "/api/test")
+    assert key.startswith("1.2.3.4:")
+
+
+def test_rate_limit_memory_eviction():
+    """Expired entries should be evicted to prevent unbounded memory growth."""
+    from app.security import RateLimitMiddleware
+
+    mw = RateLimitMiddleware(app=None)
+    key = "eviction-test:default"
+    # Add entries from 120 seconds ago (well outside the 60s window)
+    old_time = time.monotonic() - 120
+    mw._requests[key] = [old_time] * 5
+
+    call_next = AsyncMock(return_value=MagicMock())
+    with patch("app.security.settings") as mock_settings:
+        mock_settings.is_dev_mode = False
+        mock_settings.rate_limit_default = 60
+        mock_settings.rate_limit_ai = 5
+        mock_settings.rate_limit_deploy = 3
+
+        request = MagicMock()
+        request.url.path = "/api/test"
+        request.method = "GET"
+        request.headers = {}
+        request.client.host = "eviction-test"
+
+        asyncio.get_event_loop().run_until_complete(
+            mw.dispatch(request, call_next)
+        )
+    # After processing, the old entries should be gone and key should have 1 new entry
+    assert len(mw._requests.get("eviction-test:default", [])) == 1
+
+
 # --------------------------------------------------------------------------- #
 # CORS configuration tests (#51)                                               #
 # --------------------------------------------------------------------------- #
@@ -227,3 +349,29 @@ def test_cors_dev_mode_permissive():
     # In dev mode (no azure_tenant_id), CORS should be permissive
     assert _cors_methods == ["*"]
     assert _cors_headers == ["*"]
+
+
+# --------------------------------------------------------------------------- #
+# is_dev_mode alignment (#51)                                                  #
+# --------------------------------------------------------------------------- #
+
+
+def test_is_dev_mode_requires_both_tenant_and_client():
+    """is_dev_mode should be True unless BOTH tenant and client IDs are set."""
+    from app.config import Settings
+
+    # No credentials = dev mode
+    s = Settings(azure_tenant_id="", azure_client_id="")
+    assert s.is_dev_mode is True
+
+    # Only tenant = still dev mode
+    s = Settings(azure_tenant_id="tid", azure_client_id="")
+    assert s.is_dev_mode is True
+
+    # Only client = still dev mode
+    s = Settings(azure_tenant_id="", azure_client_id="cid")
+    assert s.is_dev_mode is True
+
+    # Both set = production mode
+    s = Settings(azure_tenant_id="tid", azure_client_id="cid")
+    assert s.is_dev_mode is False

--- a/backend/tests/test_security.py
+++ b/backend/tests/test_security.py
@@ -1,8 +1,13 @@
-"""Tests for security headers middleware."""
+"""Tests for security headers middleware, CSP, request validation, and rate limiting."""
+
+from unittest.mock import patch
+
 from fastapi.testclient import TestClient
+
 from app.main import app
 
 client = TestClient(app)
+
 
 def test_security_headers_present():
     r = client.get("/health")
@@ -12,9 +17,213 @@ def test_security_headers_present():
     assert "max-age" in r.headers.get("Strict-Transport-Security", "")
     assert r.headers.get("Referrer-Policy") == "strict-origin-when-cross-origin"
 
+
 def test_permissions_policy():
     r = client.get("/health")
     pp = r.headers.get("Permissions-Policy", "")
     assert "camera=()" in pp
     assert "microphone=()" in pp
     assert "geolocation=()" in pp
+
+
+# --------------------------------------------------------------------------- #
+# CSP header tests (#50)                                                       #
+# --------------------------------------------------------------------------- #
+
+
+def test_csp_header_present():
+    """CSP header should be present on all responses."""
+    r = client.get("/health")
+    csp = r.headers.get("Content-Security-Policy", "")
+    assert "default-src 'self'" in csp
+
+
+def test_csp_dev_mode_allows_ws():
+    """Dev mode CSP should allow WebSocket for Vite HMR."""
+    r = client.get("/health")
+    csp = r.headers.get("Content-Security-Policy", "")
+    # Dev mode (no azure_tenant_id) should include ws: for HMR
+    assert "ws:" in csp
+
+
+def test_csp_allows_unsafe_inline_styles():
+    """CSP must allow unsafe-inline styles for Fluent UI Griffel."""
+    r = client.get("/health")
+    csp = r.headers.get("Content-Security-Policy", "")
+    assert "'unsafe-inline'" in csp
+
+
+def test_csp_allows_data_uris():
+    """CSP must allow data: URIs for images and fonts (Fluent UI)."""
+    r = client.get("/health")
+    csp = r.headers.get("Content-Security-Policy", "")
+    assert "data:" in csp
+
+
+def test_csp_configurable_via_env():
+    """CSP policy should be overridable via ONRAMP_CSP_POLICY."""
+    custom_csp = "default-src 'none'"
+    with patch("app.security.settings") as mock_settings:
+        mock_settings.csp_policy = custom_csp
+        mock_settings.is_dev_mode = True
+        from app.security import get_csp_policy
+        assert get_csp_policy() == custom_csp
+
+
+def test_csp_production_no_ws():
+    """Production CSP should NOT include ws: connections."""
+    with patch("app.security.settings") as mock_settings:
+        mock_settings.csp_policy = ""
+        mock_settings.is_dev_mode = False
+        from app.security import get_csp_policy
+        csp = get_csp_policy()
+        assert "ws:" not in csp
+        assert "default-src 'self'" in csp
+
+
+# --------------------------------------------------------------------------- #
+# Request validation middleware tests (#51)                                     #
+# --------------------------------------------------------------------------- #
+
+
+def test_request_validation_blocks_path_traversal():
+    """Requests with .. in path should be rejected with 400."""
+    # TestClient normalizes '..' in URLs, so test the middleware directly
+    from unittest.mock import AsyncMock, MagicMock
+    import asyncio
+    from app.security import RequestValidationMiddleware
+
+    mw = RequestValidationMiddleware(app=None)
+    request = MagicMock()
+    request.url.path = "/api/../etc/passwd"
+    request.headers = {}
+    call_next = AsyncMock()
+
+    response = asyncio.get_event_loop().run_until_complete(
+        mw.dispatch(request, call_next)
+    )
+    assert response.status_code == 400
+    call_next.assert_not_called()
+
+
+def test_request_validation_blocks_oversized_body():
+    """Requests with Content-Length exceeding limit should get 413."""
+    from unittest.mock import AsyncMock, MagicMock
+    import asyncio
+    from app.security import RequestValidationMiddleware
+
+    mw = RequestValidationMiddleware(app=None)
+    request = MagicMock()
+    request.url.path = "/api/architecture/generate"
+    request.headers = {"content-length": "999999999"}
+    call_next = AsyncMock()
+
+    response = asyncio.get_event_loop().run_until_complete(
+        mw.dispatch(request, call_next)
+    )
+    assert response.status_code == 413
+    call_next.assert_not_called()
+
+
+def test_request_validation_allows_normal_requests():
+    """Normal requests should pass through validation."""
+    r = client.get("/health")
+    assert r.status_code == 200
+
+
+# --------------------------------------------------------------------------- #
+# Health endpoint production mode tests (#54)                                  #
+# --------------------------------------------------------------------------- #
+
+
+def test_health_dev_mode_verbose():
+    """Dev mode health should return detailed status info."""
+    r = client.get("/health")
+    data = r.json()
+    assert data["status"] == "healthy"
+    assert "service" in data
+    assert "mode" in data
+    assert "auth" in data
+    assert "ai" in data
+    assert "database" in data
+
+
+def test_health_production_minimal():
+    """Production health should return only status."""
+    with patch("app.main.settings") as mock_settings:
+        mock_settings.is_dev_mode = False
+        mock_settings.cors_origins = ["https://example.com"]
+        # Re-call the endpoint — settings.is_dev_mode is checked at call time
+        r = client.get("/health")
+        data = r.json()
+        assert data["status"] == "healthy"
+        # In dev mode the test client still runs dev settings at module level,
+        # but the health function checks settings.is_dev_mode dynamically
+
+
+# --------------------------------------------------------------------------- #
+# Rate limiting middleware tests (#52)                                          #
+# --------------------------------------------------------------------------- #
+
+
+def test_rate_limiting_disabled_in_dev_mode():
+    """Rate limiting should be disabled in dev mode — no 429s."""
+    for _ in range(100):
+        r = client.get("/health")
+        assert r.status_code == 200
+
+
+def test_rate_limit_middleware_exists():
+    """RateLimitMiddleware should be importable and instantiable."""
+    from app.security import RateLimitMiddleware
+    assert RateLimitMiddleware is not None
+
+
+def test_rate_limit_returns_429_when_exceeded():
+    """Rate limiter should return 429 with Retry-After when limit exceeded."""
+    from app.security import RateLimitMiddleware
+
+    # Test the middleware logic directly
+    mw = RateLimitMiddleware(app=None)
+    import time
+    key = "test-client:default"
+    now = time.monotonic()
+    # Fill up the bucket
+    mw._requests[key] = [now] * 100
+    # Check that the bucket is full
+    assert len(mw._requests[key]) >= 60
+
+
+def test_rate_limit_config_settings():
+    """Rate limit config values should be accessible."""
+    from app.config import settings
+    assert settings.rate_limit_default == 60
+    assert settings.rate_limit_ai == 5
+    assert settings.rate_limit_deploy == 3
+    assert settings.rate_limit_auth == 10
+
+
+def test_rate_limit_path_tiers():
+    """Different paths should map to different rate limit tiers."""
+    from app.security import RateLimitMiddleware
+    mw = RateLimitMiddleware(app=None)
+
+    from app.config import settings
+    assert mw._get_limit_for_path("/api/architecture/generate") == settings.rate_limit_ai
+    assert mw._get_limit_for_path("/api/architecture/refine") == settings.rate_limit_ai
+    assert mw._get_limit_for_path("/api/deployment/create") == settings.rate_limit_deploy
+    assert mw._get_limit_for_path("/api/questionnaire/next") == settings.rate_limit_default
+    assert mw._get_limit_for_path("/health") == settings.rate_limit_default
+
+
+# --------------------------------------------------------------------------- #
+# CORS configuration tests (#51)                                               #
+# --------------------------------------------------------------------------- #
+
+
+def test_cors_dev_mode_permissive():
+    """Dev mode CORS should use wildcard methods/headers."""
+    from app.main import _cors_methods, _cors_headers
+    # In dev mode (no azure_tenant_id), CORS should be permissive
+    assert _cors_methods == ["*"]
+    assert _cors_headers == ["*"]


### PR DESCRIPTION
## Summary

Fixes #50 - Add Content-Security-Policy header
Fixes #51 - Lock down CORS for production
Fixes #52 - Add rate limiting middleware
Fixes #54 - Reduce /health endpoint info in production

### Changes

- **CSP headers** (#50): Dev mode allows ws:/wss: for Vite HMR + unsafe-inline for Griffel. Production locks down to self-only. Configurable via ONRAMP_CSP_POLICY env var.
- **CORS lockdown** (#51): Production restricts to specific methods (GET/POST/PUT/PATCH/DELETE/OPTIONS) and headers (Authorization/Content-Type/Accept/X-Requested-With). Dev mode keeps wildcards.
- **Rate limiting** (#52): Path-based tiers - AI endpoints 5/min, deployment 3/min, default 60/min. Disabled in dev mode. Returns 429 with Retry-After header.
- **Request validation** (#51): Blocks oversized request bodies (>10MB) and path traversal attempts.
- **Health endpoint** (#54): Production returns minimal {status: healthy}. Dev mode keeps verbose response.
- **Settings**: Added is_dev_mode property, CSP and rate limit config options.

### Testing
- 17 new tests covering CSP, rate limiting, request validation, CORS, health endpoint
- All 359 tests pass, 75.15% coverage
- Ruff lint clean
