### PR TITLE
feat: workload inventory import (#44)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  workflow_dispatch:
 
 jobs:
   frontend:

--- a/backend/app/api/routes/workloads.py
+++ b/backend/app/api/routes/workloads.py
@@ -10,6 +10,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.auth import get_current_user
 from app.db.session import get_db
+from app.models.project import Project
 from app.models.workload import Workload
 from app.schemas.workload import (
     WorkloadCreate,
@@ -17,7 +18,7 @@ from app.schemas.workload import (
     WorkloadResponse,
     WorkloadUpdate,
 )
-from app.services.workload_importer import detect_format
+from app.services.workload_importer import detect_format, parse_file
 
 logger = logging.getLogger(__name__)
 
@@ -52,7 +53,7 @@ def _to_response(workload: Workload) -> WorkloadResponse:
 async def import_workloads(
     file: UploadFile = File(...),
     project_id: str = Query(..., description="Target project ID"),
-    _user: dict = Depends(get_current_user),
+    user: dict = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
 ) -> WorkloadImportResult:
     """Parse an uploaded CSV or JSON file and bulk-insert workloads."""
@@ -66,67 +67,20 @@ async def import_workloads(
     fmt = detect_format(filename, content)
     logger.info("Importing workloads from %s (format: %s, size: %d)", filename, fmt, len(content))
 
+    # Tenant/project scoping — only enforced when a real DB is available
+    tenant_id = user.get("tid", user.get("tenant_id", "dev-tenant"))
+    if db is not None:
+        proj_result = await db.execute(
+            select(Project).where(Project.id == project_id, Project.tenant_id == tenant_id)
+        )
+        if proj_result.scalar_one_or_none() is None:
+            raise HTTPException(status_code=403, detail="Project not found or access denied")
+
     # Parse file — collect row-level errors instead of aborting entirely
-    parsed: list[WorkloadCreate] = []
-    errors: list[str] = []
-
-    if fmt == "json":
-        # JSON: parse items individually to collect per-item errors
-        try:
-            import json as _json
-            data = _json.loads(content)
-        except ValueError as exc:
-            raise HTTPException(status_code=422, detail=f"Invalid JSON: {exc}") from exc
-
-        if isinstance(data, dict):
-            data = data.get("workloads", [data])
-        if not isinstance(data, list):
-            raise HTTPException(status_code=422, detail="JSON must be an array of workload objects")
-
-        from app.services.workload_importer import _build_workload, _normalise_column  # noqa: PLC0415
-
-        for idx, item in enumerate(data):
-            if not isinstance(item, dict):
-                errors.append(f"Item {idx}: expected object, got {type(item).__name__}")
-                continue
-            normalised: dict = {}
-            for key, value in item.items():
-                canonical = _normalise_column(str(key))
-                if isinstance(value, list):
-                    normalised[canonical] = value
-                else:
-                    normalised[canonical] = str(value) if value is not None else ""
-            try:
-                parsed.append(_build_workload(normalised, project_id))
-            except ValueError as exc:
-                errors.append(f"Item {idx}: {exc}")
-    else:
-        # CSV: parse rows individually
-        import csv as _csv
-        import io as _io
-
-        try:
-            text = content.decode("utf-8-sig")
-        except UnicodeDecodeError:
-            text = content.decode("latin-1")
-
-        reader = _csv.DictReader(_io.StringIO(text))
-        if reader.fieldnames is None:
-            raise HTTPException(status_code=422, detail="CSV file has no headers")
-
-        from app.services.workload_importer import _build_workload, _normalise_column  # noqa: PLC0415
-
-        for row_num, raw_row in enumerate(reader, start=2):
-            normalised = {}
-            for col, value in raw_row.items():
-                if col is None:
-                    continue
-                canonical = _normalise_column(col)
-                normalised[canonical] = value or ""
-            try:
-                parsed.append(_build_workload(normalised, project_id))
-            except ValueError as exc:
-                errors.append(f"Row {row_num}: {exc}")
+    try:
+        parsed, errors = parse_file(content, filename, project_id)
+    except ValueError as exc:
+        raise HTTPException(status_code=422, detail=str(exc)) from exc
 
     if not parsed and not errors:
         return WorkloadImportResult(
@@ -205,7 +159,7 @@ async def import_workloads(
 @router.get("", response_model=dict)
 async def list_workloads(
     project_id: str = Query(..., description="Project ID to filter by"),
-    _user: dict = Depends(get_current_user),
+    user: dict = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
 ) -> dict:
     """List all workloads for a given project."""
@@ -213,6 +167,13 @@ async def list_workloads(
         return {"workloads": [], "total": 0}
 
     try:
+        tenant_id = user.get("tid", user.get("tenant_id", "dev-tenant"))
+        proj_result = await db.execute(
+            select(Project).where(Project.id == project_id, Project.tenant_id == tenant_id)
+        )
+        if proj_result.scalar_one_or_none() is None:
+            raise HTTPException(status_code=403, detail="Project not found or access denied")
+
         result = await db.execute(
             select(Workload).where(Workload.project_id == project_id)
         )
@@ -221,6 +182,8 @@ async def list_workloads(
             "workloads": [_to_response(w) for w in workloads],
             "total": len(workloads),
         }
+    except HTTPException:
+        raise
     except Exception as exc:
         logger.exception("Failed to list workloads")
         raise HTTPException(status_code=500, detail=str(exc)) from exc
@@ -229,7 +192,7 @@ async def list_workloads(
 @router.post("", response_model=WorkloadResponse)
 async def create_workload(
     payload: WorkloadCreate,
-    _user: dict = Depends(get_current_user),
+    user: dict = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
 ) -> WorkloadResponse:
     """Create a single workload (manual entry)."""
@@ -257,6 +220,13 @@ async def create_workload(
         )
 
     try:
+        tenant_id = user.get("tid", user.get("tenant_id", "dev-tenant"))
+        proj_result = await db.execute(
+            select(Project).where(Project.id == payload.project_id, Project.tenant_id == tenant_id)
+        )
+        if proj_result.scalar_one_or_none() is None:
+            raise HTTPException(status_code=403, detail="Project not found or access denied")
+
         workload = Workload(
             id=str(uuid.uuid4()),
             project_id=payload.project_id,
@@ -288,7 +258,7 @@ async def create_workload(
 async def update_workload(
     workload_id: str,
     updates: WorkloadUpdate,
-    _user: dict = Depends(get_current_user),
+    user: dict = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
 ) -> WorkloadResponse:
     """Update a workload by ID."""
@@ -303,7 +273,16 @@ async def update_workload(
         if not workload:
             raise HTTPException(status_code=404, detail="Workload not found")
 
+        tenant_id = user.get("tid", user.get("tenant_id", "dev-tenant"))
+        proj_result = await db.execute(
+            select(Project).where(Project.id == workload.project_id, Project.tenant_id == tenant_id)
+        )
+        if proj_result.scalar_one_or_none() is None:
+            raise HTTPException(status_code=403, detail="Project not found or access denied")
+
         update_data = updates.model_dump(exclude_unset=True)
+        if "name" in update_data and update_data["name"] is None:
+            raise HTTPException(status_code=422, detail="name cannot be null")
         for field, value in update_data.items():
             setattr(workload, field, value)
         workload.updated_at = datetime.now(timezone.utc)
@@ -320,7 +299,7 @@ async def update_workload(
 @router.delete("/{workload_id}")
 async def delete_workload(
     workload_id: str,
-    _user: dict = Depends(get_current_user),
+    user: dict = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
 ) -> dict:
     """Delete a workload by ID."""
@@ -334,6 +313,14 @@ async def delete_workload(
         workload = result.scalar_one_or_none()
         if not workload:
             raise HTTPException(status_code=404, detail="Workload not found")
+
+        tenant_id = user.get("tid", user.get("tenant_id", "dev-tenant"))
+        proj_result = await db.execute(
+            select(Project).where(Project.id == workload.project_id, Project.tenant_id == tenant_id)
+        )
+        if proj_result.scalar_one_or_none() is None:
+            raise HTTPException(status_code=403, detail="Project not found or access denied")
+
         await db.delete(workload)
         return {"deleted": True, "id": workload_id}
     except HTTPException:

--- a/backend/app/api/routes/workloads.py
+++ b/backend/app/api/routes/workloads.py
@@ -249,6 +249,8 @@ async def create_workload(
         db.add(workload)
         await db.flush()
         return _to_response(workload)
+    except HTTPException:
+        raise
     except Exception as exc:
         logger.exception("Failed to create workload")
         raise HTTPException(status_code=500, detail=str(exc)) from exc

--- a/backend/app/api/routes/workloads.py
+++ b/backend/app/api/routes/workloads.py
@@ -1,0 +1,343 @@
+"""Workload API routes — import, list, create, update, delete."""
+
+import logging
+import uuid
+from datetime import datetime, timezone
+
+from fastapi import APIRouter, Depends, File, HTTPException, Query, UploadFile
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.auth import get_current_user
+from app.db.session import get_db
+from app.models.workload import Workload
+from app.schemas.workload import (
+    WorkloadCreate,
+    WorkloadImportResult,
+    WorkloadResponse,
+    WorkloadUpdate,
+)
+from app.services.workload_importer import detect_format
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/api/workloads", tags=["workloads"])
+
+MAX_UPLOAD_BYTES = 10 * 1024 * 1024  # 10 MB
+
+
+def _to_response(workload: Workload) -> WorkloadResponse:
+    return WorkloadResponse(
+        id=workload.id,
+        project_id=workload.project_id,
+        name=workload.name,
+        type=workload.type,
+        source_platform=workload.source_platform,
+        cpu_cores=workload.cpu_cores,
+        memory_gb=workload.memory_gb,
+        storage_gb=workload.storage_gb,
+        os_type=workload.os_type,
+        os_version=workload.os_version,
+        criticality=workload.criticality,
+        compliance_requirements=workload.compliance_requirements or [],
+        dependencies=workload.dependencies or [],
+        migration_strategy=workload.migration_strategy,
+        notes=workload.notes,
+        created_at=workload.created_at,
+        updated_at=workload.updated_at,
+    )
+
+
+@router.post("/import", response_model=WorkloadImportResult)
+async def import_workloads(
+    file: UploadFile = File(...),
+    project_id: str = Query(..., description="Target project ID"),
+    _user: dict = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+) -> WorkloadImportResult:
+    """Parse an uploaded CSV or JSON file and bulk-insert workloads."""
+    content = await file.read()
+    if len(content) > MAX_UPLOAD_BYTES:
+        raise HTTPException(status_code=413, detail="File too large (max 10 MB)")
+    if not content:
+        raise HTTPException(status_code=400, detail="Uploaded file is empty")
+
+    filename = file.filename or "upload.csv"
+    fmt = detect_format(filename, content)
+    logger.info("Importing workloads from %s (format: %s, size: %d)", filename, fmt, len(content))
+
+    # Parse file — collect row-level errors instead of aborting entirely
+    parsed: list[WorkloadCreate] = []
+    errors: list[str] = []
+
+    if fmt == "json":
+        # JSON: parse items individually to collect per-item errors
+        try:
+            import json as _json
+            data = _json.loads(content)
+        except ValueError as exc:
+            raise HTTPException(status_code=422, detail=f"Invalid JSON: {exc}") from exc
+
+        if isinstance(data, dict):
+            data = data.get("workloads", [data])
+        if not isinstance(data, list):
+            raise HTTPException(status_code=422, detail="JSON must be an array of workload objects")
+
+        from app.services.workload_importer import _build_workload, _normalise_column  # noqa: PLC0415
+
+        for idx, item in enumerate(data):
+            if not isinstance(item, dict):
+                errors.append(f"Item {idx}: expected object, got {type(item).__name__}")
+                continue
+            normalised: dict = {}
+            for key, value in item.items():
+                canonical = _normalise_column(str(key))
+                if isinstance(value, list):
+                    normalised[canonical] = value
+                else:
+                    normalised[canonical] = str(value) if value is not None else ""
+            try:
+                parsed.append(_build_workload(normalised, project_id))
+            except ValueError as exc:
+                errors.append(f"Item {idx}: {exc}")
+    else:
+        # CSV: parse rows individually
+        import csv as _csv
+        import io as _io
+
+        try:
+            text = content.decode("utf-8-sig")
+        except UnicodeDecodeError:
+            text = content.decode("latin-1")
+
+        reader = _csv.DictReader(_io.StringIO(text))
+        if reader.fieldnames is None:
+            raise HTTPException(status_code=422, detail="CSV file has no headers")
+
+        from app.services.workload_importer import _build_workload, _normalise_column  # noqa: PLC0415
+
+        for row_num, raw_row in enumerate(reader, start=2):
+            normalised = {}
+            for col, value in raw_row.items():
+                if col is None:
+                    continue
+                canonical = _normalise_column(col)
+                normalised[canonical] = value or ""
+            try:
+                parsed.append(_build_workload(normalised, project_id))
+            except ValueError as exc:
+                errors.append(f"Row {row_num}: {exc}")
+
+    if not parsed and not errors:
+        return WorkloadImportResult(
+            imported_count=0, failed_count=0, errors=[], workloads=[]
+        )
+
+    # Persist to DB (or return mock if no DB)
+    created: list[WorkloadResponse] = []
+    now = datetime.now(timezone.utc)
+
+    if db is None:
+        for wl in parsed:
+            mock = WorkloadResponse(
+                id=str(uuid.uuid4()),
+                project_id=wl.project_id,
+                name=wl.name,
+                type=wl.type,
+                source_platform=wl.source_platform,
+                cpu_cores=wl.cpu_cores,
+                memory_gb=wl.memory_gb,
+                storage_gb=wl.storage_gb,
+                os_type=wl.os_type,
+                os_version=wl.os_version,
+                criticality=wl.criticality,
+                compliance_requirements=wl.compliance_requirements,
+                dependencies=wl.dependencies,
+                migration_strategy=wl.migration_strategy,
+                notes=wl.notes,
+                created_at=now,
+                updated_at=now,
+            )
+            created.append(mock)
+    else:
+        try:
+            db_workloads = [
+                Workload(
+                    id=str(uuid.uuid4()),
+                    project_id=wl.project_id,
+                    name=wl.name,
+                    type=wl.type,
+                    source_platform=wl.source_platform,
+                    cpu_cores=wl.cpu_cores,
+                    memory_gb=wl.memory_gb,
+                    storage_gb=wl.storage_gb,
+                    os_type=wl.os_type,
+                    os_version=wl.os_version,
+                    criticality=wl.criticality,
+                    compliance_requirements=wl.compliance_requirements,
+                    dependencies=wl.dependencies,
+                    migration_strategy=wl.migration_strategy,
+                    notes=wl.notes,
+                    created_at=now,
+                    updated_at=now,
+                )
+                for wl in parsed
+            ]
+            for row in db_workloads:
+                db.add(row)
+            await db.flush()
+            created = [_to_response(row) for row in db_workloads]
+        except Exception as exc:
+            logger.exception("DB error during workload import")
+            raise HTTPException(status_code=500, detail=str(exc)) from exc
+
+    logger.info(
+        "Import complete: %d imported, %d failed", len(created), len(errors)
+    )
+    return WorkloadImportResult(
+        imported_count=len(created),
+        failed_count=len(errors),
+        errors=errors,
+        workloads=created,
+    )
+
+
+@router.get("", response_model=dict)
+async def list_workloads(
+    project_id: str = Query(..., description="Project ID to filter by"),
+    _user: dict = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+) -> dict:
+    """List all workloads for a given project."""
+    if db is None:
+        return {"workloads": [], "total": 0}
+
+    try:
+        result = await db.execute(
+            select(Workload).where(Workload.project_id == project_id)
+        )
+        workloads = result.scalars().all()
+        return {
+            "workloads": [_to_response(w) for w in workloads],
+            "total": len(workloads),
+        }
+    except Exception as exc:
+        logger.exception("Failed to list workloads")
+        raise HTTPException(status_code=500, detail=str(exc)) from exc
+
+
+@router.post("", response_model=WorkloadResponse)
+async def create_workload(
+    payload: WorkloadCreate,
+    _user: dict = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+) -> WorkloadResponse:
+    """Create a single workload (manual entry)."""
+    now = datetime.now(timezone.utc)
+
+    if db is None:
+        return WorkloadResponse(
+            id=str(uuid.uuid4()),
+            project_id=payload.project_id,
+            name=payload.name,
+            type=payload.type,
+            source_platform=payload.source_platform,
+            cpu_cores=payload.cpu_cores,
+            memory_gb=payload.memory_gb,
+            storage_gb=payload.storage_gb,
+            os_type=payload.os_type,
+            os_version=payload.os_version,
+            criticality=payload.criticality,
+            compliance_requirements=payload.compliance_requirements,
+            dependencies=payload.dependencies,
+            migration_strategy=payload.migration_strategy,
+            notes=payload.notes,
+            created_at=now,
+            updated_at=now,
+        )
+
+    try:
+        workload = Workload(
+            id=str(uuid.uuid4()),
+            project_id=payload.project_id,
+            name=payload.name,
+            type=payload.type,
+            source_platform=payload.source_platform,
+            cpu_cores=payload.cpu_cores,
+            memory_gb=payload.memory_gb,
+            storage_gb=payload.storage_gb,
+            os_type=payload.os_type,
+            os_version=payload.os_version,
+            criticality=payload.criticality,
+            compliance_requirements=payload.compliance_requirements,
+            dependencies=payload.dependencies,
+            migration_strategy=payload.migration_strategy,
+            notes=payload.notes,
+            created_at=now,
+            updated_at=now,
+        )
+        db.add(workload)
+        await db.flush()
+        return _to_response(workload)
+    except Exception as exc:
+        logger.exception("Failed to create workload")
+        raise HTTPException(status_code=500, detail=str(exc)) from exc
+
+
+@router.patch("/{workload_id}", response_model=WorkloadResponse)
+async def update_workload(
+    workload_id: str,
+    updates: WorkloadUpdate,
+    _user: dict = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+) -> WorkloadResponse:
+    """Update a workload by ID."""
+    if db is None:
+        raise HTTPException(status_code=404, detail="Database not configured")
+
+    try:
+        result = await db.execute(
+            select(Workload).where(Workload.id == workload_id)
+        )
+        workload = result.scalar_one_or_none()
+        if not workload:
+            raise HTTPException(status_code=404, detail="Workload not found")
+
+        update_data = updates.model_dump(exclude_unset=True)
+        for field, value in update_data.items():
+            setattr(workload, field, value)
+        workload.updated_at = datetime.now(timezone.utc)
+
+        await db.flush()
+        return _to_response(workload)
+    except HTTPException:
+        raise
+    except Exception as exc:
+        logger.exception("Failed to update workload %s", workload_id)
+        raise HTTPException(status_code=500, detail=str(exc)) from exc
+
+
+@router.delete("/{workload_id}")
+async def delete_workload(
+    workload_id: str,
+    _user: dict = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+) -> dict:
+    """Delete a workload by ID."""
+    if db is None:
+        return {"deleted": True, "message": "Database not configured"}
+
+    try:
+        result = await db.execute(
+            select(Workload).where(Workload.id == workload_id)
+        )
+        workload = result.scalar_one_or_none()
+        if not workload:
+            raise HTTPException(status_code=404, detail="Workload not found")
+        await db.delete(workload)
+        return {"deleted": True, "id": workload_id}
+    except HTTPException:
+        raise
+    except Exception as exc:
+        logger.exception("Failed to delete workload %s", workload_id)
+        raise HTTPException(status_code=500, detail=str(exc)) from exc

--- a/backend/app/db/migrations/versions/005_add_workloads.py
+++ b/backend/app/db/migrations/versions/005_add_workloads.py
@@ -24,7 +24,6 @@ def upgrade() -> None:
             sa.String(36),
             sa.ForeignKey("projects.id"),
             nullable=False,
-            index=True,
         ),
         sa.Column("name", sa.String(255), nullable=False),
         sa.Column("type", sa.String(50), nullable=False, server_default="other"),
@@ -53,7 +52,9 @@ def upgrade() -> None:
             nullable=False,
         ),
     )
+    op.create_index("ix_workloads_project_id", "workloads", ["project_id"])
 
 
 def downgrade() -> None:
+    op.drop_index("ix_workloads_project_id", table_name="workloads")
     op.drop_table("workloads")

--- a/backend/app/db/migrations/versions/005_add_workloads.py
+++ b/backend/app/db/migrations/versions/005_add_workloads.py
@@ -1,0 +1,59 @@
+"""Add workloads table.
+
+Revision ID: 005
+Revises: 004
+Create Date: 2026-07-21
+"""
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "005"
+down_revision: str | None = "004"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "workloads",
+        sa.Column("id", sa.String(36), primary_key=True),
+        sa.Column(
+            "project_id",
+            sa.String(36),
+            sa.ForeignKey("projects.id"),
+            nullable=False,
+            index=True,
+        ),
+        sa.Column("name", sa.String(255), nullable=False),
+        sa.Column("type", sa.String(50), nullable=False, server_default="other"),
+        sa.Column("source_platform", sa.String(50), nullable=False, server_default="other"),
+        sa.Column("cpu_cores", sa.Integer, nullable=True),
+        sa.Column("memory_gb", sa.Float, nullable=True),
+        sa.Column("storage_gb", sa.Float, nullable=True),
+        sa.Column("os_type", sa.String(100), nullable=True),
+        sa.Column("os_version", sa.String(100), nullable=True),
+        sa.Column("criticality", sa.String(50), nullable=False, server_default="standard"),
+        sa.Column("compliance_requirements", sa.JSON, nullable=True),
+        sa.Column("dependencies", sa.JSON, nullable=True),
+        sa.Column("migration_strategy", sa.String(50), nullable=False, server_default="unknown"),
+        sa.Column("notes", sa.Text, nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime,
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime,
+            server_default=sa.func.now(),
+            onupdate=sa.func.now(),
+            nullable=False,
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("workloads")

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -13,6 +13,7 @@ from app.api.routes.questionnaire import router as questionnaire_router
 from app.api.routes.questionnaire_state import router as questionnaire_state_router
 from app.api.routes.scoring import router as scoring_router
 from app.api.routes.users import router as users_router
+from app.api.routes.workloads import router as workloads_router
 from app.config import settings
 from app.db.seed import seed_database
 from app.db.session import close_db, init_db
@@ -74,6 +75,7 @@ app.include_router(bicep_router)
 app.include_router(scoring_router)
 app.include_router(questionnaire_state_router)
 app.include_router(discovery_router)
+app.include_router(workloads_router)
 
 
 @app.get("/health")

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -10,6 +10,7 @@ from app.models.project import Project
 from app.models.questionnaire import Question, QuestionCategory, QuestionnaireResponse
 from app.models.tenant import Tenant
 from app.models.user import User
+from app.models.workload import Workload
 
 __all__ = [
     "Base",
@@ -28,4 +29,5 @@ __all__ = [
     "AuditEntry",
     "DiscoveryScan",
     "DiscoveredResource",
+    "Workload",
 ]

--- a/backend/app/models/workload.py
+++ b/backend/app/models/workload.py
@@ -1,0 +1,55 @@
+"""Workload model — represents a workload to be migrated."""
+
+from sqlalchemy import JSON, Float, ForeignKey, Integer, String, Text
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.models.base import Base, TimestampMixin, generate_uuid
+
+WORKLOAD_TYPES = ["vm", "database", "web-app", "container", "other"]
+
+SOURCE_PLATFORMS = ["vmware", "hyperv", "physical", "aws", "gcp", "other"]
+
+CRITICALITY_LEVELS = [
+    "mission-critical",
+    "business-critical",
+    "standard",
+    "dev-test",
+]
+
+MIGRATION_STRATEGIES = [
+    "rehost",
+    "refactor",
+    "rearchitect",
+    "rebuild",
+    "replace",
+    "unknown",
+]
+
+
+class Workload(Base, TimestampMixin):
+    __tablename__ = "workloads"
+
+    id: Mapped[str] = mapped_column(String(36), primary_key=True, default=generate_uuid)
+    project_id: Mapped[str] = mapped_column(
+        String(36), ForeignKey("projects.id"), nullable=False, index=True
+    )
+
+    name: Mapped[str] = mapped_column(String(255), nullable=False)
+    type: Mapped[str] = mapped_column(String(50), default="other")
+    source_platform: Mapped[str] = mapped_column(String(50), default="other")
+
+    cpu_cores: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    memory_gb: Mapped[float | None] = mapped_column(Float, nullable=True)
+    storage_gb: Mapped[float | None] = mapped_column(Float, nullable=True)
+
+    os_type: Mapped[str | None] = mapped_column(String(100), nullable=True)
+    os_version: Mapped[str | None] = mapped_column(String(100), nullable=True)
+
+    criticality: Mapped[str] = mapped_column(String(50), default="standard")
+
+    # JSON arrays
+    compliance_requirements: Mapped[list | None] = mapped_column(JSON, nullable=True)
+    dependencies: Mapped[list | None] = mapped_column(JSON, nullable=True)
+
+    migration_strategy: Mapped[str] = mapped_column(String(50), default="unknown")
+    notes: Mapped[str | None] = mapped_column(Text, nullable=True)

--- a/backend/app/schemas/workload.py
+++ b/backend/app/schemas/workload.py
@@ -1,0 +1,75 @@
+"""Pydantic schemas for workload API."""
+
+from datetime import datetime
+
+from pydantic import BaseModel, Field
+
+
+class WorkloadCreate(BaseModel):
+    """Schema for creating a workload."""
+
+    project_id: str
+    name: str
+    type: str = "other"
+    source_platform: str = "other"
+    cpu_cores: int | None = None
+    memory_gb: float | None = None
+    storage_gb: float | None = None
+    os_type: str | None = None
+    os_version: str | None = None
+    criticality: str = "standard"
+    compliance_requirements: list[str] = Field(default_factory=list)
+    dependencies: list[str] = Field(default_factory=list)
+    migration_strategy: str = "unknown"
+    notes: str | None = None
+
+
+class WorkloadUpdate(BaseModel):
+    """Schema for updating a workload — all fields optional."""
+
+    name: str | None = None
+    type: str | None = None
+    source_platform: str | None = None
+    cpu_cores: int | None = None
+    memory_gb: float | None = None
+    storage_gb: float | None = None
+    os_type: str | None = None
+    os_version: str | None = None
+    criticality: str | None = None
+    compliance_requirements: list[str] | None = None
+    dependencies: list[str] | None = None
+    migration_strategy: str | None = None
+    notes: str | None = None
+
+
+class WorkloadResponse(BaseModel):
+    """Schema for returning a workload."""
+
+    id: str
+    project_id: str
+    name: str
+    type: str
+    source_platform: str
+    cpu_cores: int | None = None
+    memory_gb: float | None = None
+    storage_gb: float | None = None
+    os_type: str | None = None
+    os_version: str | None = None
+    criticality: str
+    compliance_requirements: list[str] = Field(default_factory=list)
+    dependencies: list[str] = Field(default_factory=list)
+    migration_strategy: str
+    notes: str | None = None
+    created_at: datetime
+    updated_at: datetime
+
+    model_config = {"from_attributes": True}
+
+
+class WorkloadImportResult(BaseModel):
+    """Schema for the result of a bulk workload import."""
+
+    imported_count: int
+    failed_count: int
+    errors: list[str] = Field(default_factory=list)
+    workloads: list[WorkloadResponse] = Field(default_factory=list)

--- a/backend/app/services/workload_importer.py
+++ b/backend/app/services/workload_importer.py
@@ -162,6 +162,69 @@ def detect_format(filename: str, content: bytes) -> str:
     return "csv"
 
 
+def parse_file(
+    content: bytes, filename: str, project_id: str
+) -> tuple[list[WorkloadCreate], list[str]]:
+    """Parse CSV or JSON bytes, collecting per-row errors without aborting.
+
+    Returns ``(parsed_workloads, errors)``.  Raises ``ValueError`` for fatal
+    format errors (invalid JSON syntax, CSV with no header row).
+    """
+    fmt = detect_format(filename, content)
+    parsed: list[WorkloadCreate] = []
+    errors: list[str] = []
+
+    if fmt == "json":
+        try:
+            data = json.loads(content)
+        except json.JSONDecodeError as exc:
+            raise ValueError(f"Invalid JSON: {exc}") from exc
+
+        if isinstance(data, dict):
+            data = data.get("workloads", [data])
+        if not isinstance(data, list):
+            raise ValueError("JSON must be an array of workload objects")
+
+        for idx, item in enumerate(data):
+            if not isinstance(item, dict):
+                errors.append(f"Item {idx}: expected object, got {type(item).__name__}")
+                continue
+            normalised: dict = {}
+            for key, value in item.items():
+                canonical = _normalise_column(str(key))
+                if isinstance(value, list):
+                    normalised[canonical] = value  # type: ignore[assignment]
+                else:
+                    normalised[canonical] = str(value) if value is not None else ""
+            try:
+                parsed.append(_build_workload(normalised, project_id))
+            except ValueError as exc:
+                errors.append(f"Item {idx}: {exc}")
+    else:
+        try:
+            text = content.decode("utf-8-sig")
+        except UnicodeDecodeError:
+            text = content.decode("latin-1")
+
+        reader = csv.DictReader(io.StringIO(text))
+        if reader.fieldnames is None:
+            raise ValueError("CSV file has no headers")
+
+        for row_num, raw_row in enumerate(reader, start=2):
+            normalised = {}
+            for col, value in raw_row.items():
+                if col is None:
+                    continue
+                canonical = _normalise_column(col)
+                normalised[canonical] = value or ""
+            try:
+                parsed.append(_build_workload(normalised, project_id))
+            except ValueError as exc:
+                errors.append(f"Row {row_num}: {exc}")
+
+    return parsed, errors
+
+
 def parse_csv(content: bytes, project_id: str) -> list[WorkloadCreate]:
     """Parse CSV bytes into a list of WorkloadCreate objects.
 
@@ -195,7 +258,7 @@ def parse_csv(content: bytes, project_id: str) -> list[WorkloadCreate]:
             workload = _build_workload(normalised, project_id)
             results.append(workload)
         except ValueError as exc:
-            logger.warning("Skipping CSV row %d: %s", row_num, exc)
+            logger.warning("Invalid CSV row %d: %s", row_num, exc)
             raise ValueError(f"Row {row_num}: {exc}") from exc
 
     return results

--- a/backend/app/services/workload_importer.py
+++ b/backend/app/services/workload_importer.py
@@ -1,0 +1,243 @@
+"""Workload importer service — parse CSV and JSON files into WorkloadCreate objects."""
+
+import csv
+import io
+import json
+import logging
+
+from app.schemas.workload import WorkloadCreate
+
+logger = logging.getLogger(__name__)
+
+# Column name aliases: maps common variants to canonical field names
+_COLUMN_ALIASES: dict[str, str] = {
+    # name
+    "workload_name": "name",
+    "vm_name": "name",
+    "server_name": "name",
+    "hostname": "name",
+    # type
+    "workload_type": "type",
+    "resource_type": "type",
+    # source_platform
+    "platform": "source_platform",
+    "source": "source_platform",
+    "hypervisor": "source_platform",
+    "environment": "source_platform",
+    # cpu
+    "cpu": "cpu_cores",
+    "cpus": "cpu_cores",
+    "vcpu": "cpu_cores",
+    "vcpus": "cpu_cores",
+    "num_cpu": "cpu_cores",
+    # memory
+    "memory": "memory_gb",
+    "ram": "memory_gb",
+    "ram_gb": "memory_gb",
+    "memory_gb_total": "memory_gb",
+    # storage
+    "storage": "storage_gb",
+    "disk": "storage_gb",
+    "disk_gb": "storage_gb",
+    "hdd_gb": "storage_gb",
+    "total_storage_gb": "storage_gb",
+    # os
+    "os": "os_type",
+    "operating_system": "os_type",
+    "os_name": "os_type",
+    "os_ver": "os_version",
+    "os_release": "os_version",
+    # criticality
+    "priority": "criticality",
+    "tier": "criticality",
+    "importance": "criticality",
+    # migration_strategy
+    "strategy": "migration_strategy",
+    "migration": "migration_strategy",
+    "migration_approach": "migration_strategy",
+    # compliance
+    "compliance": "compliance_requirements",
+    "frameworks": "compliance_requirements",
+    # notes
+    "description": "notes",
+    "comments": "notes",
+    "remarks": "notes",
+}
+
+# Valid enum values — values not in these sets get mapped to a default
+_VALID_TYPES = {"vm", "database", "web-app", "container", "other"}
+_VALID_PLATFORMS = {"vmware", "hyperv", "physical", "aws", "gcp", "other"}
+_VALID_CRITICALITY = {"mission-critical", "business-critical", "standard", "dev-test"}
+_VALID_STRATEGIES = {"rehost", "refactor", "rearchitect", "rebuild", "replace", "unknown"}
+
+
+def _normalise_column(raw: str) -> str:
+    """Convert a raw column header to a canonical field name."""
+    cleaned = raw.strip().lower().replace(" ", "_").replace("-", "_")
+    return _COLUMN_ALIASES.get(cleaned, cleaned)
+
+
+def _coerce_int(value: str) -> int | None:
+    try:
+        return int(float(value.strip()))
+    except (ValueError, AttributeError):
+        return None
+
+
+def _coerce_float(value: str) -> float | None:
+    try:
+        return float(value.strip())
+    except (ValueError, AttributeError):
+        return None
+
+
+def _parse_list_field(value: str) -> list[str]:
+    """Parse a semi-colon or comma-separated string into a list."""
+    if not value or not value.strip():
+        return []
+    # Try semicolon first, then comma
+    sep = ";" if ";" in value else ","
+    return [item.strip() for item in value.split(sep) if item.strip()]
+
+
+def _build_workload(row: dict[str, str], project_id: str) -> WorkloadCreate:
+    """Convert a normalised row dict into a WorkloadCreate."""
+    name = row.get("name", "").strip()
+    if not name:
+        raise ValueError("Missing required field: name")
+
+    raw_type = row.get("type", "").strip().lower().replace(" ", "-")
+    wl_type = raw_type if raw_type in _VALID_TYPES else "other"
+
+    raw_platform = row.get("source_platform", "").strip().lower().replace(" ", "_")
+    platform = raw_platform if raw_platform in _VALID_PLATFORMS else "other"
+
+    raw_criticality = row.get("criticality", "").strip().lower().replace(" ", "-")
+    criticality = raw_criticality if raw_criticality in _VALID_CRITICALITY else "standard"
+
+    raw_strategy = row.get("migration_strategy", "").strip().lower()
+    strategy = raw_strategy if raw_strategy in _VALID_STRATEGIES else "unknown"
+
+    compliance_raw = row.get("compliance_requirements", "")
+    if isinstance(compliance_raw, list):
+        compliance = compliance_raw
+    else:
+        compliance = _parse_list_field(compliance_raw)
+
+    deps_raw = row.get("dependencies", "")
+    if isinstance(deps_raw, list):
+        deps = deps_raw
+    else:
+        deps = _parse_list_field(deps_raw)
+
+    return WorkloadCreate(
+        project_id=project_id,
+        name=name,
+        type=wl_type,
+        source_platform=platform,
+        cpu_cores=_coerce_int(row.get("cpu_cores", "")),
+        memory_gb=_coerce_float(row.get("memory_gb", "")),
+        storage_gb=_coerce_float(row.get("storage_gb", "")),
+        os_type=row.get("os_type") or None,
+        os_version=row.get("os_version") or None,
+        criticality=criticality,
+        compliance_requirements=compliance,
+        dependencies=deps,
+        migration_strategy=strategy,
+        notes=row.get("notes") or None,
+    )
+
+
+def detect_format(filename: str, content: bytes) -> str:
+    """Detect whether content is CSV or JSON based on filename and sniffing."""
+    lower = filename.lower()
+    if lower.endswith(".json"):
+        return "json"
+    if lower.endswith(".csv") or lower.endswith(".tsv"):
+        return "csv"
+    # Sniff content
+    snippet = content[:512].lstrip()
+    if snippet.startswith(b"[") or snippet.startswith(b"{"):
+        return "json"
+    return "csv"
+
+
+def parse_csv(content: bytes, project_id: str) -> list[WorkloadCreate]:
+    """Parse CSV bytes into a list of WorkloadCreate objects.
+
+    Handles BOM-prefixed files and maps common column name variants.
+    Raises ValueError on completely unparseable content.
+    """
+    try:
+        text = content.decode("utf-8-sig")  # strips BOM if present
+    except UnicodeDecodeError:
+        text = content.decode("latin-1")
+
+    reader = csv.DictReader(io.StringIO(text))
+    if reader.fieldnames is None:
+        raise ValueError("CSV file has no headers")
+
+    # Build normalised column map: canonical_name -> original_header
+    col_map = {_normalise_column(col): col for col in reader.fieldnames}
+    logger.debug("CSV column map: %s", col_map)
+
+    results: list[WorkloadCreate] = []
+    for row_num, raw_row in enumerate(reader, start=2):  # start=2 (row 1 is header)
+        # Remap columns to canonical names
+        normalised: dict[str, str] = {}
+        for original_col, value in raw_row.items():
+            if original_col is None:
+                continue
+            canonical = _normalise_column(original_col)
+            normalised[canonical] = value or ""
+
+        try:
+            workload = _build_workload(normalised, project_id)
+            results.append(workload)
+        except ValueError as exc:
+            logger.warning("Skipping CSV row %d: %s", row_num, exc)
+            raise ValueError(f"Row {row_num}: {exc}") from exc
+
+    return results
+
+
+def parse_json(content: bytes, project_id: str) -> list[WorkloadCreate]:
+    """Parse JSON bytes into a list of WorkloadCreate objects.
+
+    Accepts either a JSON array of objects, or a single object, or a dict
+    with a 'workloads' key containing an array.
+    """
+    try:
+        data = json.loads(content)
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"Invalid JSON: {exc}") from exc
+
+    if isinstance(data, dict):
+        # Accept {workloads: [...]} wrapper
+        data = data.get("workloads", [data])
+
+    if not isinstance(data, list):
+        raise ValueError("JSON must be an array of workload objects")
+
+    results: list[WorkloadCreate] = []
+    for idx, item in enumerate(data):
+        if not isinstance(item, dict):
+            raise ValueError(f"Item {idx}: expected object, got {type(item).__name__}")
+
+        # Normalise keys
+        normalised: dict[str, str] = {}
+        for key, value in item.items():
+            canonical = _normalise_column(str(key))
+            if isinstance(value, list):
+                normalised[canonical] = value  # type: ignore[assignment]
+            else:
+                normalised[canonical] = str(value) if value is not None else ""
+
+        try:
+            workload = _build_workload(normalised, project_id)
+            results.append(workload)
+        except ValueError as exc:
+            logger.warning("Skipping JSON item %d: %s", idx, exc)
+            raise ValueError(f"Item {idx}: {exc}") from exc
+
+    return results

--- a/backend/tests/test_migrations.py
+++ b/backend/tests/test_migrations.py
@@ -23,7 +23,7 @@ async def test_migrations_run_cleanly():
     async with engine.connect() as conn:
         result = await conn.execute(text("SELECT version_num FROM alembic_version"))
         versions = [row[0] for row in result]
-        assert "004" in versions
+        assert "005" in versions
 
     await engine.dispose()
 

--- a/backend/tests/test_routes_workloads.py
+++ b/backend/tests/test_routes_workloads.py
@@ -1,0 +1,217 @@
+"""Tests for workload API routes."""
+
+import io
+import json
+
+import pytest
+from fastapi.testclient import TestClient
+
+from app.main import app
+
+client = TestClient(app)
+
+PROJECT_ID = "proj-test-routes"
+
+
+# ---------------------------------------------------------------------------
+# POST /api/workloads  (manual create)
+# ---------------------------------------------------------------------------
+
+def test_create_workload_basic():
+    payload = {"project_id": PROJECT_ID, "name": "MyVM", "type": "vm"}
+    r = client.post("/api/workloads", json=payload)
+    assert r.status_code == 200
+    data = r.json()
+    assert data["name"] == "MyVM"
+    assert data["type"] == "vm"
+    assert "id" in data
+
+
+def test_create_workload_full_payload():
+    payload = {
+        "project_id": PROJECT_ID,
+        "name": "FullVM",
+        "type": "vm",
+        "source_platform": "vmware",
+        "cpu_cores": 8,
+        "memory_gb": 32.0,
+        "storage_gb": 500.0,
+        "os_type": "Windows",
+        "os_version": "Server 2022",
+        "criticality": "mission-critical",
+        "compliance_requirements": ["SOC2"],
+        "dependencies": [],
+        "migration_strategy": "rehost",
+        "notes": "Important server",
+    }
+    r = client.post("/api/workloads", json=payload)
+    assert r.status_code == 200
+    data = r.json()
+    assert data["criticality"] == "mission-critical"
+    assert data["migration_strategy"] == "rehost"
+    assert data["compliance_requirements"] == ["SOC2"]
+
+
+def test_create_workload_missing_name():
+    r = client.post("/api/workloads", json={"project_id": PROJECT_ID})
+    assert r.status_code == 422
+
+
+def test_create_workload_missing_project_id():
+    r = client.post("/api/workloads", json={"name": "NoProject"})
+    assert r.status_code == 422
+
+
+# ---------------------------------------------------------------------------
+# GET /api/workloads?project_id=...
+# ---------------------------------------------------------------------------
+
+def test_list_workloads_returns_list():
+    r = client.get(f"/api/workloads?project_id={PROJECT_ID}")
+    assert r.status_code == 200
+    data = r.json()
+    assert "workloads" in data
+    assert isinstance(data["workloads"], list)
+
+
+def test_list_workloads_missing_project_id():
+    r = client.get("/api/workloads")
+    assert r.status_code == 422
+
+
+# ---------------------------------------------------------------------------
+# POST /api/workloads/import — CSV
+# ---------------------------------------------------------------------------
+
+def test_import_csv_basic():
+    csv_content = b"name,type,cpu_cores\nweb01,vm,4\nweb02,container,2\n"
+    r = client.post(
+        f"/api/workloads/import?project_id={PROJECT_ID}",
+        files={"file": ("workloads.csv", io.BytesIO(csv_content), "text/csv")},
+    )
+    assert r.status_code == 200
+    data = r.json()
+    assert data["imported_count"] == 2
+    assert data["failed_count"] == 0
+    assert len(data["workloads"]) == 2
+
+
+def test_import_csv_with_aliases():
+    csv_content = b"vm_name,cpus,ram_gb\nserver1,8,32\n"
+    r = client.post(
+        f"/api/workloads/import?project_id={PROJECT_ID}",
+        files={"file": ("vms.csv", io.BytesIO(csv_content), "text/csv")},
+    )
+    assert r.status_code == 200
+    data = r.json()
+    assert data["imported_count"] == 1
+    assert data["workloads"][0]["name"] == "server1"
+
+
+def test_import_csv_row_with_missing_name_recorded_as_error():
+    # Row 2 has no name — should be counted as failed
+    csv_content = b"name,type\nweb01,vm\n,container\n"
+    r = client.post(
+        f"/api/workloads/import?project_id={PROJECT_ID}",
+        files={"file": ("bad.csv", io.BytesIO(csv_content), "text/csv")},
+    )
+    assert r.status_code == 200
+    data = r.json()
+    assert data["imported_count"] == 1
+    assert data["failed_count"] == 1
+    assert len(data["errors"]) == 1
+
+
+# ---------------------------------------------------------------------------
+# POST /api/workloads/import — JSON
+# ---------------------------------------------------------------------------
+
+def test_import_json_basic():
+    payload = [{"name": "svc1", "type": "web-app"}, {"name": "svc2", "type": "database"}]
+    r = client.post(
+        f"/api/workloads/import?project_id={PROJECT_ID}",
+        files={
+            "file": ("workloads.json", io.BytesIO(json.dumps(payload).encode()), "application/json")
+        },
+    )
+    assert r.status_code == 200
+    data = r.json()
+    assert data["imported_count"] == 2
+    assert data["failed_count"] == 0
+
+
+def test_import_json_wrapped():
+    payload = {"workloads": [{"name": "wrapped1"}]}
+    r = client.post(
+        f"/api/workloads/import?project_id={PROJECT_ID}",
+        files={
+            "file": ("w.json", io.BytesIO(json.dumps(payload).encode()), "application/json")
+        },
+    )
+    assert r.status_code == 200
+    assert r.json()["imported_count"] == 1
+
+
+def test_import_empty_file_returns_zero():
+    r = client.post(
+        f"/api/workloads/import?project_id={PROJECT_ID}",
+        files={"file": ("empty.csv", io.BytesIO(b""), "text/csv")},
+    )
+    assert r.status_code == 400
+
+
+def test_import_missing_project_id_returns_422():
+    csv_content = b"name\nweb01\n"
+    r = client.post(
+        "/api/workloads/import",
+        files={"file": ("w.csv", io.BytesIO(csv_content), "text/csv")},
+    )
+    assert r.status_code == 422
+
+
+def test_import_invalid_json_returns_422():
+    r = client.post(
+        f"/api/workloads/import?project_id={PROJECT_ID}",
+        files={"file": ("bad.json", io.BytesIO(b"not-json"), "application/json")},
+    )
+    assert r.status_code == 422
+
+
+# ---------------------------------------------------------------------------
+# PATCH /api/workloads/{id}
+# ---------------------------------------------------------------------------
+
+def test_patch_workload_no_db_returns_404():
+    """In dev mode without DB, PATCH returns 404."""
+    r = client.patch("/api/workloads/nonexistent", json={"name": "Updated"})
+    assert r.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# DELETE /api/workloads/{id}
+# ---------------------------------------------------------------------------
+
+def test_delete_workload_no_db_returns_success():
+    """In dev mode without DB, DELETE returns success message."""
+    r = client.delete("/api/workloads/some-id")
+    assert r.status_code == 200
+    data = r.json()
+    assert data["deleted"] is True
+
+
+# ---------------------------------------------------------------------------
+# WorkloadImportResult structure
+# ---------------------------------------------------------------------------
+
+def test_import_result_has_required_fields():
+    csv_content = b"name\ntest-workload\n"
+    r = client.post(
+        f"/api/workloads/import?project_id={PROJECT_ID}",
+        files={"file": ("test.csv", io.BytesIO(csv_content), "text/csv")},
+    )
+    assert r.status_code == 200
+    data = r.json()
+    assert "imported_count" in data
+    assert "failed_count" in data
+    assert "errors" in data
+    assert "workloads" in data

--- a/backend/tests/test_workload_importer.py
+++ b/backend/tests/test_workload_importer.py
@@ -1,0 +1,215 @@
+"""Tests for workload importer service."""
+
+import json
+
+import pytest
+
+from app.services.workload_importer import (
+    detect_format,
+    parse_csv,
+    parse_json,
+)
+
+PROJECT_ID = "proj-test-001"
+
+
+# ---------------------------------------------------------------------------
+# detect_format
+# ---------------------------------------------------------------------------
+
+def test_detect_format_json_extension():
+    assert detect_format("workloads.json", b"[]") == "json"
+
+
+def test_detect_format_csv_extension():
+    assert detect_format("workloads.csv", b"name,type\n") == "csv"
+
+
+def test_detect_format_sniff_json_array():
+    assert detect_format("upload", b'[{"name": "web1"}]') == "json"
+
+
+def test_detect_format_sniff_json_object():
+    assert detect_format("upload", b'{"workloads": []}') == "json"
+
+
+def test_detect_format_sniff_csv_fallback():
+    assert detect_format("data.txt", b"name,type,cpu\n") == "csv"
+
+
+# ---------------------------------------------------------------------------
+# parse_csv — happy path
+# ---------------------------------------------------------------------------
+
+def test_parse_csv_basic():
+    csv_content = b"name,type,cpu_cores,memory_gb\nweb01,vm,4,16\n"
+    result = parse_csv(csv_content, PROJECT_ID)
+    assert len(result) == 1
+    wl = result[0]
+    assert wl.name == "web01"
+    assert wl.type == "vm"
+    assert wl.cpu_cores == 4
+    assert wl.memory_gb == 16.0
+    assert wl.project_id == PROJECT_ID
+
+
+def test_parse_csv_column_aliases():
+    """cpus/ram/disk/vm_name aliases map to canonical fields."""
+    csv_content = b"vm_name,cpus,ram_gb,disk_gb\ndb01,8,32.5,500\n"
+    result = parse_csv(csv_content, PROJECT_ID)
+    assert len(result) == 1
+    wl = result[0]
+    assert wl.name == "db01"
+    assert wl.cpu_cores == 8
+    assert wl.memory_gb == 32.5
+    assert wl.storage_gb == 500.0
+
+
+def test_parse_csv_type_normalisation():
+    csv_content = b"name,type\napp1,web-app\n"
+    result = parse_csv(csv_content, PROJECT_ID)
+    assert result[0].type == "web-app"
+
+
+def test_parse_csv_unknown_type_defaults_to_other():
+    csv_content = b"name,type\napp1,mainframe\n"
+    result = parse_csv(csv_content, PROJECT_ID)
+    assert result[0].type == "other"
+
+
+def test_parse_csv_compliance_semicolon():
+    csv_content = b"name,compliance_requirements\napp1,SOC2;ISO27001\n"
+    result = parse_csv(csv_content, PROJECT_ID)
+    assert result[0].compliance_requirements == ["SOC2", "ISO27001"]
+
+
+def test_parse_csv_compliance_comma():
+    csv_content = b"name,compliance\napp1,SOC2,ISO27001\n"
+    # NOTE: CSV comma-separated inside a field requires quoting
+    csv_content = b'name,compliance\napp1,"SOC2,ISO27001"\n'
+    result = parse_csv(csv_content, PROJECT_ID)
+    assert result[0].compliance_requirements == ["SOC2", "ISO27001"]
+
+
+def test_parse_csv_multiple_rows():
+    csv_content = b"name,type\nvm1,vm\nvm2,container\n"
+    result = parse_csv(csv_content, PROJECT_ID)
+    assert len(result) == 2
+    assert result[1].type == "container"
+
+
+def test_parse_csv_bom_prefix():
+    """UTF-8 BOM should be stripped correctly."""
+    # Prepend BOM bytes directly so utf-8-sig decoding removes them
+    csv_content = b"\xef\xbb\xbfname,type\nweb01,vm\n"
+    result = parse_csv(csv_content, PROJECT_ID)
+    assert result[0].name == "web01"
+
+
+def test_parse_csv_empty_optional_fields():
+    csv_content = b"name,cpu_cores,memory_gb,storage_gb\nweb01,,,\n"
+    result = parse_csv(csv_content, PROJECT_ID)
+    wl = result[0]
+    assert wl.cpu_cores is None
+    assert wl.memory_gb is None
+    assert wl.storage_gb is None
+
+
+def test_parse_csv_criticality_alias():
+    csv_content = b"name,priority\napp1,mission-critical\n"
+    result = parse_csv(csv_content, PROJECT_ID)
+    assert result[0].criticality == "mission-critical"
+
+
+# ---------------------------------------------------------------------------
+# parse_csv — error cases
+# ---------------------------------------------------------------------------
+
+def test_parse_csv_missing_name_raises():
+    csv_content = b"type,cpu_cores\nvm,4\n"
+    with pytest.raises(ValueError, match="name"):
+        parse_csv(csv_content, PROJECT_ID)
+
+
+def test_parse_csv_no_headers_raises():
+    with pytest.raises(ValueError, match="no headers"):
+        parse_csv(b"", PROJECT_ID)
+
+
+# ---------------------------------------------------------------------------
+# parse_json — happy path
+# ---------------------------------------------------------------------------
+
+def test_parse_json_array():
+    data = [{"name": "svc1", "type": "vm", "cpu_cores": 2}]
+    result = parse_json(json.dumps(data).encode(), PROJECT_ID)
+    assert len(result) == 1
+    assert result[0].name == "svc1"
+    assert result[0].cpu_cores == 2
+
+
+def test_parse_json_wrapped_in_workloads_key():
+    data = {"workloads": [{"name": "svc2", "type": "container"}]}
+    result = parse_json(json.dumps(data).encode(), PROJECT_ID)
+    assert len(result) == 1
+    assert result[0].type == "container"
+
+
+def test_parse_json_single_object():
+    data = {"name": "single-vm", "type": "vm"}
+    result = parse_json(json.dumps(data).encode(), PROJECT_ID)
+    assert len(result) == 1
+    assert result[0].name == "single-vm"
+
+
+def test_parse_json_compliance_list():
+    data = [{"name": "app", "compliance_requirements": ["SOC2", "PCI-DSS"]}]
+    result = parse_json(json.dumps(data).encode(), PROJECT_ID)
+    assert result[0].compliance_requirements == ["SOC2", "PCI-DSS"]
+
+
+def test_parse_json_source_platform_normalisation():
+    data = [{"name": "vm1", "source_platform": "vmware"}]
+    result = parse_json(json.dumps(data).encode(), PROJECT_ID)
+    assert result[0].source_platform == "vmware"
+
+
+def test_parse_json_unknown_platform_defaults():
+    data = [{"name": "vm1", "source_platform": "hyper-v-pro"}]
+    result = parse_json(json.dumps(data).encode(), PROJECT_ID)
+    assert result[0].source_platform == "other"
+
+
+def test_parse_json_column_aliases():
+    """JSON keys should also be normalised via aliases."""
+    data = [{"workload_name": "svc3", "cpus": 4, "ram": 8}]
+    result = parse_json(json.dumps(data).encode(), PROJECT_ID)
+    assert result[0].name == "svc3"
+    assert result[0].cpu_cores == 4
+    assert result[0].memory_gb == 8.0
+
+
+# ---------------------------------------------------------------------------
+# parse_json — error cases
+# ---------------------------------------------------------------------------
+
+def test_parse_json_invalid_json_raises():
+    with pytest.raises(ValueError, match="Invalid JSON"):
+        parse_json(b"not-json", PROJECT_ID)
+
+
+def test_parse_json_non_array_non_dict_raises():
+    with pytest.raises(ValueError, match="array"):
+        parse_json(b'"just a string"', PROJECT_ID)
+
+
+def test_parse_json_missing_name_raises():
+    data = [{"type": "vm"}]
+    with pytest.raises(ValueError, match="name"):
+        parse_json(json.dumps(data).encode(), PROJECT_ID)
+
+
+def test_parse_json_item_not_dict_raises():
+    data = [1, 2, 3]
+    with pytest.raises(ValueError):
+        parse_json(json.dumps(data).encode(), PROJECT_ID)

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,6 +1,6 @@
 import { Suspense, lazy } from "react";
 import { FluentProvider, webLightTheme } from "@fluentui/react-components";
-import { BrowserRouter, Routes, Route } from "react-router-dom";
+import { BrowserRouter, Routes, Route, Navigate } from "react-router-dom";
 import { AuthProvider } from "./auth";
 import Layout from "./components/shared/Layout";
 import ErrorBoundary from "./components/shared/ErrorBoundary";
@@ -59,6 +59,7 @@ function App() {
                   <Route path="/gap-analysis/:scanId" element={<GapAnalysisPage />} />
 
                   {/* Workloads */}
+                  <Route path="/workloads" element={<Navigate to="/projects" replace />} />
                   <Route path="/projects/:projectId/workloads" element={
                     <ProjectProvider><WorkloadsPage /></ProjectProvider>
                   } />

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -15,6 +15,7 @@ const BicepPage = lazy(() => import("./pages/BicepPage"));
 const DeployPage = lazy(() => import("./pages/DeployPage"));
 const ProjectDetailPage = lazy(() => import("./pages/ProjectDetailPage"));
 const GapAnalysisPage = lazy(() => import("./pages/GapAnalysisPage"));
+const WorkloadsPage = lazy(() => import("./pages/WorkloadsPage"));
 
 function App() {
   return (
@@ -56,6 +57,11 @@ function App() {
 
                   {/* Gap analysis */}
                   <Route path="/gap-analysis/:scanId" element={<GapAnalysisPage />} />
+
+                  {/* Workloads */}
+                  <Route path="/projects/:projectId/workloads" element={
+                    <ProjectProvider><WorkloadsPage /></ProjectProvider>
+                  } />
                 </Routes>
               </Suspense>
             </ErrorBoundary>

--- a/frontend/src/pages/WorkloadsPage.test.tsx
+++ b/frontend/src/pages/WorkloadsPage.test.tsx
@@ -204,7 +204,8 @@ describe("Create workload dialog", () => {
     await userEvent.click(screen.getByRole("tab", { name: /Inventory/i }));
     await waitFor(() => screen.getByRole("button", { name: /Add Workload/i }));
     await userEvent.click(screen.getByRole("button", { name: /Add Workload/i }));
-    expect(screen.getByRole("heading", { name: /Add Workload/i })).toBeInTheDocument();
+    // findByPlaceholderText confirms the dialog form is open and the name input is rendered
+    expect(await screen.findByPlaceholderText(/e.g. web-server-01/i)).toBeInTheDocument();
   });
 
   it("creates a workload and closes dialog on success", async () => {
@@ -213,9 +214,9 @@ describe("Create workload dialog", () => {
     await userEvent.click(screen.getByRole("tab", { name: /Inventory/i }));
     await waitFor(() => screen.getByRole("button", { name: /Add Workload/i }));
     await userEvent.click(screen.getByRole("button", { name: /Add Workload/i }));
-    const nameInput = screen.getByPlaceholderText(/e.g. web-server-01/i);
+    const nameInput = await screen.findByPlaceholderText(/e.g. web-server-01/i);
     await userEvent.type(nameInput, "New VM");
-    await userEvent.click(screen.getByRole("button", { name: /Create Workload/i }));
+    await userEvent.click(await screen.findByRole("button", { name: /Create Workload/i }));
     await waitFor(() => {
       expect(mockedApi.workloads.create).toHaveBeenCalledWith(
         expect.objectContaining({ name: "New VM" }),
@@ -227,9 +228,19 @@ describe("Create workload dialog", () => {
     renderPage();
     await userEvent.click(screen.getByRole("tab", { name: /Inventory/i }));
     await waitFor(() => screen.getByRole("button", { name: /Add Workload/i }));
-    await userEvent.click(screen.getByRole("button", { name: /Add Workload/i }));
+    // Use fireEvent to avoid pointer event sequences that may close the dialog
+    fireEvent.click(screen.getByRole("button", { name: /Add Workload/i }));
+    // Wait for the entire dialog to render (form + action buttons)
+    await waitFor(() => {
+      screen.getByPlaceholderText(/e.g. web-server-01/i);
+      screen.getByRole("button", { name: /Create Workload/i });
+    });
+    // Focus inside the dialog first to prevent pointer events from dismissing it
+    await userEvent.click(screen.getByPlaceholderText(/e.g. web-server-01/i));
     await userEvent.click(screen.getByRole("button", { name: /Create Workload/i }));
-    expect(screen.getByText("Name is required")).toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.getByText("Name is required")).toBeInTheDocument();
+    });
   });
 });
 
@@ -241,8 +252,10 @@ describe("Delete workload", () => {
     await userEvent.click(screen.getByRole("tab", { name: /Inventory/i }));
     await waitFor(() => screen.getByText("Web Server 01"));
     await userEvent.click(screen.getByLabelText("Delete Web Server 01"));
-    expect(screen.getByText(/Are you sure you want to delete/i)).toBeInTheDocument();
-    await userEvent.click(screen.getByRole("button", { name: /^Delete$/i }));
+    await waitFor(() => {
+      expect(screen.getByText(/Are you sure you want to delete/i)).toBeInTheDocument();
+    });
+    await userEvent.click(await screen.findByRole("button", { name: /^Delete$/i }));
     await waitFor(() => {
       expect(mockedApi.workloads.delete).toHaveBeenCalledWith("wl-001");
     });
@@ -256,8 +269,13 @@ describe("Edit workload dialog", () => {
     renderPage();
     await userEvent.click(screen.getByRole("tab", { name: /Inventory/i }));
     await waitFor(() => screen.getByText("Web Server 01"));
-    await userEvent.click(screen.getByLabelText("Edit Web Server 01"));
-    expect(screen.getByRole("heading", { name: /Edit Workload/i })).toBeInTheDocument();
+    // Use fireEvent to avoid pointer event sequences that may close the dialog
+    fireEvent.click(screen.getByLabelText("Edit Web Server 01"));
+    // Wait for the entire dialog to render (form + action buttons)
+    await waitFor(() => {
+      screen.getByDisplayValue("Web Server 01");
+      screen.getByRole("button", { name: /Save Changes/i });
+    });
     const nameInput = screen.getByDisplayValue("Web Server 01");
     await userEvent.clear(nameInput);
     await userEvent.type(nameInput, "Renamed");
@@ -276,7 +294,15 @@ describe("Edit workload dialog", () => {
     renderPage();
     await userEvent.click(screen.getByRole("tab", { name: /Inventory/i }));
     await waitFor(() => screen.getByText("Web Server 01"));
-    await userEvent.click(screen.getByLabelText("Edit Web Server 01"));
+    // Use fireEvent to avoid pointer event sequences that may close the dialog
+    fireEvent.click(screen.getByLabelText("Edit Web Server 01"));
+    // Wait for the entire dialog to render (form + action buttons)
+    await waitFor(() => {
+      screen.getByDisplayValue("Web Server 01");
+      screen.getByRole("button", { name: /Save Changes/i });
+    });
+    // Focus inside the dialog first to prevent pointer events from dismissing it
+    await userEvent.click(screen.getByDisplayValue("Web Server 01"));
     await userEvent.click(screen.getByRole("button", { name: /Save Changes/i }));
     await waitFor(() => {
       expect(screen.getByText("Update failed")).toBeInTheDocument();

--- a/frontend/src/pages/WorkloadsPage.test.tsx
+++ b/frontend/src/pages/WorkloadsPage.test.tsx
@@ -1,0 +1,299 @@
+import { render, screen, waitFor, fireEvent } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { FluentProvider, teamsLightTheme } from "@fluentui/react-components";
+import { MemoryRouter } from "react-router-dom";
+import { vi, describe, it, expect, beforeEach } from "vitest";
+
+import WorkloadsPage from "./WorkloadsPage";
+
+vi.mock("../services/api", () => ({
+  api: {
+    workloads: {
+      list: vi.fn(),
+      create: vi.fn(),
+      update: vi.fn(),
+      delete: vi.fn(),
+      importFile: vi.fn(),
+    },
+  },
+}));
+
+import { api } from "../services/api";
+
+const mockedApi = api as unknown as {
+  workloads: {
+    list: ReturnType<typeof vi.fn>;
+    create: ReturnType<typeof vi.fn>;
+    update: ReturnType<typeof vi.fn>;
+    delete: ReturnType<typeof vi.fn>;
+    importFile: ReturnType<typeof vi.fn>;
+  };
+};
+
+function renderPage() {
+  return render(
+    <FluentProvider theme={teamsLightTheme}>
+      <MemoryRouter>
+        <WorkloadsPage projectId="test-project-id" />
+      </MemoryRouter>
+    </FluentProvider>,
+  );
+}
+
+const mockWorkload = {
+  id: "wl-001",
+  project_id: "test-project-id",
+  name: "Web Server 01",
+  type: "vm",
+  source_platform: "vmware",
+  cpu_cores: 4,
+  memory_gb: 16.0,
+  storage_gb: 500.0,
+  os_type: "Windows",
+  os_version: "Server 2022",
+  criticality: "standard",
+  compliance_requirements: [],
+  dependencies: [],
+  migration_strategy: "rehost",
+  notes: null,
+  created_at: "2024-01-01T00:00:00",
+  updated_at: "2024-01-01T00:00:00",
+};
+
+beforeEach(() => {
+  vi.resetAllMocks();
+});
+
+describe("WorkloadsPage rendering", () => {
+  it("renders the heading", () => {
+    renderPage();
+    expect(screen.getByText("Workload Inventory")).toBeInTheDocument();
+  });
+
+  it("renders Import and Inventory tabs", () => {
+    renderPage();
+    expect(screen.getByRole("tab", { name: /Import/i })).toBeInTheDocument();
+    expect(screen.getByRole("tab", { name: /Inventory/i })).toBeInTheDocument();
+  });
+
+  it("shows the drop zone by default on Import tab", () => {
+    renderPage();
+    expect(screen.getByText(/Drop a CSV or JSON file here/i)).toBeInTheDocument();
+  });
+});
+
+describe("Import tab", () => {
+  it("shows file name and Import button after selecting a file", async () => {
+    renderPage();
+    const input = screen.getByLabelText(/File input for workload import/i);
+    const file = new File(["name,type\nweb01,vm\n"], "workloads.csv", { type: "text/csv" });
+    await userEvent.upload(input, file);
+    expect(screen.getAllByText(/workloads.csv/).length).toBeGreaterThan(0);
+    expect(screen.getByRole("button", { name: /^Import$/i })).toBeInTheDocument();
+  });
+
+  it("calls importFile and shows results on success", async () => {
+    mockedApi.workloads.list.mockResolvedValue({ workloads: [], total: 0 });
+    mockedApi.workloads.importFile.mockResolvedValue({
+      imported_count: 2,
+      failed_count: 0,
+      errors: [],
+      workloads: [
+        { ...mockWorkload, id: "wl-001", name: "Web Server 01" },
+        { ...mockWorkload, id: "wl-002", name: "DB Server 01" },
+      ],
+    });
+    renderPage();
+    const input = screen.getByLabelText(/File input for workload import/i);
+    const file = new File(["name,type\nweb01,vm\n"], "workloads.csv", { type: "text/csv" });
+    await userEvent.upload(input, file);
+    const importBtn = screen.getByRole("button", { name: /^Import$/i });
+    await userEvent.click(importBtn);
+    await waitFor(() => {
+      expect(screen.getByText(/Imported/i)).toBeInTheDocument();
+    });
+    expect(mockedApi.workloads.importFile).toHaveBeenCalledWith(file, "test-project-id");
+  });
+
+  it("shows row errors from import result", async () => {
+    mockedApi.workloads.list.mockResolvedValue({ workloads: [], total: 0 });
+    mockedApi.workloads.importFile.mockResolvedValue({
+      imported_count: 1,
+      failed_count: 1,
+      errors: ["Row 3: Missing required field: name"],
+      workloads: [mockWorkload],
+    });
+    renderPage();
+    const input = screen.getByLabelText(/File input for workload import/i);
+    await userEvent.upload(input, new File(["name\nweb01\n"], "f.csv"));
+    await userEvent.click(screen.getByRole("button", { name: /^Import$/i }));
+    await waitFor(() => {
+      expect(screen.getByText(/Row 3: Missing required field: name/)).toBeInTheDocument();
+    });
+  });
+
+  it("shows error message when import throws", async () => {
+    mockedApi.workloads.importFile.mockRejectedValue(new Error("Network error"));
+    renderPage();
+    const input = screen.getByLabelText(/File input for workload import/i);
+    await userEvent.upload(input, new File(["name\nweb01\n"], "f.csv"));
+    await userEvent.click(screen.getByRole("button", { name: /^Import$/i }));
+    await waitFor(() => {
+      expect(screen.getByText(/Network error/)).toBeInTheDocument();
+    });
+  });
+
+  it("clears file selection when Clear button is clicked", async () => {
+    renderPage();
+    const input = screen.getByLabelText(/File input for workload import/i);
+    await userEvent.upload(input, new File(["name\nweb01\n"], "test.csv"));
+    expect(screen.getAllByText(/test.csv/).length).toBeGreaterThan(0);
+    await userEvent.click(screen.getByRole("button", { name: /Clear/i }));
+    expect(screen.getByText(/Drop a CSV or JSON file here/i)).toBeInTheDocument();
+  });
+});
+
+describe("Inventory tab", () => {
+  it("loads and displays workloads when Inventory tab is selected", async () => {
+    mockedApi.workloads.list.mockResolvedValue({ workloads: [mockWorkload], total: 1 });
+    renderPage();
+    await userEvent.click(screen.getByRole("tab", { name: /Inventory/i }));
+    await waitFor(() => {
+      expect(screen.getByText("Web Server 01")).toBeInTheDocument();
+    });
+    expect(mockedApi.workloads.list).toHaveBeenCalledWith("test-project-id");
+  });
+
+  it("shows empty state when no workloads exist", async () => {
+    mockedApi.workloads.list.mockResolvedValue({ workloads: [], total: 0 });
+    renderPage();
+    await userEvent.click(screen.getByRole("tab", { name: /Inventory/i }));
+    await waitFor(() => {
+      expect(screen.getByText(/No workloads yet/i)).toBeInTheDocument();
+    });
+  });
+
+  it("shows error message when list fails", async () => {
+    mockedApi.workloads.list.mockRejectedValue(new Error("Server error"));
+    renderPage();
+    await userEvent.click(screen.getByRole("tab", { name: /Inventory/i }));
+    await waitFor(() => {
+      expect(screen.getByText(/Server error/)).toBeInTheDocument();
+    });
+  });
+
+  it("refreshes list when Refresh button is clicked", async () => {
+    mockedApi.workloads.list.mockResolvedValue({ workloads: [mockWorkload], total: 1 });
+    renderPage();
+    await userEvent.click(screen.getByRole("tab", { name: /Inventory/i }));
+    await waitFor(() => screen.getByText("Web Server 01"));
+    await userEvent.click(screen.getByRole("button", { name: /Refresh/i }));
+    await waitFor(() => {
+      expect(mockedApi.workloads.list).toHaveBeenCalledTimes(2);
+    });
+  });
+});
+
+describe("Create workload dialog", () => {
+  beforeEach(async () => {
+    mockedApi.workloads.list.mockResolvedValue({ workloads: [], total: 0 });
+  });
+
+  it("opens Add Workload dialog on Inventory tab", async () => {
+    renderPage();
+    await userEvent.click(screen.getByRole("tab", { name: /Inventory/i }));
+    await waitFor(() => screen.getByRole("button", { name: /Add Workload/i }));
+    await userEvent.click(screen.getByRole("button", { name: /Add Workload/i }));
+    expect(screen.getByRole("heading", { name: /Add Workload/i })).toBeInTheDocument();
+  });
+
+  it("creates a workload and closes dialog on success", async () => {
+    mockedApi.workloads.create.mockResolvedValue({ ...mockWorkload, name: "New VM" });
+    renderPage();
+    await userEvent.click(screen.getByRole("tab", { name: /Inventory/i }));
+    await waitFor(() => screen.getByRole("button", { name: /Add Workload/i }));
+    await userEvent.click(screen.getByRole("button", { name: /Add Workload/i }));
+    const nameInput = screen.getByPlaceholderText(/e.g. web-server-01/i);
+    await userEvent.type(nameInput, "New VM");
+    await userEvent.click(screen.getByRole("button", { name: /Create Workload/i }));
+    await waitFor(() => {
+      expect(mockedApi.workloads.create).toHaveBeenCalledWith(
+        expect.objectContaining({ name: "New VM" }),
+      );
+    });
+  });
+
+  it("shows validation error when name is empty", async () => {
+    renderPage();
+    await userEvent.click(screen.getByRole("tab", { name: /Inventory/i }));
+    await waitFor(() => screen.getByRole("button", { name: /Add Workload/i }));
+    await userEvent.click(screen.getByRole("button", { name: /Add Workload/i }));
+    await userEvent.click(screen.getByRole("button", { name: /Create Workload/i }));
+    expect(screen.getByText("Name is required")).toBeInTheDocument();
+  });
+});
+
+describe("Delete workload", () => {
+  it("deletes workload and removes from list", async () => {
+    mockedApi.workloads.list.mockResolvedValue({ workloads: [mockWorkload], total: 1 });
+    mockedApi.workloads.delete.mockResolvedValue({ deleted: true, id: "wl-001" });
+    renderPage();
+    await userEvent.click(screen.getByRole("tab", { name: /Inventory/i }));
+    await waitFor(() => screen.getByText("Web Server 01"));
+    await userEvent.click(screen.getByLabelText("Delete Web Server 01"));
+    expect(screen.getByText(/Are you sure you want to delete/i)).toBeInTheDocument();
+    await userEvent.click(screen.getByRole("button", { name: /^Delete$/i }));
+    await waitFor(() => {
+      expect(mockedApi.workloads.delete).toHaveBeenCalledWith("wl-001");
+    });
+  });
+});
+
+describe("Edit workload dialog", () => {
+  it("opens edit dialog pre-filled and saves changes", async () => {
+    mockedApi.workloads.list.mockResolvedValue({ workloads: [mockWorkload], total: 1 });
+    mockedApi.workloads.update.mockResolvedValue({ ...mockWorkload, name: "Renamed" });
+    renderPage();
+    await userEvent.click(screen.getByRole("tab", { name: /Inventory/i }));
+    await waitFor(() => screen.getByText("Web Server 01"));
+    await userEvent.click(screen.getByLabelText("Edit Web Server 01"));
+    expect(screen.getByRole("heading", { name: /Edit Workload/i })).toBeInTheDocument();
+    const nameInput = screen.getByDisplayValue("Web Server 01");
+    await userEvent.clear(nameInput);
+    await userEvent.type(nameInput, "Renamed");
+    await userEvent.click(screen.getByRole("button", { name: /Save Changes/i }));
+    await waitFor(() => {
+      expect(mockedApi.workloads.update).toHaveBeenCalledWith(
+        "wl-001",
+        expect.objectContaining({ name: "Renamed" }),
+      );
+    });
+  });
+
+  it("shows error when save fails", async () => {
+    mockedApi.workloads.list.mockResolvedValue({ workloads: [mockWorkload], total: 1 });
+    mockedApi.workloads.update.mockRejectedValue(new Error("Update failed"));
+    renderPage();
+    await userEvent.click(screen.getByRole("tab", { name: /Inventory/i }));
+    await waitFor(() => screen.getByText("Web Server 01"));
+    await userEvent.click(screen.getByLabelText("Edit Web Server 01"));
+    await userEvent.click(screen.getByRole("button", { name: /Save Changes/i }));
+    await waitFor(() => {
+      expect(screen.getByText("Update failed")).toBeInTheDocument();
+    });
+  });
+});
+
+describe("Import tab drag-and-drop", () => {
+  it("accepts a dropped file", async () => {
+    renderPage();
+    const dropZone = screen.getByRole("button", { name: /drop zone/i });
+    const file = new File(["name,type\nApp,vm"], "workloads.csv", { type: "text/csv" });
+    const dt = { files: [file], types: ["Files"] };
+    fireEvent.dragOver(dropZone, { dataTransfer: dt });
+    fireEvent.drop(dropZone, { dataTransfer: dt });
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: /^Import$/i })).toBeInTheDocument();
+    });
+  });
+});

--- a/frontend/src/pages/WorkloadsPage.tsx
+++ b/frontend/src/pages/WorkloadsPage.tsx
@@ -175,6 +175,7 @@ export default function WorkloadsPage({ projectId: propProjectId }: WorkloadsPag
   // Delete dialog
   const [deleteTarget, setDeleteTarget] = useState<WorkloadRecord | null>(null);
   const [deleteLoading, setDeleteLoading] = useState(false);
+  const [deleteError, setDeleteError] = useState<string | null>(null);
 
   const handleDrop = useCallback((e: React.DragEvent<HTMLDivElement>) => {
     e.preventDefault();
@@ -289,12 +290,14 @@ export default function WorkloadsPage({ projectId: propProjectId }: WorkloadsPag
   const handleDelete = async () => {
     if (!deleteTarget) return;
     setDeleteLoading(true);
+    setDeleteError(null);
     try {
       await api.workloads.delete(deleteTarget.id);
       setWorkloads((prev) => prev.filter((w) => w.id !== deleteTarget.id));
       setDeleteTarget(null);
-    } catch {
-      // ignore
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : "Delete failed";
+      setDeleteError(message);
     } finally {
       setDeleteLoading(false);
     }
@@ -694,7 +697,7 @@ export default function WorkloadsPage({ projectId: propProjectId }: WorkloadsPag
       </Dialog>
 
       {/* ---- Delete Confirm Dialog ---- */}
-      <Dialog open={!!deleteTarget} onOpenChange={(_, d) => !d.open && setDeleteTarget(null)}>
+      <Dialog open={!!deleteTarget} onOpenChange={(_, d) => { if (!d.open) { setDeleteTarget(null); setDeleteError(null); } }}>
         <DialogSurface>
           <DialogBody>
             <DialogTitle>Delete Workload</DialogTitle>
@@ -703,6 +706,11 @@ export default function WorkloadsPage({ projectId: propProjectId }: WorkloadsPag
                 Are you sure you want to delete{" "}
                 <strong>{deleteTarget?.name}</strong>? This action cannot be undone.
               </Text>
+              {deleteError && (
+                <MessageBar intent="error">
+                  <MessageBarBody>{deleteError}</MessageBarBody>
+                </MessageBar>
+              )}
             </DialogContent>
             <DialogActions>
               <DialogTrigger disableButtonEnhancement>

--- a/frontend/src/pages/WorkloadsPage.tsx
+++ b/frontend/src/pages/WorkloadsPage.tsx
@@ -1,0 +1,725 @@
+import { useCallback, useRef, useState } from "react";
+import {
+  Badge,
+  Button,
+  Dialog,
+  DialogActions,
+  DialogBody,
+  DialogContent,
+  DialogSurface,
+  DialogTitle,
+  DialogTrigger,
+  Divider,
+  Field,
+  Input,
+  Label,
+  MessageBar,
+  MessageBarBody,
+  Select,
+  Spinner,
+  Tab,
+  TabList,
+  Table,
+  TableBody,
+  TableCell,
+  TableHeader,
+  TableHeaderCell,
+  TableRow,
+  Text,
+  Textarea,
+  makeStyles,
+  tokens,
+} from "@fluentui/react-components";
+import {
+  ArrowUploadRegular,
+  CheckmarkCircleRegular,
+  DeleteRegular,
+  DocumentRegular,
+  EditRegular,
+  WarningRegular,
+} from "@fluentui/react-icons";
+import type {
+  WorkloadCreateRequest,
+  WorkloadImportResult,
+  WorkloadRecord,
+} from "../services/api";
+import { api } from "../services/api";
+
+const useStyles = makeStyles({
+  root: {
+    maxWidth: "1100px",
+    margin: "0 auto",
+    padding: tokens.spacingVerticalXL,
+    display: "flex",
+    flexDirection: "column",
+    gap: tokens.spacingVerticalL,
+  },
+  heading: {
+    fontSize: tokens.fontSizeBase600,
+    fontWeight: tokens.fontWeightSemibold,
+  },
+  tabContent: {
+    paddingTop: tokens.spacingVerticalL,
+    display: "flex",
+    flexDirection: "column",
+    gap: tokens.spacingVerticalM,
+  },
+  dropZone: {
+    border: `2px dashed ${tokens.colorNeutralStroke1}`,
+    borderRadius: tokens.borderRadiusMedium,
+    padding: tokens.spacingVerticalXXL,
+    textAlign: "center",
+    cursor: "pointer",
+    display: "flex",
+    flexDirection: "column",
+    alignItems: "center",
+    gap: tokens.spacingVerticalS,
+    ":hover": {
+      backgroundColor: tokens.colorNeutralBackground2,
+    },
+  },
+  dropZoneActive: {
+    backgroundColor: tokens.colorBrandBackground2,
+  },
+  previewSection: {
+    display: "flex",
+    flexDirection: "column",
+    gap: tokens.spacingVerticalS,
+  },
+  errorList: {
+    display: "flex",
+    flexDirection: "column",
+    gap: tokens.spacingVerticalXS,
+  },
+  tableWrapper: {
+    overflowX: "auto",
+  },
+  actionRow: {
+    display: "flex",
+    gap: tokens.spacingHorizontalM,
+    alignItems: "center",
+    justifyContent: "space-between",
+  },
+  formGrid: {
+    display: "grid",
+    gridTemplateColumns: "1fr 1fr",
+    gap: tokens.spacingVerticalM,
+  },
+  formFullRow: {
+    gridColumn: "1 / -1",
+  },
+  importSummary: {
+    display: "flex",
+    gap: tokens.spacingHorizontalM,
+    alignItems: "center",
+  },
+});
+
+type TabValue = "import" | "inventory";
+
+const WORKLOAD_TYPES = ["vm", "database", "web-app", "container", "other"];
+const SOURCE_PLATFORMS = ["vmware", "hyperv", "physical", "aws", "gcp", "other"];
+const CRITICALITY_OPTIONS = ["mission-critical", "business-critical", "standard", "dev-test"];
+const MIGRATION_STRATEGIES = ["rehost", "refactor", "rearchitect", "rebuild", "replace", "unknown"];
+
+interface WorkloadsPageProps {
+  projectId?: string;
+}
+
+function emptyDraft(projectId: string): WorkloadCreateRequest {
+  return {
+    project_id: projectId,
+    name: "",
+    type: "other",
+    source_platform: "other",
+    cpu_cores: null,
+    memory_gb: null,
+    storage_gb: null,
+    os_type: null,
+    os_version: null,
+    criticality: "standard",
+    compliance_requirements: [],
+    dependencies: [],
+    migration_strategy: "unknown",
+    notes: null,
+  };
+}
+
+export default function WorkloadsPage({ projectId = "dev-project" }: WorkloadsPageProps) {
+  const styles = useStyles();
+  const [activeTab, setActiveTab] = useState<TabValue>("import");
+
+  // Import tab
+  const [dragOver, setDragOver] = useState(false);
+  const [importFile, setImportFile] = useState<File | null>(null);
+  const [importResult, setImportResult] = useState<WorkloadImportResult | null>(null);
+  const [importLoading, setImportLoading] = useState(false);
+  const [importError, setImportError] = useState<string | null>(null);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  // Inventory tab
+  const [workloads, setWorkloads] = useState<WorkloadRecord[]>([]);
+  const [listLoading, setListLoading] = useState(false);
+  const [listError, setListError] = useState<string | null>(null);
+
+  // Create/edit dialog
+  const [dialogOpen, setDialogOpen] = useState(false);
+  const [editTarget, setEditTarget] = useState<WorkloadRecord | null>(null);
+  const [draft, setDraft] = useState<WorkloadCreateRequest>(emptyDraft(projectId));
+  const [saveLoading, setSaveLoading] = useState(false);
+  const [saveError, setSaveError] = useState<string | null>(null);
+
+  // Delete dialog
+  const [deleteTarget, setDeleteTarget] = useState<WorkloadRecord | null>(null);
+  const [deleteLoading, setDeleteLoading] = useState(false);
+
+  const handleDrop = useCallback((e: React.DragEvent<HTMLDivElement>) => {
+    e.preventDefault();
+    setDragOver(false);
+    const file = e.dataTransfer.files[0];
+    if (file) {
+      setImportFile(file);
+      setImportResult(null);
+      setImportError(null);
+    }
+  }, []);
+
+  const handleFileSelect = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0] ?? null;
+    if (file) {
+      setImportFile(file);
+      setImportResult(null);
+      setImportError(null);
+    }
+  };
+
+  const handleImport = async () => {
+    if (!importFile) return;
+    setImportLoading(true);
+    setImportError(null);
+    try {
+      const result = await api.workloads.importFile(importFile, projectId);
+      setImportResult(result);
+      if (result.imported_count > 0) {
+        fetchWorkloads();
+      }
+    } catch (err) {
+      setImportError(err instanceof Error ? err.message : "Import failed");
+    } finally {
+      setImportLoading(false);
+    }
+  };
+
+  const fetchWorkloads = useCallback(async () => {
+    setListLoading(true);
+    setListError(null);
+    try {
+      const data = await api.workloads.list(projectId);
+      setWorkloads(data.workloads);
+    } catch (err) {
+      setListError(err instanceof Error ? err.message : "Failed to load workloads");
+    } finally {
+      setListLoading(false);
+    }
+  }, [projectId]);
+
+  const handleTabChange = (_: unknown, data: { value: unknown }) => {
+    const tab = data.value as TabValue;
+    setActiveTab(tab);
+    if (tab === "inventory" && workloads.length === 0) {
+      fetchWorkloads();
+    }
+  };
+
+  const openCreate = () => {
+    setEditTarget(null);
+    setDraft(emptyDraft(projectId));
+    setSaveError(null);
+    setDialogOpen(true);
+  };
+
+  const openEdit = (wl: WorkloadRecord) => {
+    setEditTarget(wl);
+    setDraft({
+      project_id: wl.project_id,
+      name: wl.name,
+      type: wl.type,
+      source_platform: wl.source_platform,
+      cpu_cores: wl.cpu_cores,
+      memory_gb: wl.memory_gb,
+      storage_gb: wl.storage_gb,
+      os_type: wl.os_type,
+      os_version: wl.os_version,
+      criticality: wl.criticality,
+      compliance_requirements: wl.compliance_requirements,
+      dependencies: wl.dependencies,
+      migration_strategy: wl.migration_strategy,
+      notes: wl.notes,
+    });
+    setSaveError(null);
+    setDialogOpen(true);
+  };
+
+  const handleSave = async () => {
+    if (!draft.name.trim()) {
+      setSaveError("Name is required");
+      return;
+    }
+    setSaveLoading(true);
+    setSaveError(null);
+    try {
+      if (editTarget) {
+        const updated = await api.workloads.update(editTarget.id, draft);
+        setWorkloads((prev) => prev.map((w) => (w.id === editTarget.id ? updated : w)));
+      } else {
+        const created = await api.workloads.create(draft);
+        setWorkloads((prev) => [...prev, created]);
+      }
+      setDialogOpen(false);
+    } catch (err) {
+      setSaveError(err instanceof Error ? err.message : "Save failed");
+    } finally {
+      setSaveLoading(false);
+    }
+  };
+
+  const handleDelete = async () => {
+    if (!deleteTarget) return;
+    setDeleteLoading(true);
+    try {
+      await api.workloads.delete(deleteTarget.id);
+      setWorkloads((prev) => prev.filter((w) => w.id !== deleteTarget.id));
+      setDeleteTarget(null);
+    } catch {
+      // ignore
+    } finally {
+      setDeleteLoading(false);
+    }
+  };
+
+  return (
+    <div className={styles.root}>
+      <Text className={styles.heading}>Workload Inventory</Text>
+
+      <TabList selectedValue={activeTab} onTabSelect={handleTabChange}>
+        <Tab value="import" icon={<ArrowUploadRegular />}>Import</Tab>
+        <Tab value="inventory" icon={<DocumentRegular />}>Inventory</Tab>
+      </TabList>
+
+      {/* ---- Import Tab ---- */}
+      {activeTab === "import" && (
+        <div className={styles.tabContent}>
+          <Text>Upload a CSV or JSON file to bulk-import workloads into this project.</Text>
+
+          <div
+            className={`${styles.dropZone} ${dragOver ? styles.dropZoneActive : ""}`}
+            onDragOver={(e) => { e.preventDefault(); setDragOver(true); }}
+            onDragLeave={() => setDragOver(false)}
+            onDrop={handleDrop}
+            onClick={() => fileInputRef.current?.click()}
+            role="button"
+            tabIndex={0}
+            onKeyDown={(e) => e.key === "Enter" && fileInputRef.current?.click()}
+            aria-label="Drop zone for workload import file"
+          >
+            <ArrowUploadRegular style={{ fontSize: 32, color: tokens.colorBrandForeground1 }} />
+            <Text weight="semibold">
+              {importFile ? importFile.name : "Drop a CSV or JSON file here"}
+            </Text>
+            <Text size={200} style={{ color: tokens.colorNeutralForeground3 }}>
+              or click to browse
+            </Text>
+            <input
+              ref={fileInputRef}
+              type="file"
+              accept=".csv,.json"
+              style={{ display: "none" }}
+              onChange={handleFileSelect}
+              aria-label="File input for workload import"
+            />
+          </div>
+
+          {importFile && (
+            <div className={styles.actionRow}>
+              <Text>
+                Selected: <strong>{importFile.name}</strong>{" "}
+                ({(importFile.size / 1024).toFixed(1)} KB)
+              </Text>
+              <div style={{ display: "flex", gap: tokens.spacingHorizontalS }}>
+                <Button
+                  appearance="subtle"
+                  onClick={() => { setImportFile(null); setImportResult(null); setImportError(null); }}
+                >
+                  Clear
+                </Button>
+                <Button
+                  appearance="primary"
+                  onClick={handleImport}
+                  disabled={importLoading}
+                  icon={importLoading ? <Spinner size="tiny" /> : undefined}
+                >
+                  {importLoading ? "Importing\u2026" : "Import"}
+                </Button>
+              </div>
+            </div>
+          )}
+
+          {importError && (
+            <MessageBar intent="error">
+              <MessageBarBody>{importError}</MessageBarBody>
+            </MessageBar>
+          )}
+
+          {importResult && (
+            <div className={styles.previewSection}>
+              <div className={styles.importSummary}>
+                <CheckmarkCircleRegular
+                  style={{ fontSize: 20, color: tokens.colorStatusSuccessForeground1 }}
+                />
+                <Text>
+                  Imported{" "}
+                  <strong>{importResult.imported_count}</strong>{" "}
+                  workload{importResult.imported_count !== 1 ? "s" : ""}
+                  {importResult.failed_count > 0 && (
+                    <span style={{ color: tokens.colorStatusWarningForeground1 }}>
+                      {" "}({importResult.failed_count} failed)
+                    </span>
+                  )}
+                </Text>
+              </div>
+
+              {importResult.errors.length > 0 && (
+                <div className={styles.errorList}>
+                  <Text weight="semibold" style={{ color: tokens.colorStatusWarningForeground1 }}>
+                    <WarningRegular /> Row errors:
+                  </Text>
+                  {importResult.errors.map((err, i) => (
+                    <Text key={i} size={200} style={{ color: tokens.colorStatusWarningForeground1 }}>
+                      {err}
+                    </Text>
+                  ))}
+                </div>
+              )}
+
+              {importResult.workloads.length > 0 && (
+                <>
+                  <Divider />
+                  <Text weight="semibold">Preview ({importResult.workloads.length} rows)</Text>
+                  <div className={styles.tableWrapper}>
+                    <Table>
+                      <TableHeader>
+                        <TableRow>
+                          <TableHeaderCell>Name</TableHeaderCell>
+                          <TableHeaderCell>Type</TableHeaderCell>
+                          <TableHeaderCell>Platform</TableHeaderCell>
+                          <TableHeaderCell>CPUs</TableHeaderCell>
+                          <TableHeaderCell>RAM (GB)</TableHeaderCell>
+                          <TableHeaderCell>Criticality</TableHeaderCell>
+                          <TableHeaderCell>Strategy</TableHeaderCell>
+                        </TableRow>
+                      </TableHeader>
+                      <TableBody>
+                        {importResult.workloads.map((wl) => (
+                          <TableRow key={wl.id}>
+                            <TableCell>{wl.name}</TableCell>
+                            <TableCell>{wl.type}</TableCell>
+                            <TableCell>{wl.source_platform}</TableCell>
+                            <TableCell>{wl.cpu_cores ?? "\u2014"}</TableCell>
+                            <TableCell>{wl.memory_gb ?? "\u2014"}</TableCell>
+                            <TableCell>
+                              <Badge
+                                appearance="tint"
+                                color={
+                                  wl.criticality === "mission-critical"
+                                    ? "danger"
+                                    : wl.criticality === "business-critical"
+                                      ? "warning"
+                                      : "informative"
+                                }
+                              >
+                                {wl.criticality}
+                              </Badge>
+                            </TableCell>
+                            <TableCell>{wl.migration_strategy}</TableCell>
+                          </TableRow>
+                        ))}
+                      </TableBody>
+                    </Table>
+                  </div>
+                </>
+              )}
+            </div>
+          )}
+        </div>
+      )}
+
+      {/* ---- Inventory Tab ---- */}
+      {activeTab === "inventory" && (
+        <div className={styles.tabContent}>
+          <div className={styles.actionRow}>
+            <Text>
+              {workloads.length} workload{workloads.length !== 1 ? "s" : ""} in this project
+            </Text>
+            <div style={{ display: "flex", gap: tokens.spacingHorizontalS }}>
+              <Button appearance="subtle" onClick={fetchWorkloads} disabled={listLoading}>
+                {listLoading ? <Spinner size="tiny" /> : "Refresh"}
+              </Button>
+              <Button appearance="primary" onClick={openCreate}>
+                Add Workload
+              </Button>
+            </div>
+          </div>
+
+          {listError && (
+            <MessageBar intent="error">
+              <MessageBarBody>{listError}</MessageBarBody>
+            </MessageBar>
+          )}
+          {listLoading && <Spinner label="Loading workloads\u2026" />}
+          {!listLoading && workloads.length === 0 && (
+            <MessageBar intent="info">
+              <MessageBarBody>
+                No workloads yet. Import a file or add one manually.
+              </MessageBarBody>
+            </MessageBar>
+          )}
+          {!listLoading && workloads.length > 0 && (
+            <div className={styles.tableWrapper}>
+              <Table>
+                <TableHeader>
+                  <TableRow>
+                    <TableHeaderCell>Name</TableHeaderCell>
+                    <TableHeaderCell>Type</TableHeaderCell>
+                    <TableHeaderCell>Platform</TableHeaderCell>
+                    <TableHeaderCell>CPUs</TableHeaderCell>
+                    <TableHeaderCell>RAM (GB)</TableHeaderCell>
+                    <TableHeaderCell>OS</TableHeaderCell>
+                    <TableHeaderCell>Criticality</TableHeaderCell>
+                    <TableHeaderCell>Strategy</TableHeaderCell>
+                    <TableHeaderCell>Actions</TableHeaderCell>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {workloads.map((wl) => (
+                    <TableRow key={wl.id}>
+                      <TableCell>{wl.name}</TableCell>
+                      <TableCell>{wl.type}</TableCell>
+                      <TableCell>{wl.source_platform}</TableCell>
+                      <TableCell>{wl.cpu_cores ?? "\u2014"}</TableCell>
+                      <TableCell>{wl.memory_gb ?? "\u2014"}</TableCell>
+                      <TableCell>{wl.os_type ?? "\u2014"}</TableCell>
+                      <TableCell>
+                        <Badge
+                          appearance="tint"
+                          color={
+                            wl.criticality === "mission-critical"
+                              ? "danger"
+                              : wl.criticality === "business-critical"
+                                ? "warning"
+                                : "informative"
+                          }
+                        >
+                          {wl.criticality}
+                        </Badge>
+                      </TableCell>
+                      <TableCell>{wl.migration_strategy}</TableCell>
+                      <TableCell>
+                        <div style={{ display: "flex", gap: tokens.spacingHorizontalXS }}>
+                          <Button
+                            appearance="subtle"
+                            size="small"
+                            icon={<EditRegular />}
+                            onClick={() => openEdit(wl)}
+                            aria-label={`Edit ${wl.name}`}
+                          />
+                          <Button
+                            appearance="subtle"
+                            size="small"
+                            icon={<DeleteRegular />}
+                            onClick={() => setDeleteTarget(wl)}
+                            aria-label={`Delete ${wl.name}`}
+                          />
+                        </div>
+                      </TableCell>
+                    </TableRow>
+                  ))}
+                </TableBody>
+              </Table>
+            </div>
+          )}
+        </div>
+      )}
+
+      {/* ---- Create/Edit Dialog ---- */}
+      <Dialog open={dialogOpen} onOpenChange={(_, d) => setDialogOpen(d.open)}>
+        <DialogSurface>
+          <DialogBody>
+            <DialogTitle>{editTarget ? "Edit Workload" : "Add Workload"}</DialogTitle>
+            <DialogContent>
+              <div className={styles.formGrid}>
+                <Field label="Name" required className={styles.formFullRow}>
+                  <Input
+                    value={draft.name}
+                    onChange={(_, d) => setDraft((p: WorkloadCreateRequest) => ({ ...p, name: d.value }))}
+                    placeholder="e.g. web-server-01"
+                  />
+                </Field>
+                <Field label="Type">
+                  <Select
+                    value={draft.type ?? "other"}
+                    onChange={(_, d) => setDraft((p: WorkloadCreateRequest) => ({ ...p, type: d.value }))}
+                  >
+                    {WORKLOAD_TYPES.map((t) => <option key={t} value={t}>{t}</option>)}
+                  </Select>
+                </Field>
+                <Field label="Source Platform">
+                  <Select
+                    value={draft.source_platform ?? "other"}
+                    onChange={(_, d) => setDraft((p: WorkloadCreateRequest) => ({ ...p, source_platform: d.value }))}
+                  >
+                    {SOURCE_PLATFORMS.map((p) => <option key={p} value={p}>{p}</option>)}
+                  </Select>
+                </Field>
+                <Field label="CPU Cores">
+                  <Input
+                    type="number"
+                    value={draft.cpu_cores != null ? String(draft.cpu_cores) : ""}
+                    onChange={(_, d) =>
+                      setDraft((p: WorkloadCreateRequest) => ({ ...p, cpu_cores: d.value ? parseInt(d.value, 10) : null }))
+                    }
+                    placeholder="e.g. 4"
+                  />
+                </Field>
+                <Field label="Memory (GB)">
+                  <Input
+                    type="number"
+                    value={draft.memory_gb != null ? String(draft.memory_gb) : ""}
+                    onChange={(_, d) =>
+                      setDraft((p: WorkloadCreateRequest) => ({ ...p, memory_gb: d.value ? parseFloat(d.value) : null }))
+                    }
+                    placeholder="e.g. 16"
+                  />
+                </Field>
+                <Field label="Storage (GB)">
+                  <Input
+                    type="number"
+                    value={draft.storage_gb != null ? String(draft.storage_gb) : ""}
+                    onChange={(_, d) =>
+                      setDraft((p: WorkloadCreateRequest) => ({ ...p, storage_gb: d.value ? parseFloat(d.value) : null }))
+                    }
+                    placeholder="e.g. 500"
+                  />
+                </Field>
+                <Field label="OS Type">
+                  <Input
+                    value={draft.os_type ?? ""}
+                    onChange={(_, d) => setDraft((p: WorkloadCreateRequest) => ({ ...p, os_type: d.value || null }))}
+                    placeholder="e.g. Windows"
+                  />
+                </Field>
+                <Field label="OS Version">
+                  <Input
+                    value={draft.os_version ?? ""}
+                    onChange={(_, d) => setDraft((p: WorkloadCreateRequest) => ({ ...p, os_version: d.value || null }))}
+                    placeholder="e.g. Server 2022"
+                  />
+                </Field>
+                <Field label="Criticality">
+                  <Select
+                    value={draft.criticality ?? "standard"}
+                    onChange={(_, d) => setDraft((p: WorkloadCreateRequest) => ({ ...p, criticality: d.value }))}
+                  >
+                    {CRITICALITY_OPTIONS.map((c) => <option key={c} value={c}>{c}</option>)}
+                  </Select>
+                </Field>
+                <Field label="Migration Strategy">
+                  <Select
+                    value={draft.migration_strategy ?? "unknown"}
+                    onChange={(_, d) => setDraft((p: WorkloadCreateRequest) => ({ ...p, migration_strategy: d.value }))}
+                  >
+                    {MIGRATION_STRATEGIES.map((s) => <option key={s} value={s}>{s}</option>)}
+                  </Select>
+                </Field>
+                <Field
+                  label="Compliance Requirements"
+                  hint="Comma-separated list of framework IDs"
+                  className={styles.formFullRow}
+                >
+                  <Input
+                    value={(draft.compliance_requirements ?? []).join(", ")}
+                    onChange={(_, d) =>
+                      setDraft((p: WorkloadCreateRequest) => ({
+                        ...p,
+                        compliance_requirements: d.value
+                          ? d.value.split(",").map((s) => s.trim()).filter(Boolean)
+                          : [],
+                      }))
+                    }
+                    placeholder="e.g. SOC2, ISO27001"
+                  />
+                </Field>
+                <Field label="Notes" className={styles.formFullRow}>
+                  <Textarea
+                    value={draft.notes ?? ""}
+                    onChange={(_, d) => setDraft((p: WorkloadCreateRequest) => ({ ...p, notes: d.value || null }))}
+                    placeholder="Optional notes about this workload"
+                    rows={3}
+                  />
+                </Field>
+              </div>
+              {saveError && (
+                <MessageBar intent="error" style={{ marginTop: tokens.spacingVerticalM }}>
+                  <MessageBarBody>{saveError}</MessageBarBody>
+                </MessageBar>
+              )}
+            </DialogContent>
+            <DialogActions>
+              <DialogTrigger disableButtonEnhancement>
+                <Button appearance="secondary">Cancel</Button>
+              </DialogTrigger>
+              <Button
+                appearance="primary"
+                onClick={handleSave}
+                disabled={saveLoading}
+                icon={saveLoading ? <Spinner size="tiny" /> : undefined}
+              >
+                {saveLoading ? "Saving\u2026" : editTarget ? "Save Changes" : "Create Workload"}
+              </Button>
+            </DialogActions>
+          </DialogBody>
+        </DialogSurface>
+      </Dialog>
+
+      {/* ---- Delete Confirm Dialog ---- */}
+      <Dialog open={!!deleteTarget} onOpenChange={(_, d) => !d.open && setDeleteTarget(null)}>
+        <DialogSurface>
+          <DialogBody>
+            <DialogTitle>Delete Workload</DialogTitle>
+            <DialogContent>
+              <Text>
+                Are you sure you want to delete{" "}
+                <strong>{deleteTarget?.name}</strong>? This action cannot be undone.
+              </Text>
+            </DialogContent>
+            <DialogActions>
+              <DialogTrigger disableButtonEnhancement>
+                <Button appearance="secondary">Cancel</Button>
+              </DialogTrigger>
+              <Button
+                appearance="primary"
+                onClick={handleDelete}
+                disabled={deleteLoading}
+                icon={deleteLoading ? <Spinner size="tiny" /> : undefined}
+                style={{ backgroundColor: tokens.colorStatusDangerBackground3 }}
+              >
+                {deleteLoading ? "Deleting\u2026" : "Delete"}
+              </Button>
+            </DialogActions>
+          </DialogBody>
+        </DialogSurface>
+      </Dialog>
+
+      <Label style={{ display: "none" }}>Workload import file picker</Label>
+    </div>
+  );
+}

--- a/frontend/src/pages/WorkloadsPage.tsx
+++ b/frontend/src/pages/WorkloadsPage.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useRef, useState } from "react";
+import { useParams } from "react-router-dom";
 import {
   Badge,
   Button,
@@ -145,7 +146,9 @@ function emptyDraft(projectId: string): WorkloadCreateRequest {
   };
 }
 
-export default function WorkloadsPage({ projectId = "dev-project" }: WorkloadsPageProps) {
+export default function WorkloadsPage({ projectId: propProjectId }: WorkloadsPageProps) {
+  const { projectId: paramProjectId } = useParams<{ projectId: string }>();
+  const projectId = propProjectId ?? paramProjectId ?? "dev-project";
   const styles = useStyles();
   const [activeTab, setActiveTab] = useState<TabValue>("import");
 

--- a/frontend/src/services/api.test.ts
+++ b/frontend/src/services/api.test.ts
@@ -392,14 +392,14 @@ describe("api.workloads", () => {
     expect(call[0]).toContain("project_id=proj-1");
   });
 
-  it("list without projectId calls /api/workloads", async () => {
+  it("list with projectId includes project_id query param", async () => {
     vi.stubGlobal("fetch", vi.fn().mockResolvedValue({
       ok: true,
       json: () => Promise.resolve({ workloads: [], total: 0 }),
     }));
-    await api.workloads.list();
+    await api.workloads.list("proj-2");
     expect(fetch).toHaveBeenCalledWith(
-      "/api/workloads",
+      expect.stringContaining("project_id=proj-2"),
       expect.any(Object)
     );
   });

--- a/frontend/src/services/api.test.ts
+++ b/frontend/src/services/api.test.ts
@@ -379,3 +379,90 @@ describe("api.deployment list with projectId", () => {
     expect(call[0]).toContain(encodeURIComponent("my project/id"));
   });
 });
+
+describe("api.workloads", () => {
+  it("list calls correct endpoint with project_id", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ workloads: [], total: 0 }),
+    }));
+    await api.workloads.list("proj-1");
+    const call = (fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(call[0]).toContain("/api/workloads");
+    expect(call[0]).toContain("project_id=proj-1");
+  });
+
+  it("list without projectId calls /api/workloads", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ workloads: [], total: 0 }),
+    }));
+    await api.workloads.list();
+    expect(fetch).toHaveBeenCalledWith(
+      "/api/workloads",
+      expect.any(Object)
+    );
+  });
+
+  it("create sends POST with workload body", async () => {
+    const body = { project_id: "proj-1", name: "MyVM", type: "vm", source_platform: "other" };
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ id: "w1", ...body }),
+    }));
+    await api.workloads.create(body);
+    const call = (fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(call[0]).toBe("/api/workloads");
+    expect(call[1].method).toBe("POST");
+    const parsed = JSON.parse(call[1].body);
+    expect(parsed.name).toBe("MyVM");
+    expect(parsed.project_id).toBe("proj-1");
+  });
+
+  it("update sends PATCH to correct endpoint", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ id: "w1", name: "Updated" }),
+    }));
+    await api.workloads.update("w1", { name: "Updated" });
+    const call = (fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(call[0]).toBe("/api/workloads/w1");
+    expect(call[1].method).toBe("PATCH");
+    const parsed = JSON.parse(call[1].body);
+    expect(parsed.name).toBe("Updated");
+  });
+
+  it("delete sends DELETE to correct endpoint", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ deleted: true }),
+    }));
+    await api.workloads.delete("w1");
+    const call = (fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(call[0]).toBe("/api/workloads/w1");
+    expect(call[1].method).toBe("DELETE");
+  });
+
+  it("importFile sends POST with file as form data and project_id as query param", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ imported_count: 1, failed_count: 0, errors: [], workloads: [] }),
+    }));
+    const fakeFile = new File(["name\nweb01"], "workloads.csv", { type: "text/csv" });
+    await api.workloads.importFile(fakeFile, "proj-1");
+    const call = (fetch as ReturnType<typeof vi.fn>).mock.calls[0];
+    expect(call[0]).toContain("/api/workloads/import");
+    expect(call[0]).toContain("project_id=proj-1");
+    expect(call[1].method).toBe("POST");
+    expect(call[1].body).toBeInstanceOf(FormData);
+  });
+
+  it("importFile throws on non-ok response", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({
+      ok: false,
+      text: () => Promise.resolve("Import failed"),
+    }));
+    const fakeFile = new File(["name\nweb01"], "workloads.csv", { type: "text/csv" });
+    await expect(api.workloads.importFile(fakeFile, "proj-1")).rejects.toThrow("Import failed");
+  });
+});

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -237,8 +237,7 @@ export const api = {
     importFile: async (file: File, projectId: string): Promise<WorkloadImportResult> => {
       const form = new FormData();
       form.append("file", file);
-      form.append("project_id", projectId);
-      const res = await fetch(`/api/workloads/import`, { method: "POST", body: form });
+      const res = await fetch(`${API_BASE}/api/workloads/import?project_id=${encodeURIComponent(projectId)}`, { method: "POST", body: form });
       if (!res.ok) {
         const detail = await res.text();
         throw new Error(detail || "Import failed");

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -214,6 +214,38 @@ export const api = {
         `/api/discovery/scan/${scanId}/brownfield-context`,
       ),
   },
+
+  workloads: {
+    list: (projectId?: string) =>
+      fetchApi<WorkloadListResponse>(
+        `/api/workloads${projectId ? `?project_id=${encodeURIComponent(projectId)}` : ""}`,
+      ),
+    create: (body: WorkloadCreateRequest) =>
+      fetchApi<WorkloadRecord>("/api/workloads", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(body),
+      }),
+    update: (id: string, body: Partial<WorkloadCreateRequest>) =>
+      fetchApi<WorkloadRecord>(`/api/workloads/${id}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(body),
+      }),
+    delete: (id: string) =>
+      fetchApi<void>(`/api/workloads/${id}`, { method: "DELETE" }),
+    importFile: async (file: File, projectId: string): Promise<WorkloadImportResult> => {
+      const form = new FormData();
+      form.append("file", file);
+      form.append("project_id", projectId);
+      const res = await fetch(`/api/workloads/import`, { method: "POST", body: form });
+      if (!res.ok) {
+        const detail = await res.text();
+        throw new Error(detail || "Import failed");
+      }
+      return res.json() as Promise<WorkloadImportResult>;
+    },
+  },
 };
 
 export interface Category {
@@ -386,4 +418,53 @@ export interface BrownfieldContextResponse {
   scan_id: string;
   discovered_answers: Record<string, DiscoveredAnswer>;
   gap_summary: Record<string, number>;
+}
+
+export interface WorkloadRecord {
+  id: string;
+  project_id: string;
+  name: string;
+  type: string;
+  source_platform: string;
+  cpu_cores: number | null;
+  memory_gb: number | null;
+  storage_gb: number | null;
+  os_type: string | null;
+  os_version: string | null;
+  criticality: string;
+  compliance_requirements: string[];
+  dependencies: string[];
+  migration_strategy: string;
+  notes: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface WorkloadCreateRequest {
+  project_id: string;
+  name: string;
+  type: string;
+  source_platform: string;
+  cpu_cores?: number | null;
+  memory_gb?: number | null;
+  storage_gb?: number | null;
+  os_type?: string | null;
+  os_version?: string | null;
+  criticality?: string;
+  compliance_requirements?: string[];
+  dependencies?: string[];
+  migration_strategy?: string;
+  notes?: string | null;
+}
+
+export interface WorkloadListResponse {
+  workloads: WorkloadRecord[];
+  total: number;
+}
+
+export interface WorkloadImportResult {
+  imported_count: number;
+  failed_count: number;
+  errors: string[];
+  workloads: WorkloadRecord[];
 }

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -216,9 +216,9 @@ export const api = {
   },
 
   workloads: {
-    list: (projectId?: string) =>
+    list: (projectId: string) =>
       fetchApi<WorkloadListResponse>(
-        `/api/workloads${projectId ? `?project_id=${encodeURIComponent(projectId)}` : ""}`,
+        `/api/workloads?project_id=${encodeURIComponent(projectId)}`,
       ),
     create: (body: WorkloadCreateRequest) =>
       fetchApi<WorkloadRecord>("/api/workloads", {
@@ -239,7 +239,13 @@ export const api = {
       form.append("file", file);
       const res = await fetch(`${API_BASE}/api/workloads/import?project_id=${encodeURIComponent(projectId)}`, { method: "POST", body: form });
       if (!res.ok) {
-        const detail = await res.text();
+        let detail: string;
+        try {
+          const json = await res.json() as { detail?: string };
+          detail = json.detail || JSON.stringify(json);
+        } catch {
+          detail = await res.text();
+        }
         throw new Error(detail || "Import failed");
       }
       return res.json() as Promise<WorkloadImportResult>;

--- a/frontend/src/test/setup.ts
+++ b/frontend/src/test/setup.ts
@@ -1,4 +1,5 @@
 import "@testing-library/jest-dom/vitest";
+import { configure } from "@testing-library/react";
 
 // Polyfill ResizeObserver for jsdom (used by Fluent UI MessageBar)
 global.ResizeObserver = class ResizeObserver {
@@ -6,3 +7,7 @@ global.ResizeObserver = class ResizeObserver {
   unobserve() {}
   disconnect() {}
 };
+
+// Increase async utility timeout to handle coverage instrumentation overhead
+// (Fluent UI Dialog portals can be slow to mount under V8 coverage)
+configure({ asyncUtilTimeout: 5000 });

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -9,6 +9,8 @@ export default defineConfig({
     environment: "jsdom",
     setupFiles: ["./src/test/setup.ts"],
     include: ["src/**/*.test.{ts,tsx}"],
+    // Coverage instrumentation adds overhead; increase timeout for dialog-heavy tests
+    testTimeout: 15000,
     coverage: {
       provider: "v8",
       reporter: ["text", "text-summary", "lcov"],


### PR DESCRIPTION
Closes #44

## Summary

Adds workload inventory import to the OnRamp Azure landing zone tool, enabling teams to bulk-import existing workloads via CSV/JSON and manage them through a full-CRUD inventory UI.

## Changes

### Backend
- **`backend/app/models/workload.py`** — SQLAlchemy 2.0 `Workload` model with 15 fields: name, type, source_platform, cpu_cores, memory_gb, storage_gb, os_type, os_version, criticality, compliance_requirements (JSON), dependencies (JSON), migration_strategy, notes
- **`backend/app/schemas/workload.py`** — Pydantic v2 schemas: `WorkloadCreate`, `WorkloadUpdate`, `WorkloadResponse`, `WorkloadImportResult`
- **`backend/app/services/workload_importer.py`** — CSV/JSON importer with column alias mapping (handles variant column names), format auto-detection, and per-row error collection
- **`backend/app/api/routes/workloads.py`** — 5 endpoints: `POST /api/workloads/import`, `GET /api/workloads`, `POST /api/workloads`, `PATCH /api/workloads/{id}`, `DELETE /api/workloads/{id}`
- **`backend/app/db/migrations/versions/005_add_workloads.py`** — Alembic migration (down_revision=004)

### Frontend
- **`frontend/src/pages/WorkloadsPage.tsx`** — Two-tab page: Import (drag-drop zone, import preview table with success/error feedback) and Inventory (table with edit/delete actions, create dialog)
- **`frontend/src/services/api.ts`** — Added `workloads` namespace with list/create/update/delete/importFile methods; added 4 TypeScript interfaces
- **`frontend/src/App.tsx`** — Added `/workloads` and `/projects/:projectId/workloads` routes

## Tests
- 28 backend importer tests (`test_workload_importer.py`)
- 17 backend route tests (`test_routes_workloads.py`)
- 19 frontend tests (`WorkloadsPage.test.tsx`) covering import flow, inventory CRUD, edit dialog, delete dialog, drag-drop

## Coverage
- Backend: 76.4% (above 75% threshold)
- Frontend functions: 60.4% (above 60% threshold)