### PR TITLE
fix: fix README Deploy button URL and verify deployment param alignment

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # 🚀 OnRamp — Azure Landing Zone Architect & Deployer
 
-[![Deploy to Azure](https://aka.ms/deploytoazurebutton)](https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2FYOUR-GITHUB-ORG%2Fonramp%2Fmain%2Finfra%2Fazuredeploy.json)
+[![Deploy to Azure](https://aka.ms/deploytoazurebutton)](https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2FJoshLuedeman%2Fonramp%2Fmain%2Finfra%2Fazuredeploy.json)
 
 **OnRamp** is an AI-powered web application that guides Azure customers through designing and deploying Cloud Adoption Framework (CAF) aligned landing zones. Answer questions about your organization, get an AI-generated architecture recommendation, review it visually, and deploy it to Azure with a single click.
 

--- a/backend/tests/test_routes_deployment.py
+++ b/backend/tests/test_routes_deployment.py
@@ -4,6 +4,7 @@ from fastapi.testclient import TestClient
 from httpx import ASGITransport, AsyncClient
 
 from app.main import app
+from app.services.credentials import credential_manager
 
 client = TestClient(app)
 
@@ -144,21 +145,32 @@ def test_validate_deployment_missing_field():
     assert r.status_code == 422
 
 
-def test_validate_deployment_uses_region_not_location():
+def test_validate_deployment_uses_region_not_location(monkeypatch):
     """Verify the API uses 'region' parameter (not 'location') matching frontend contract."""
+    captured_regions = []
+    original_check = credential_manager.check_subscription_quotas
+
+    async def capture_region(sub_id, region):
+        captured_regions.append(region)
+        return await original_check(sub_id, region)
+
+    monkeypatch.setattr(credential_manager, "check_subscription_quotas", capture_region)
+
+    # Explicit region should be passed through
     r = client.post("/api/deployment/validate", json={
         "subscription_id": "test-sub",
         "region": "westus2",
     })
     assert r.status_code == 200
+    assert captured_regions[-1] == "westus2"
 
-    # 'location' alone (without region) should still work via default
+    # 'location' is not a valid field — Pydantic ignores it, uses default 'eastus2'
     r2 = client.post("/api/deployment/validate", json={
         "subscription_id": "test-sub",
         "location": "westus2",
     })
     assert r2.status_code == 200
-    # 'location' is ignored — Pydantic strips unknown fields, uses default region
+    assert captured_regions[-1] == "eastus2"  # default, not 'westus2'
 
 
 def test_create_deployment_missing_fields():

--- a/backend/tests/test_routes_deployment.py
+++ b/backend/tests/test_routes_deployment.py
@@ -144,6 +144,23 @@ def test_validate_deployment_missing_field():
     assert r.status_code == 422
 
 
+def test_validate_deployment_uses_region_not_location():
+    """Verify the API uses 'region' parameter (not 'location') matching frontend contract."""
+    r = client.post("/api/deployment/validate", json={
+        "subscription_id": "test-sub",
+        "region": "westus2",
+    })
+    assert r.status_code == 200
+
+    # 'location' alone (without region) should still work via default
+    r2 = client.post("/api/deployment/validate", json={
+        "subscription_id": "test-sub",
+        "location": "westus2",
+    })
+    assert r2.status_code == 200
+    # 'location' is ignored — Pydantic strips unknown fields, uses default region
+
+
 def test_create_deployment_missing_fields():
     """Create without required fields returns 422."""
     r = client.post("/api/deployment/create", json={"project_id": "p1"})


### PR DESCRIPTION
## PR F: Bug Fixes & Docs

**#58 — Fix README Deploy to Azure button URL**
- Replaced \YOUR-GITHUB-ORG\ placeholder with \JoshLuedeman\ in the Deploy to Azure button URL
- Verified no other placeholder values remain in README

**#57 — Fix deployment validate parameter mismatch**
- Frontend and backend already use \egion\ (aligned in PR #71)
- Added explicit test verifying the parameter contract: \egion\ is used, \location\ is ignored
- 366 backend tests pass

Closes #57, Closes #58