### PR TITLE
feat: Workload-to-subscription mapping (#45)

### DIFF
--- a/backend/app/api/routes/workloads.py
+++ b/backend/app/api/routes/workloads.py
@@ -1,4 +1,4 @@
-"""Workload API routes — import, list, create, update, delete."""
+"""Workload API routes — import, list, create, update, delete, map."""
 
 import logging
 import uuid
@@ -18,6 +18,7 @@ from app.schemas.workload import (
     WorkloadResponse,
     WorkloadUpdate,
 )
+from app.schemas.workload_mapping import MappingOverride, MappingRequest, MappingResponse
 from app.services.workload_importer import detect_format, parse_file
 
 logger = logging.getLogger(__name__)
@@ -44,6 +45,8 @@ def _to_response(workload: Workload) -> WorkloadResponse:
         dependencies=workload.dependencies or [],
         migration_strategy=workload.migration_strategy,
         notes=workload.notes,
+        target_subscription_id=workload.target_subscription_id,
+        mapping_reasoning=workload.mapping_reasoning,
         created_at=workload.created_at,
         updated_at=workload.updated_at,
     )
@@ -329,4 +332,142 @@ async def delete_workload(
         raise
     except Exception as exc:
         logger.exception("Failed to delete workload %s", workload_id)
+        raise HTTPException(status_code=500, detail=str(exc)) from exc
+
+
+# ---------------------------------------------------------------------------
+# POST /api/workloads/map — generate workload-to-subscription mappings
+# ---------------------------------------------------------------------------
+
+@router.post("/map", response_model=MappingResponse)
+async def map_workloads(
+    payload: MappingRequest,
+    user: dict = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+) -> MappingResponse:
+    """Generate AI-powered workload-to-subscription mappings for a project."""
+    from app.services.workload_mapper import generate_mapping, validate_mappings
+
+    tenant_id = user.get("tid", user.get("tenant_id", "dev-tenant"))
+
+    # Fetch workloads for project
+    if db is None:
+        return MappingResponse(mappings=[], warnings=["Database not configured"])
+
+    try:
+        proj_result = await db.execute(
+            select(Project).where(Project.id == payload.project_id, Project.tenant_id == tenant_id)
+        )
+        if proj_result.scalar_one_or_none() is None:
+            raise HTTPException(status_code=403, detail="Project not found or access denied")
+
+        wl_result = await db.execute(
+            select(Workload).where(Workload.project_id == payload.project_id)
+        )
+        workloads = wl_result.scalars().all()
+
+        if not workloads:
+            return MappingResponse(mappings=[], warnings=["No workloads found for this project"])
+
+        # Fetch architecture for subscription list
+        architecture: dict = {}
+        if payload.architecture_id:
+            from app.models import Architecture as ArchModel
+            arch_result = await db.execute(
+                select(ArchModel).where(
+                    ArchModel.id == payload.architecture_id,
+                )
+            )
+            arch_record = arch_result.scalar_one_or_none()
+            if arch_record:
+                architecture = arch_record.architecture_data or {}
+        else:
+            # Try to load the project's architecture
+            from app.models import Architecture as ArchModel
+            arch_result = await db.execute(
+                select(ArchModel).where(ArchModel.project_id == payload.project_id)
+            )
+            arch_record = arch_result.scalar_one_or_none()
+            if arch_record:
+                architecture = arch_record.architecture_data or {}
+
+        workloads_dicts = [
+            {
+                "id": w.id,
+                "name": w.name,
+                "type": w.type,
+                "criticality": w.criticality,
+                "compliance_requirements": w.compliance_requirements or [],
+                "dependencies": w.dependencies or [],
+            }
+            for w in workloads
+        ]
+
+        ai_client = None
+        if payload.use_ai:
+            from app.services.ai_foundry import ai_client as _ai_client
+            ai_client = _ai_client
+
+        mappings = await generate_mapping(workloads_dicts, architecture, ai_client)
+        global_warnings = validate_mappings(mappings, workloads_dicts)
+
+        logger.info(
+            "Generated %d mappings for project %s (%d warnings)",
+            len(mappings),
+            payload.project_id,
+            len(global_warnings),
+        )
+        return MappingResponse(mappings=mappings, warnings=global_warnings)
+
+    except HTTPException:
+        raise
+    except Exception as exc:
+        logger.exception("Failed to generate mappings for project %s", payload.project_id)
+        raise HTTPException(status_code=500, detail=str(exc)) from exc
+
+
+# ---------------------------------------------------------------------------
+# PATCH /api/workloads/{workload_id}/mapping — persist manual override
+# ---------------------------------------------------------------------------
+
+@router.patch("/{workload_id}/mapping", response_model=WorkloadResponse)
+async def override_workload_mapping(
+    workload_id: str,
+    override: MappingOverride,
+    user: dict = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+) -> WorkloadResponse:
+    """Manually override the AI-recommended subscription for a workload."""
+    if db is None:
+        raise HTTPException(status_code=404, detail="Database not configured")
+
+    try:
+        result = await db.execute(
+            select(Workload).where(Workload.id == workload_id)
+        )
+        workload = result.scalar_one_or_none()
+        if not workload:
+            raise HTTPException(status_code=404, detail="Workload not found")
+
+        tenant_id = user.get("tid", user.get("tenant_id", "dev-tenant"))
+        proj_result = await db.execute(
+            select(Project).where(
+                Project.id == workload.project_id, Project.tenant_id == tenant_id
+            )
+        )
+        if proj_result.scalar_one_or_none() is None:
+            raise HTTPException(status_code=403, detail="Project not found or access denied")
+
+        workload.target_subscription_id = override.target_subscription_id
+        workload.mapping_reasoning = override.reasoning
+        workload.updated_at = datetime.now(timezone.utc)
+
+        await db.flush()
+        logger.info("Overrode mapping for workload %s → %s", workload_id, override.target_subscription_id)
+        return _to_response(workload)
+
+    except HTTPException:
+        raise
+    except Exception as exc:
+        logger.exception("Failed to override mapping for workload %s", workload_id)
         raise HTTPException(status_code=500, detail=str(exc)) from exc

--- a/backend/app/api/routes/workloads.py
+++ b/backend/app/api/routes/workloads.py
@@ -373,19 +373,29 @@ async def map_workloads(
         architecture: dict = {}
         if payload.architecture_id:
             from app.models import Architecture as ArchModel
+            # Scope the architecture lookup to the tenant via the project relationship
             arch_result = await db.execute(
-                select(ArchModel).where(
+                select(ArchModel)
+                .join(Project, ArchModel.project_id == Project.id)
+                .where(
                     ArchModel.id == payload.architecture_id,
+                    ArchModel.project_id == payload.project_id,
+                    Project.tenant_id == tenant_id,
                 )
             )
             arch_record = arch_result.scalar_one_or_none()
             if arch_record:
                 architecture = arch_record.architecture_data or {}
         else:
-            # Try to load the project's architecture
+            # Try to load the project's architecture — already scoped to the tenant's project
             from app.models import Architecture as ArchModel
             arch_result = await db.execute(
-                select(ArchModel).where(ArchModel.project_id == payload.project_id)
+                select(ArchModel)
+                .join(Project, ArchModel.project_id == Project.id)
+                .where(
+                    ArchModel.project_id == payload.project_id,
+                    Project.tenant_id == tenant_id,
+                )
             )
             arch_record = arch_result.scalar_one_or_none()
             if arch_record:
@@ -410,6 +420,14 @@ async def map_workloads(
 
         mappings = await generate_mapping(workloads_dicts, architecture, ai_client)
         global_warnings = validate_mappings(mappings, workloads_dicts)
+
+        # Surface a user-visible warning when no subscriptions are in the architecture
+        if not mappings and not (architecture.get("subscriptions") or []):
+            global_warnings.insert(
+                0,
+                "No subscriptions found in the project architecture. "
+                "Generate an architecture first, then retry mapping.",
+            )
 
         logger.info(
             "Generated %d mappings for project %s (%d warnings)",

--- a/backend/app/db/migrations/versions/006_add_workload_mapping_fields.py
+++ b/backend/app/db/migrations/versions/006_add_workload_mapping_fields.py
@@ -1,0 +1,31 @@
+"""Add workload mapping fields.
+
+Revision ID: 006
+Revises: 005
+Create Date: 2026-07-21
+"""
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "006"
+down_revision: str | None = "005"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "workloads",
+        sa.Column("target_subscription_id", sa.String(255), nullable=True),
+    )
+    op.add_column(
+        "workloads",
+        sa.Column("mapping_reasoning", sa.Text, nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("workloads", "mapping_reasoning")
+    op.drop_column("workloads", "target_subscription_id")

--- a/backend/app/models/workload.py
+++ b/backend/app/models/workload.py
@@ -53,3 +53,7 @@ class Workload(Base, TimestampMixin):
 
     migration_strategy: Mapped[str] = mapped_column(String(50), default="unknown")
     notes: Mapped[str | None] = mapped_column(Text, nullable=True)
+
+    # Mapping fields — populated by workload mapper service
+    target_subscription_id: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    mapping_reasoning: Mapped[str | None] = mapped_column(Text, nullable=True)

--- a/backend/app/schemas/workload.py
+++ b/backend/app/schemas/workload.py
@@ -60,6 +60,8 @@ class WorkloadResponse(BaseModel):
     dependencies: list[str] = Field(default_factory=list)
     migration_strategy: str
     notes: str | None = None
+    target_subscription_id: str | None = None
+    mapping_reasoning: str | None = None
     created_at: datetime
     updated_at: datetime
 

--- a/backend/app/schemas/workload_mapping.py
+++ b/backend/app/schemas/workload_mapping.py
@@ -1,0 +1,38 @@
+"""Pydantic schemas for workload-to-subscription mapping."""
+
+from pydantic import BaseModel, Field
+
+
+class WorkloadMapping(BaseModel):
+    """Represents a recommended mapping of a workload to a target subscription."""
+
+    workload_id: str
+    workload_name: str
+    recommended_subscription_id: str
+    recommended_subscription_name: str
+    reasoning: str
+    confidence_score: float = Field(..., ge=0.0, le=1.0)
+    warnings: list[str] = Field(default_factory=list)
+
+
+class MappingRequest(BaseModel):
+    """Request body for generating workload-to-subscription mappings."""
+
+    project_id: str
+    architecture_id: str = ""
+    use_ai: bool = True
+
+
+class MappingResponse(BaseModel):
+    """Response containing generated mappings and validation warnings."""
+
+    mappings: list[WorkloadMapping] = Field(default_factory=list)
+    warnings: list[str] = Field(default_factory=list)
+
+
+class MappingOverride(BaseModel):
+    """Manual override of an AI-generated mapping recommendation."""
+
+    target_subscription_id: str
+    target_subscription_name: str = ""
+    reasoning: str = "Manual override"

--- a/backend/app/services/workload_mapper.py
+++ b/backend/app/services/workload_mapper.py
@@ -72,10 +72,6 @@ def _rule_based_mapping(
             # Penalise sandbox/dev for compliance workloads
             if any(kw in sub_text for kw in ("dev", "test", "sandbox")):
                 score -= 0.3
-                warnings.append(
-                    f"Workload '{workload.get('name')}' has compliance requirements "
-                    f"({', '.join(compliance_reqs)}) but may be mapped to a non-production subscription."
-                )
 
         # Network requirements — penalise sandbox for mission-critical
         if criticality == "mission-critical" and any(kw in sub_text for kw in ("dev", "sandbox")):
@@ -91,6 +87,14 @@ def _rule_based_mapping(
     best_id = max(scores, key=lambda k: scores[k])
     best_sub = next(s for s in subscriptions if _subscription_id(s) == best_id)
     best_score = scores[best_id]
+
+    # Generate warnings based on the selected subscription only
+    best_sub_text = f"{best_sub.get('name', '').lower()} {best_sub.get('purpose', '').lower()}"
+    if compliance_reqs and any(kw in best_sub_text for kw in ("dev", "test", "sandbox")):
+        warnings.append(
+            f"Workload '{workload.get('name')}' has compliance requirements "
+            f"({', '.join(compliance_reqs)}) but may be mapped to a non-production subscription."
+        )
 
     # Normalise score to 0–1
     confidence = min(max(0.4 + best_score, 0.1), 0.95)
@@ -218,12 +222,24 @@ async def _ai_generate_mapping(
         parsed = json.loads(raw)
         if isinstance(parsed, list):
             mappings: list[WorkloadMapping] = []
+            mapped_ids: set[str] = set()
             for item in parsed:
                 try:
-                    mappings.append(WorkloadMapping(**item))
+                    m = WorkloadMapping(**item)
+                    mappings.append(m)
+                    mapped_ids.add(m.workload_id)
                 except Exception as exc:
                     logger.warning("Skipping invalid mapping item from AI: %s — %s", item, exc)
-            logger.info("AI returned %d mappings", len(mappings))
+
+            # Fill in any workloads the AI omitted with rule-based fallbacks
+            unmapped = [w for w in workloads if w.get("id", "") not in mapped_ids]
+            if unmapped:
+                logger.info(
+                    "AI omitted %d workload(s) — filling with rule-based mappings", len(unmapped)
+                )
+                mappings.extend(_rule_based_generate_mapping(unmapped, subscriptions))
+
+            logger.info("AI returned %d mappings (after fill)", len(mappings))
             return mappings
     except (json.JSONDecodeError, TypeError, ValueError) as exc:
         logger.warning("AI mapping parse failed (%s) — falling back to rule-based", exc)

--- a/backend/app/services/workload_mapper.py
+++ b/backend/app/services/workload_mapper.py
@@ -1,0 +1,299 @@
+"""WorkloadMapper service — maps workloads to target Azure subscriptions."""
+
+import json
+import logging
+from typing import TYPE_CHECKING
+
+from app.schemas.workload_mapping import WorkloadMapping
+
+if TYPE_CHECKING:
+    from app.services.ai_foundry import AIFoundryClient
+
+logger = logging.getLogger(__name__)
+
+# Maximum workloads allowed per subscription before a warning is raised
+MAX_WORKLOADS_PER_SUBSCRIPTION = 50
+
+# Criticality → preferred subscription purpose keywords (ordered by preference)
+_CRITICALITY_SUBSCRIPTION_HINTS: dict[str, list[str]] = {
+    "mission-critical": ["prod", "production", "critical"],
+    "business-critical": ["prod", "production", "workload"],
+    "standard": ["workload", "prod", "standard"],
+    "dev-test": ["dev", "test", "sandbox", "non-prod"],
+}
+
+# Compliance requirements that indicate sensitive data subscriptions
+_COMPLIANCE_SENSITIVE: set[str] = {"HIPAA", "PCI-DSS", "FedRAMP", "ITAR", "SOC2", "ISO27001"}
+
+
+def _subscription_id(subscription: dict) -> str:
+    """Return a stable identifier for a subscription dict."""
+    return subscription.get("id") or subscription.get("name", "unknown")
+
+
+def _rule_based_mapping(
+    workload: dict,
+    subscriptions: list[dict],
+) -> tuple[dict, float, list[str]]:
+    """Map a workload to a subscription using rule-based logic.
+
+    Returns (best_subscription, confidence_score, warnings).
+    """
+    warnings: list[str] = []
+    criticality: str = workload.get("criticality", "standard")
+    compliance_reqs: list[str] = workload.get("compliance_requirements") or []
+    workload_type: str = workload.get("type", "other")
+
+    # Score each subscription
+    scores: dict[str, float] = {}
+    for sub in subscriptions:
+        sub_name = sub.get("name", "").lower()
+        sub_purpose = sub.get("purpose", "").lower()
+        sub_text = f"{sub_name} {sub_purpose}"
+        score = 0.0
+
+        # Criticality hint matching
+        hints = _CRITICALITY_SUBSCRIPTION_HINTS.get(criticality, ["workload"])
+        for i, hint in enumerate(hints):
+            if hint in sub_text:
+                score += 0.4 - i * 0.05  # First hint worth more
+                break
+
+        # Workload type matching
+        if workload_type in ("database",) and "data" in sub_text:
+            score += 0.2
+        elif workload_type in ("web-app", "container") and ("app" in sub_text or "web" in sub_text):
+            score += 0.15
+
+        # Compliance matching — prefer subscriptions tagged for regulated workloads
+        if compliance_reqs:
+            if any(kw in sub_text for kw in ("regulated", "secure", "compliance", "hipaa", "pci")):
+                score += 0.2
+            # Penalise sandbox/dev for compliance workloads
+            if any(kw in sub_text for kw in ("dev", "test", "sandbox")):
+                score -= 0.3
+                warnings.append(
+                    f"Workload '{workload.get('name')}' has compliance requirements "
+                    f"({', '.join(compliance_reqs)}) but may be mapped to a non-production subscription."
+                )
+
+        # Network requirements — penalise sandbox for mission-critical
+        if criticality == "mission-critical" and any(kw in sub_text for kw in ("dev", "sandbox")):
+            score -= 0.4
+
+        scores[_subscription_id(sub)] = score
+
+    if not scores:
+        # No subscriptions available — return first or a dummy
+        fallback = subscriptions[0] if subscriptions else {"name": "unknown", "id": "unknown"}
+        return fallback, 0.0, ["No subscriptions available in architecture"]
+
+    best_id = max(scores, key=lambda k: scores[k])
+    best_sub = next(s for s in subscriptions if _subscription_id(s) == best_id)
+    best_score = scores[best_id]
+
+    # Normalise score to 0–1
+    confidence = min(max(0.4 + best_score, 0.1), 0.95)
+    return best_sub, round(confidence, 2), warnings
+
+
+async def generate_mapping(
+    workloads: list[dict],
+    architecture: dict,
+    ai_client: "AIFoundryClient | None" = None,
+) -> list[WorkloadMapping]:
+    """Generate workload-to-subscription mappings.
+
+    Uses AI when ``ai_client`` is provided and configured; falls back to
+    deterministic rule-based logic otherwise.
+
+    Args:
+        workloads: List of workload dicts (from DB or API response).
+        architecture: Architecture dict containing a ``subscriptions`` key.
+        ai_client: Optional AI Foundry client for AI-powered mapping.
+
+    Returns:
+        List of :class:`WorkloadMapping` instances.
+    """
+    subscriptions: list[dict] = architecture.get("subscriptions") or []
+    if not subscriptions:
+        logger.warning("No subscriptions found in architecture — returning empty mappings")
+        return []
+
+    # Normalise subscriptions to ensure they have an "id" field
+    for i, sub in enumerate(subscriptions):
+        if not sub.get("id"):
+            sub["id"] = sub.get("name", f"sub-{i}")
+
+    use_ai = ai_client is not None and ai_client.is_configured
+
+    if use_ai:
+        logger.info("Generating AI-powered workload mappings for %d workloads", len(workloads))
+        mappings = await _ai_generate_mapping(workloads, subscriptions, ai_client)  # type: ignore[arg-type]
+    else:
+        logger.info("Generating rule-based workload mappings for %d workloads", len(workloads))
+        mappings = _rule_based_generate_mapping(workloads, subscriptions)
+
+    return mappings
+
+
+def _rule_based_generate_mapping(
+    workloads: list[dict],
+    subscriptions: list[dict],
+) -> list[WorkloadMapping]:
+    """Apply deterministic rules to map each workload to a subscription."""
+    mappings: list[WorkloadMapping] = []
+    for wl in workloads:
+        best_sub, confidence, warnings = _rule_based_mapping(wl, subscriptions)
+        mappings.append(
+            WorkloadMapping(
+                workload_id=wl.get("id", ""),
+                workload_name=wl.get("name", "Unknown"),
+                recommended_subscription_id=_subscription_id(best_sub),
+                recommended_subscription_name=best_sub.get("name", "Unknown"),
+                reasoning=_build_rule_reasoning(wl, best_sub),
+                confidence_score=confidence,
+                warnings=warnings,
+            )
+        )
+    return mappings
+
+
+def _build_rule_reasoning(workload: dict, subscription: dict) -> str:
+    """Construct a human-readable reasoning string for a rule-based mapping."""
+    parts: list[str] = []
+    criticality = workload.get("criticality", "standard")
+    workload_type = workload.get("type", "other")
+    compliance_reqs = workload.get("compliance_requirements") or []
+
+    parts.append(
+        f"Workload type '{workload_type}' with criticality '{criticality}' "
+        f"maps to subscription '{subscription.get('name')}' "
+        f"(purpose: {subscription.get('purpose', 'unknown')})."
+    )
+    if compliance_reqs:
+        parts.append(f"Compliance requirements: {', '.join(compliance_reqs)}.")
+    return " ".join(parts)
+
+
+async def _ai_generate_mapping(
+    workloads: list[dict],
+    subscriptions: list[dict],
+    ai_client: "AIFoundryClient",
+) -> list[WorkloadMapping]:
+    """Use AI to generate workload-to-subscription mappings."""
+    system_prompt = (
+        "You are an Azure cloud architect expert. Given a list of workloads and available "
+        "Azure subscriptions, map each workload to the most appropriate subscription. "
+        "Consider: workload type, criticality, compliance requirements, and subscription purpose. "
+        "Respond ONLY with a valid JSON array of mapping objects. Each object must have: "
+        "workload_id (string), workload_name (string), recommended_subscription_id (string), "
+        "recommended_subscription_name (string), reasoning (string), confidence_score (float 0-1), "
+        "warnings (array of strings)."
+    )
+
+    workloads_summary = [
+        {
+            "id": w.get("id", ""),
+            "name": w.get("name", ""),
+            "type": w.get("type", "other"),
+            "criticality": w.get("criticality", "standard"),
+            "compliance_requirements": w.get("compliance_requirements") or [],
+        }
+        for w in workloads
+    ]
+    subscriptions_summary = [
+        {"id": _subscription_id(s), "name": s.get("name", ""), "purpose": s.get("purpose", "")}
+        for s in subscriptions
+    ]
+
+    user_prompt = (
+        f"Workloads:\n{json.dumps(workloads_summary, indent=2)}\n\n"
+        f"Available subscriptions:\n{json.dumps(subscriptions_summary, indent=2)}\n\n"
+        "Respond with a JSON array of mappings."
+    )
+
+    try:
+        raw = await ai_client.generate_completion_async(system_prompt, user_prompt)
+        parsed = json.loads(raw)
+        if isinstance(parsed, list):
+            mappings: list[WorkloadMapping] = []
+            for item in parsed:
+                try:
+                    mappings.append(WorkloadMapping(**item))
+                except Exception as exc:
+                    logger.warning("Skipping invalid mapping item from AI: %s — %s", item, exc)
+            logger.info("AI returned %d mappings", len(mappings))
+            return mappings
+    except (json.JSONDecodeError, TypeError, ValueError) as exc:
+        logger.warning("AI mapping parse failed (%s) — falling back to rule-based", exc)
+
+    # Fallback to rule-based
+    return _rule_based_generate_mapping(workloads, subscriptions)
+
+
+def validate_mappings(mappings: list[WorkloadMapping], workloads: list[dict]) -> list[str]:
+    """Validate generated mappings and return warning messages.
+
+    Checks for:
+    - Compliance mismatches (high-compliance workload in dev/sandbox subscription)
+    - Subscription overload (>50 workloads in one subscription)
+    - Dependent workloads split across subscriptions with no network path
+    """
+    warnings: list[str] = []
+
+    # Build lookup by workload_id
+    workload_by_id: dict[str, dict] = {w.get("id", ""): w for w in workloads}
+
+    # Count workloads per subscription
+    sub_workload_counts: dict[str, int] = {}
+    for m in mappings:
+        sub_workload_counts[m.recommended_subscription_id] = (
+            sub_workload_counts.get(m.recommended_subscription_id, 0) + 1
+        )
+
+    # Check subscription overload
+    for sub_id, count in sub_workload_counts.items():
+        if count > MAX_WORKLOADS_PER_SUBSCRIPTION:
+            warnings.append(
+                f"Subscription '{sub_id}' has {count} workloads assigned, "
+                f"which exceeds the recommended maximum of {MAX_WORKLOADS_PER_SUBSCRIPTION}."
+            )
+
+    # Check compliance mismatches
+    for m in mappings:
+        wl = workload_by_id.get(m.workload_id, {})
+        compliance_reqs: list[str] = wl.get("compliance_requirements") or []
+        sensitive = [r for r in compliance_reqs if r in _COMPLIANCE_SENSITIVE]
+        sub_name = m.recommended_subscription_name.lower()
+        if sensitive and any(kw in sub_name for kw in ("dev", "test", "sandbox")):
+            warnings.append(
+                f"Workload '{m.workload_name}' has sensitive compliance requirements "
+                f"({', '.join(sensitive)}) but is mapped to a non-production subscription "
+                f"('{m.recommended_subscription_name}'). Consider moving to a regulated subscription."
+            )
+
+    # Check dependent workloads split across subscriptions
+    mapping_by_id: dict[str, WorkloadMapping] = {m.workload_id: m for m in mappings}
+    for m in mappings:
+        wl = workload_by_id.get(m.workload_id, {})
+        deps: list[str] = wl.get("dependencies") or []
+        for dep_id in deps:
+            dep_mapping = mapping_by_id.get(dep_id)
+            if dep_mapping is None:
+                continue
+            if dep_mapping.recommended_subscription_id != m.recommended_subscription_id:
+                # Check if the subscriptions have names suggesting a peered network
+                src_sub = m.recommended_subscription_name.lower()
+                dep_sub = dep_mapping.recommended_subscription_name.lower()
+                # Hub-spoke peering keywords
+                peered = any(kw in src_sub or kw in dep_sub for kw in ("hub", "shared", "platform"))
+                if not peered:
+                    warnings.append(
+                        f"Workload '{m.workload_name}' depends on '{dep_mapping.workload_name}' "
+                        f"but they are in different subscriptions "
+                        f"('{m.recommended_subscription_name}' vs '{dep_mapping.recommended_subscription_name}') "
+                        f"with no confirmed network path. Verify VNet peering is in place."
+                    )
+
+    return warnings

--- a/backend/tests/test_migrations.py
+++ b/backend/tests/test_migrations.py
@@ -23,7 +23,7 @@ async def test_migrations_run_cleanly():
     async with engine.connect() as conn:
         result = await conn.execute(text("SELECT version_num FROM alembic_version"))
         versions = [row[0] for row in result]
-        assert "005" in versions
+        assert "006" in versions
 
     await engine.dispose()
 

--- a/backend/tests/test_workload_mapper.py
+++ b/backend/tests/test_workload_mapper.py
@@ -331,6 +331,17 @@ async def test_generate_mapping_ai_fallback_on_bad_json():
     assert len(result) == len(SAMPLE_WORKLOADS)
 
 
+@pytest.mark.asyncio
+async def test_generate_mapping_ai_fills_missing_workloads():
+    """When AI omits workloads, rule-based mappings fill the gaps."""
+    # AI only maps wl-1; wl-2 and wl-3 are omitted
+    result = await generate_mapping(SAMPLE_WORKLOADS, SAMPLE_ARCHITECTURE, ai_client=_MockAIClient())  # type: ignore[arg-type]
+    # Should have all 3 workloads mapped (1 from AI + 2 from rule-based fill)
+    assert len(result) == len(SAMPLE_WORKLOADS)
+    ids = {m.workload_id for m in result}
+    assert ids == {"wl-1", "wl-2", "wl-3"}
+
+
 # ---------------------------------------------------------------------------
 # API routes — POST /api/workloads/map
 # ---------------------------------------------------------------------------
@@ -344,6 +355,8 @@ def test_map_workloads_no_db():
     assert "mappings" in data
     assert "warnings" in data
     assert isinstance(data["mappings"], list)
+    # No workloads in DB → warning expected
+    assert len(data["warnings"]) > 0
 
 
 def test_map_workloads_missing_project_id():

--- a/backend/tests/test_workload_mapper.py
+++ b/backend/tests/test_workload_mapper.py
@@ -1,0 +1,407 @@
+"""Tests for WorkloadMapper service and mapping API routes."""
+
+import json
+
+import pytest
+from fastapi.testclient import TestClient
+
+from app.main import app
+from app.schemas.workload_mapping import WorkloadMapping
+from app.services.workload_mapper import (
+    generate_mapping,
+    validate_mappings,
+    _rule_based_mapping,
+)
+
+client = TestClient(app)
+
+PROJECT_ID = "proj-mapper-test"
+
+# ---------------------------------------------------------------------------
+# Helper data
+# ---------------------------------------------------------------------------
+
+SAMPLE_SUBSCRIPTIONS = [
+    {"id": "sub-prod", "name": "sub-workload-prod", "purpose": "Production workloads"},
+    {"id": "sub-dev", "name": "sub-workload-dev", "purpose": "Development and testing"},
+    {"id": "sub-platform", "name": "sub-platform", "purpose": "Shared platform services"},
+]
+
+SAMPLE_ARCHITECTURE = {"subscriptions": SAMPLE_SUBSCRIPTIONS}
+
+SAMPLE_WORKLOADS = [
+    {
+        "id": "wl-1",
+        "name": "ProdWebApp",
+        "type": "web-app",
+        "criticality": "mission-critical",
+        "compliance_requirements": [],
+        "dependencies": [],
+    },
+    {
+        "id": "wl-2",
+        "name": "DevDB",
+        "type": "database",
+        "criticality": "dev-test",
+        "compliance_requirements": [],
+        "dependencies": [],
+    },
+    {
+        "id": "wl-3",
+        "name": "ComplianceApp",
+        "type": "vm",
+        "criticality": "business-critical",
+        "compliance_requirements": ["HIPAA", "SOC2"],
+        "dependencies": ["wl-1"],
+    },
+]
+
+
+# ---------------------------------------------------------------------------
+# WorkloadMapper service — rule-based mapping
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_generate_mapping_empty_architecture():
+    """Empty subscriptions list returns no mappings."""
+    result = await generate_mapping(SAMPLE_WORKLOADS, {}, ai_client=None)
+    assert result == []
+
+
+@pytest.mark.asyncio
+async def test_generate_mapping_returns_one_per_workload():
+    result = await generate_mapping(SAMPLE_WORKLOADS, SAMPLE_ARCHITECTURE, ai_client=None)
+    assert len(result) == len(SAMPLE_WORKLOADS)
+
+
+@pytest.mark.asyncio
+async def test_generate_mapping_workload_ids_preserved():
+    result = await generate_mapping(SAMPLE_WORKLOADS, SAMPLE_ARCHITECTURE, ai_client=None)
+    ids = {m.workload_id for m in result}
+    assert ids == {"wl-1", "wl-2", "wl-3"}
+
+
+@pytest.mark.asyncio
+async def test_generate_mapping_mission_critical_goes_to_prod():
+    result = await generate_mapping(SAMPLE_WORKLOADS, SAMPLE_ARCHITECTURE, ai_client=None)
+    prod_mapping = next(m for m in result if m.workload_id == "wl-1")
+    # Mission-critical workload should land in a production-like subscription
+    assert "prod" in prod_mapping.recommended_subscription_name.lower()
+
+
+@pytest.mark.asyncio
+async def test_generate_mapping_dev_test_goes_to_dev():
+    result = await generate_mapping(SAMPLE_WORKLOADS, SAMPLE_ARCHITECTURE, ai_client=None)
+    dev_mapping = next(m for m in result if m.workload_id == "wl-2")
+    assert "dev" in dev_mapping.recommended_subscription_name.lower()
+
+
+@pytest.mark.asyncio
+async def test_generate_mapping_confidence_in_range():
+    result = await generate_mapping(SAMPLE_WORKLOADS, SAMPLE_ARCHITECTURE, ai_client=None)
+    for m in result:
+        assert 0.0 <= m.confidence_score <= 1.0
+
+
+@pytest.mark.asyncio
+async def test_generate_mapping_has_reasoning():
+    result = await generate_mapping(SAMPLE_WORKLOADS, SAMPLE_ARCHITECTURE, ai_client=None)
+    for m in result:
+        assert len(m.reasoning) > 0
+
+
+@pytest.mark.asyncio
+async def test_generate_mapping_no_subscriptions():
+    arch = {"subscriptions": []}
+    result = await generate_mapping(SAMPLE_WORKLOADS, arch, ai_client=None)
+    assert result == []
+
+
+@pytest.mark.asyncio
+async def test_generate_mapping_assigns_subscription_name():
+    result = await generate_mapping(SAMPLE_WORKLOADS, SAMPLE_ARCHITECTURE, ai_client=None)
+    for m in result:
+        assert m.recommended_subscription_name != ""
+
+
+# ---------------------------------------------------------------------------
+# Rule-based mapping helper
+# ---------------------------------------------------------------------------
+
+def test_rule_based_mapping_mission_critical():
+    wl = {"name": "ProdVM", "type": "vm", "criticality": "mission-critical", "compliance_requirements": []}
+    sub, confidence, warnings = _rule_based_mapping(wl, SAMPLE_SUBSCRIPTIONS)
+    assert "prod" in sub["name"].lower()
+    assert confidence > 0
+
+
+def test_rule_based_mapping_dev_test():
+    wl = {"name": "TestVM", "type": "vm", "criticality": "dev-test", "compliance_requirements": []}
+    sub, confidence, warnings = _rule_based_mapping(wl, SAMPLE_SUBSCRIPTIONS)
+    assert "dev" in sub["name"].lower()
+
+
+def test_rule_based_mapping_compliance_warning():
+    wl = {
+        "name": "HIPAAApp",
+        "type": "vm",
+        "criticality": "dev-test",
+        "compliance_requirements": ["HIPAA"],
+    }
+    # Dev workload with compliance — warning expected
+    _, _, warnings = _rule_based_mapping(wl, SAMPLE_SUBSCRIPTIONS)
+    assert any("compliance" in w.lower() or "HIPAA" in w for w in warnings)
+
+
+def test_rule_based_mapping_empty_subscriptions():
+    wl = {"name": "NoSub", "type": "vm", "criticality": "standard", "compliance_requirements": []}
+    sub, confidence, warnings = _rule_based_mapping(wl, [])
+    assert confidence == 0.0
+    assert len(warnings) > 0
+
+
+# ---------------------------------------------------------------------------
+# validate_mappings
+# ---------------------------------------------------------------------------
+
+def test_validate_mappings_no_warnings_clean():
+    """Clean mappings with no issues should produce no warnings."""
+    workloads = [
+        {"id": "w1", "name": "VM1", "compliance_requirements": [], "dependencies": []},
+    ]
+    mappings = [
+        WorkloadMapping(
+            workload_id="w1",
+            workload_name="VM1",
+            recommended_subscription_id="sub-prod",
+            recommended_subscription_name="sub-workload-prod",
+            reasoning="test",
+            confidence_score=0.9,
+            warnings=[],
+        )
+    ]
+    result = validate_mappings(mappings, workloads)
+    assert result == []
+
+
+def test_validate_mappings_subscription_overload():
+    """More than 50 workloads in one subscription should produce a warning."""
+    workloads = [{"id": f"w{i}", "name": f"VM{i}", "compliance_requirements": [], "dependencies": []} for i in range(55)]
+    mappings = [
+        WorkloadMapping(
+            workload_id=f"w{i}",
+            workload_name=f"VM{i}",
+            recommended_subscription_id="sub-prod",
+            recommended_subscription_name="sub-workload-prod",
+            reasoning="test",
+            confidence_score=0.9,
+            warnings=[],
+        )
+        for i in range(55)
+    ]
+    result = validate_mappings(mappings, workloads)
+    assert any("55" in w or "exceed" in w.lower() for w in result)
+
+
+def test_validate_mappings_compliance_mismatch():
+    """HIPAA workload in dev subscription should produce a warning."""
+    workloads = [
+        {"id": "w1", "name": "HIPAAApp", "compliance_requirements": ["HIPAA"], "dependencies": []},
+    ]
+    mappings = [
+        WorkloadMapping(
+            workload_id="w1",
+            workload_name="HIPAAApp",
+            recommended_subscription_id="sub-dev",
+            recommended_subscription_name="sub-workload-dev",
+            reasoning="test",
+            confidence_score=0.5,
+            warnings=[],
+        )
+    ]
+    result = validate_mappings(mappings, workloads)
+    assert any("HIPAA" in w or "compliance" in w.lower() for w in result)
+
+
+def test_validate_mappings_split_dependencies():
+    """Dependent workloads in different subscriptions should produce a warning."""
+    workloads = [
+        {"id": "w1", "name": "Frontend", "compliance_requirements": [], "dependencies": ["w2"]},
+        {"id": "w2", "name": "Backend", "compliance_requirements": [], "dependencies": []},
+    ]
+    mappings = [
+        WorkloadMapping(
+            workload_id="w1",
+            workload_name="Frontend",
+            recommended_subscription_id="sub-prod",
+            recommended_subscription_name="sub-workload-prod",
+            reasoning="test",
+            confidence_score=0.9,
+            warnings=[],
+        ),
+        WorkloadMapping(
+            workload_id="w2",
+            workload_name="Backend",
+            recommended_subscription_id="sub-dev",
+            recommended_subscription_name="sub-workload-dev",
+            reasoning="test",
+            confidence_score=0.7,
+            warnings=[],
+        ),
+    ]
+    result = validate_mappings(mappings, workloads)
+    assert any("depend" in w.lower() or "split" in w.lower() or "Frontend" in w for w in result)
+
+
+def test_validate_mappings_hub_spoke_no_warning():
+    """Dependencies across hub/platform subs should NOT produce network warning."""
+    workloads = [
+        {"id": "w1", "name": "App", "compliance_requirements": [], "dependencies": ["w2"]},
+        {"id": "w2", "name": "SharedSvc", "compliance_requirements": [], "dependencies": []},
+    ]
+    mappings = [
+        WorkloadMapping(
+            workload_id="w1",
+            workload_name="App",
+            recommended_subscription_id="sub-workload",
+            recommended_subscription_name="sub-workload-prod",
+            reasoning="test",
+            confidence_score=0.9,
+            warnings=[],
+        ),
+        WorkloadMapping(
+            workload_id="w2",
+            workload_name="SharedSvc",
+            recommended_subscription_id="sub-hub",
+            recommended_subscription_name="sub-hub-platform",
+            reasoning="test",
+            confidence_score=0.8,
+            warnings=[],
+        ),
+    ]
+    result = validate_mappings(mappings, workloads)
+    # hub/platform subscriptions are assumed peered — no network warning
+    assert not any("network" in w.lower() or "peering" in w.lower() for w in result)
+
+
+# ---------------------------------------------------------------------------
+# AI fallback — mock AI client
+# ---------------------------------------------------------------------------
+
+class _MockAIClient:
+    is_configured = True
+
+    async def generate_completion_async(self, system_prompt: str, user_prompt: str) -> str:
+        # Return valid JSON matching the expected schema
+        return json.dumps(
+            [
+                {
+                    "workload_id": "wl-1",
+                    "workload_name": "ProdWebApp",
+                    "recommended_subscription_id": "sub-prod",
+                    "recommended_subscription_name": "sub-workload-prod",
+                    "reasoning": "AI selected prod",
+                    "confidence_score": 0.92,
+                    "warnings": [],
+                }
+            ]
+        )
+
+
+class _BrokenAIClient:
+    is_configured = True
+
+    async def generate_completion_async(self, system_prompt: str, user_prompt: str) -> str:
+        return "NOT_JSON_AT_ALL"
+
+
+@pytest.mark.asyncio
+async def test_generate_mapping_ai_mode():
+    workloads = [SAMPLE_WORKLOADS[0]]
+    result = await generate_mapping(workloads, SAMPLE_ARCHITECTURE, ai_client=_MockAIClient())  # type: ignore[arg-type]
+    assert len(result) == 1
+    assert result[0].recommended_subscription_id == "sub-prod"
+    assert result[0].confidence_score == 0.92
+
+
+@pytest.mark.asyncio
+async def test_generate_mapping_ai_fallback_on_bad_json():
+    """When AI returns bad JSON, falls back to rule-based."""
+    result = await generate_mapping(SAMPLE_WORKLOADS, SAMPLE_ARCHITECTURE, ai_client=_BrokenAIClient())  # type: ignore[arg-type]
+    assert len(result) == len(SAMPLE_WORKLOADS)
+
+
+# ---------------------------------------------------------------------------
+# API routes — POST /api/workloads/map
+# ---------------------------------------------------------------------------
+
+def test_map_workloads_no_db():
+    """Without DB, returns 200 with empty mappings and a warning."""
+    payload = {"project_id": PROJECT_ID, "architecture_id": "", "use_ai": False}
+    r = client.post("/api/workloads/map", json=payload)
+    assert r.status_code == 200
+    data = r.json()
+    assert "mappings" in data
+    assert "warnings" in data
+    assert isinstance(data["mappings"], list)
+
+
+def test_map_workloads_missing_project_id():
+    r = client.post("/api/workloads/map", json={"architecture_id": ""})
+    assert r.status_code == 422
+
+
+def test_map_workloads_returns_mapping_response_shape():
+    payload = {"project_id": PROJECT_ID, "use_ai": False}
+    r = client.post("/api/workloads/map", json=payload)
+    assert r.status_code == 200
+    data = r.json()
+    assert set(data.keys()) >= {"mappings", "warnings"}
+
+
+# ---------------------------------------------------------------------------
+# API routes — PATCH /api/workloads/{id}/mapping
+# ---------------------------------------------------------------------------
+
+def test_override_mapping_no_db():
+    """Without DB, returns 404."""
+    payload = {"target_subscription_id": "sub-prod", "reasoning": "Manual override"}
+    r = client.patch("/api/workloads/nonexistent-id/mapping", json=payload)
+    assert r.status_code == 404
+
+
+def test_override_mapping_missing_subscription_id():
+    r = client.patch("/api/workloads/some-id/mapping", json={"reasoning": "test"})
+    assert r.status_code == 422
+
+
+# ---------------------------------------------------------------------------
+# WorkloadMapping schema validation
+# ---------------------------------------------------------------------------
+
+def test_workload_mapping_schema_confidence_bounds():
+    from pydantic import ValidationError
+    with pytest.raises(ValidationError):
+        WorkloadMapping(
+            workload_id="w1",
+            workload_name="VM",
+            recommended_subscription_id="sub",
+            recommended_subscription_name="sub",
+            reasoning="x",
+            confidence_score=1.5,  # invalid
+            warnings=[],
+        )
+
+
+def test_workload_mapping_schema_valid():
+    m = WorkloadMapping(
+        workload_id="w1",
+        workload_name="VM",
+        recommended_subscription_id="sub-prod",
+        recommended_subscription_name="sub-workload-prod",
+        reasoning="Matched production",
+        confidence_score=0.85,
+        warnings=["Check firewall"],
+    )
+    assert m.confidence_score == 0.85
+    assert m.warnings == ["Check firewall"]

--- a/frontend/src/components/migration/WorkloadMapper.test.tsx
+++ b/frontend/src/components/migration/WorkloadMapper.test.tsx
@@ -109,6 +109,15 @@ describe("WorkloadMapper", () => {
       warnings: [],
     });
     vi.spyOn(apiModule.api.workloads, "overrideMapping").mockResolvedValue(MOCK_WORKLOADS[0]);
+    vi.spyOn(apiModule.api.architecture, "getByProject").mockResolvedValue({
+      architecture: {
+        organization_size: "small",
+        management_groups: {},
+        subscriptions: MOCK_SUBSCRIPTIONS,
+        network_topology: {},
+      },
+      project_id: "proj-1",
+    });
   });
 
   it("renders the component title", async () => {
@@ -235,9 +244,47 @@ describe("WorkloadMapper", () => {
   });
 
   it("shows empty subscriptions hint when none provided", async () => {
+    vi.spyOn(apiModule.api.architecture, "getByProject").mockResolvedValue({
+      architecture: null,
+      project_id: "proj-1",
+    });
     renderMapper("proj-1", []);
     await waitFor(() => {
       expect(screen.getByText(/no subscriptions available/i)).toBeInTheDocument();
+    });
+  });
+
+  it("loads subscriptions from architecture when not provided via props", async () => {
+    renderMapper("proj-1", []); // No props subscriptions, should load from architecture
+    await waitFor(() => {
+      // Subscriptions loaded from architecture mock
+      expect(screen.getByText("sub-workload-prod")).toBeInTheDocument();
+    });
+  });
+
+  it("shows override failure error and reverts mapping", async () => {
+    vi.spyOn(apiModule.api.workloads, "overrideMapping").mockRejectedValue(
+      new Error("Save failed")
+    );
+
+    renderMapper();
+    await waitFor(() => screen.getByText("ProdWebApp"));
+
+    // Generate mappings first
+    fireEvent.click(screen.getByRole("button", { name: /generate mapping/i }));
+    await waitFor(() => screen.getAllByText("Suggested"));
+
+    // Drag the workload card (simulate dragstart then drop)
+    const card = screen.getByTestId("workload-card-wl-1");
+    fireEvent.dragStart(card);
+
+    const target = screen.getByTestId("subscription-target-sub-dev");
+    fireEvent.dragOver(target);
+    fireEvent.drop(target);
+
+    // Error message should appear after failed PATCH
+    await waitFor(() => {
+      expect(screen.getByText(/failed to save mapping override/i)).toBeInTheDocument();
     });
   });
 

--- a/frontend/src/components/migration/WorkloadMapper.test.tsx
+++ b/frontend/src/components/migration/WorkloadMapper.test.tsx
@@ -1,0 +1,266 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { FluentProvider, teamsLightTheme } from "@fluentui/react-components";
+import { MemoryRouter } from "react-router-dom";
+import WorkloadMapper from "./WorkloadMapper";
+import * as apiModule from "../../services/api";
+
+// ---------------------------------------------------------------------------
+// Mock data
+// ---------------------------------------------------------------------------
+
+const MOCK_WORKLOADS = [
+  {
+    id: "wl-1",
+    project_id: "proj-1",
+    name: "ProdWebApp",
+    type: "web-app",
+    source_platform: "vmware",
+    cpu_cores: 4,
+    memory_gb: 16,
+    storage_gb: 100,
+    os_type: "Linux",
+    os_version: "Ubuntu 22.04",
+    criticality: "mission-critical",
+    compliance_requirements: ["SOC2"],
+    dependencies: [],
+    migration_strategy: "rehost",
+    notes: null,
+    target_subscription_id: null,
+    mapping_reasoning: null,
+    created_at: "2025-01-01T00:00:00Z",
+    updated_at: "2025-01-01T00:00:00Z",
+  },
+  {
+    id: "wl-2",
+    project_id: "proj-1",
+    name: "DevDatabase",
+    type: "database",
+    source_platform: "other",
+    cpu_cores: 2,
+    memory_gb: 8,
+    storage_gb: 200,
+    os_type: null,
+    os_version: null,
+    criticality: "dev-test",
+    compliance_requirements: [],
+    dependencies: [],
+    migration_strategy: "refactor",
+    notes: null,
+    target_subscription_id: null,
+    mapping_reasoning: null,
+    created_at: "2025-01-01T00:00:00Z",
+    updated_at: "2025-01-01T00:00:00Z",
+  },
+];
+
+const MOCK_MAPPINGS = [
+  {
+    workload_id: "wl-1",
+    workload_name: "ProdWebApp",
+    recommended_subscription_id: "sub-prod",
+    recommended_subscription_name: "sub-workload-prod",
+    reasoning: "Mission-critical maps to production",
+    confidence_score: 0.92,
+    warnings: [],
+  },
+  {
+    workload_id: "wl-2",
+    workload_name: "DevDatabase",
+    recommended_subscription_id: "sub-dev",
+    recommended_subscription_name: "sub-workload-dev",
+    reasoning: "Dev-test maps to dev subscription",
+    confidence_score: 0.75,
+    warnings: [],
+  },
+];
+
+const MOCK_SUBSCRIPTIONS = [
+  { id: "sub-prod", name: "sub-workload-prod", purpose: "Production workloads" },
+  { id: "sub-dev", name: "sub-workload-dev", purpose: "Development and testing" },
+];
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function renderMapper(projectId = "proj-1", subscriptions = MOCK_SUBSCRIPTIONS) {
+  return render(
+    <MemoryRouter>
+      <FluentProvider theme={teamsLightTheme}>
+        <WorkloadMapper projectId={projectId} subscriptions={subscriptions} />
+      </FluentProvider>
+    </MemoryRouter>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("WorkloadMapper", () => {
+  beforeEach(() => {
+    vi.spyOn(apiModule.api.workloads, "list").mockResolvedValue({
+      workloads: MOCK_WORKLOADS,
+      total: MOCK_WORKLOADS.length,
+    });
+    vi.spyOn(apiModule.api.workloads, "generateMapping").mockResolvedValue({
+      mappings: MOCK_MAPPINGS,
+      warnings: [],
+    });
+    vi.spyOn(apiModule.api.workloads, "overrideMapping").mockResolvedValue(MOCK_WORKLOADS[0]);
+  });
+
+  it("renders the component title", async () => {
+    renderMapper();
+    await waitFor(() => {
+      expect(screen.getByText("Workload–Subscription Mapping")).toBeInTheDocument();
+    });
+  });
+
+  it("renders Generate Mapping button", async () => {
+    renderMapper();
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: /generate mapping/i })).toBeInTheDocument();
+    });
+  });
+
+  it("loads and displays workloads", async () => {
+    renderMapper();
+    await waitFor(() => {
+      expect(screen.getByText("ProdWebApp")).toBeInTheDocument();
+      expect(screen.getByText("DevDatabase")).toBeInTheDocument();
+    });
+  });
+
+  it("displays workload criticality badges", async () => {
+    renderMapper();
+    await waitFor(() => {
+      expect(screen.getByText("mission-critical")).toBeInTheDocument();
+      expect(screen.getByText("dev-test")).toBeInTheDocument();
+    });
+  });
+
+  it("displays subscription targets", async () => {
+    renderMapper();
+    await waitFor(() => {
+      expect(screen.getByText("sub-workload-prod")).toBeInTheDocument();
+      expect(screen.getByText("sub-workload-dev")).toBeInTheDocument();
+    });
+  });
+
+  it("shows 'Drop workloads here' hint on empty subscriptions", async () => {
+    renderMapper();
+    await waitFor(() => {
+      const hints = screen.getAllByText(/drop workloads here/i);
+      expect(hints.length).toBeGreaterThan(0);
+    });
+  });
+
+  it("calls generateMapping API on button click", async () => {
+    renderMapper();
+    await waitFor(() => screen.getByText("ProdWebApp"));
+
+    const btn = screen.getByRole("button", { name: /generate mapping/i });
+    fireEvent.click(btn);
+
+    await waitFor(() => {
+      expect(apiModule.api.workloads.generateMapping).toHaveBeenCalledWith("proj-1", "", true);
+    });
+  });
+
+  it("shows suggested badge and confidence after mapping generation", async () => {
+    renderMapper();
+    await waitFor(() => screen.getByText("ProdWebApp"));
+
+    fireEvent.click(screen.getByRole("button", { name: /generate mapping/i }));
+
+    await waitFor(() => {
+      const badges = screen.getAllByText("Suggested");
+      expect(badges.length).toBeGreaterThan(0);
+    });
+
+    await waitFor(() => {
+      // 92% confidence → "High"
+      expect(screen.getByText(/High.*92%|92%.*High/i)).toBeInTheDocument();
+    });
+  });
+
+  it("shows warnings from API response", async () => {
+    vi.spyOn(apiModule.api.workloads, "generateMapping").mockResolvedValue({
+      mappings: MOCK_MAPPINGS,
+      warnings: ["Workload 'ProdWebApp' has compliance requirements mapped to dev subscription"],
+    });
+
+    renderMapper();
+    await waitFor(() => screen.getByText("ProdWebApp"));
+    fireEvent.click(screen.getByRole("button", { name: /generate mapping/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText(/ProdWebApp.*compliance/i)).toBeInTheDocument();
+    });
+  });
+
+  it("shows error message when mapping API fails", async () => {
+    vi.spyOn(apiModule.api.workloads, "generateMapping").mockRejectedValue(
+      new Error("Server error")
+    );
+
+    renderMapper();
+    await waitFor(() => screen.getByText("ProdWebApp"));
+    fireEvent.click(screen.getByRole("button", { name: /generate mapping/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText(/server error/i)).toBeInTheDocument();
+    });
+  });
+
+  it("shows empty state hint when no workloads", async () => {
+    vi.spyOn(apiModule.api.workloads, "list").mockResolvedValue({ workloads: [], total: 0 });
+
+    renderMapper();
+    await waitFor(() => {
+      expect(screen.getByText(/no workloads found/i)).toBeInTheDocument();
+    });
+  });
+
+  it("disables Generate Mapping button when no workloads", async () => {
+    vi.spyOn(apiModule.api.workloads, "list").mockResolvedValue({ workloads: [], total: 0 });
+
+    renderMapper();
+    await waitFor(() => {
+      const btn = screen.getByRole("button", { name: /generate mapping/i });
+      expect(btn).toBeDisabled();
+    });
+  });
+
+  it("shows empty subscriptions hint when none provided", async () => {
+    renderMapper("proj-1", []);
+    await waitFor(() => {
+      expect(screen.getByText(/no subscriptions available/i)).toBeInTheDocument();
+    });
+  });
+
+  it("shows compliance requirements badge", async () => {
+    renderMapper();
+    await waitFor(() => {
+      expect(screen.getByText("SOC2")).toBeInTheDocument();
+    });
+  });
+
+  it("groups workloads by type", async () => {
+    renderMapper();
+    await waitFor(() => {
+      expect(screen.getByText("web-app")).toBeInTheDocument();
+      expect(screen.getByText("database")).toBeInTheDocument();
+    });
+  });
+
+  it("workload cards are draggable", async () => {
+    renderMapper();
+    await waitFor(() => screen.getByText("ProdWebApp"));
+
+    const card = screen.getByTestId("workload-card-wl-1");
+    expect(card).toHaveAttribute("draggable", "true");
+  });
+});

--- a/frontend/src/components/migration/WorkloadMapper.test.tsx
+++ b/frontend/src/components/migration/WorkloadMapper.test.tsx
@@ -76,8 +76,8 @@ const MOCK_MAPPINGS = [
 ];
 
 const MOCK_SUBSCRIPTIONS = [
-  { id: "sub-prod", name: "sub-workload-prod", purpose: "Production workloads" },
-  { id: "sub-dev", name: "sub-workload-dev", purpose: "Development and testing" },
+  { id: "sub-prod", name: "sub-workload-prod", purpose: "Production workloads", management_group: "mg-corp" },
+  { id: "sub-dev", name: "sub-workload-dev", purpose: "Development and testing", management_group: "mg-corp" },
 ];
 
 // ---------------------------------------------------------------------------

--- a/frontend/src/components/migration/WorkloadMapper.tsx
+++ b/frontend/src/components/migration/WorkloadMapper.tsx
@@ -1,0 +1,497 @@
+import { useCallback, useEffect, useState } from "react";
+import {
+  Badge,
+  Button,
+  MessageBar,
+  MessageBarBody,
+  Spinner,
+  Text,
+  makeStyles,
+  tokens,
+} from "@fluentui/react-components";
+import {
+  ArrowSyncRegular,
+  CheckmarkCircleRegular,
+  WarningRegular,
+} from "@fluentui/react-icons";
+import type { WorkloadMappingRecord, WorkloadRecord } from "../../services/api";
+import { api } from "../../services/api";
+
+// ---------------------------------------------------------------------------
+// Styles
+// ---------------------------------------------------------------------------
+
+const useStyles = makeStyles({
+  root: {
+    display: "flex",
+    flexDirection: "column",
+    gap: tokens.spacingVerticalM,
+    padding: tokens.spacingHorizontalM,
+  },
+  header: {
+    display: "flex",
+    alignItems: "center",
+    justifyContent: "space-between",
+    flexWrap: "wrap",
+    gap: tokens.spacingHorizontalS,
+  },
+  title: {
+    fontSize: tokens.fontSizeBase500,
+    fontWeight: tokens.fontWeightSemibold,
+  },
+  panes: {
+    display: "grid",
+    gridTemplateColumns: "1fr 1fr",
+    gap: tokens.spacingHorizontalL,
+  },
+  pane: {
+    display: "flex",
+    flexDirection: "column",
+    gap: tokens.spacingVerticalS,
+  },
+  paneTitle: {
+    fontSize: tokens.fontSizeBase400,
+    fontWeight: tokens.fontWeightSemibold,
+    paddingBottom: tokens.spacingVerticalXS,
+    borderBottomWidth: "2px",
+    borderBottomStyle: "solid",
+    borderBottomColor: tokens.colorBrandBackground,
+  },
+  workloadCard: {
+    display: "flex",
+    flexDirection: "column",
+    gap: tokens.spacingVerticalXS,
+    padding: tokens.spacingVerticalS,
+    paddingLeft: tokens.spacingHorizontalS,
+    paddingRight: tokens.spacingHorizontalS,
+    borderRadius: tokens.borderRadiusMedium,
+    borderTopWidth: "1px",
+    borderBottomWidth: "1px",
+    borderLeftWidth: "1px",
+    borderRightWidth: "1px",
+    borderTopStyle: "solid",
+    borderBottomStyle: "solid",
+    borderLeftStyle: "solid",
+    borderRightStyle: "solid",
+    borderTopColor: tokens.colorNeutralStroke1,
+    borderBottomColor: tokens.colorNeutralStroke1,
+    borderLeftColor: tokens.colorNeutralStroke1,
+    borderRightColor: tokens.colorNeutralStroke1,
+    backgroundColor: tokens.colorNeutralBackground1,
+  },
+  workloadCardDragging: {
+    opacity: "0.5",
+    backgroundColor: tokens.colorBrandBackground2,
+  },
+  workloadName: {
+    fontWeight: tokens.fontWeightSemibold,
+    fontSize: tokens.fontSizeBase300,
+  },
+  workloadMeta: {
+    display: "flex",
+    gap: tokens.spacingHorizontalXS,
+    flexWrap: "wrap",
+    alignItems: "center",
+  },
+  mappingRow: {
+    display: "flex",
+    alignItems: "center",
+    gap: tokens.spacingHorizontalXS,
+    marginTop: tokens.spacingVerticalXS,
+  },
+  mappingText: {
+    fontSize: tokens.fontSizeBase200,
+    color: tokens.colorNeutralForeground3,
+  },
+  subscriptionCard: {
+    display: "flex",
+    flexDirection: "column",
+    gap: tokens.spacingVerticalXS,
+    padding: tokens.spacingVerticalS,
+    paddingLeft: tokens.spacingHorizontalS,
+    paddingRight: tokens.spacingHorizontalS,
+    borderRadius: tokens.borderRadiusMedium,
+    borderTopWidth: "2px",
+    borderBottomWidth: "2px",
+    borderLeftWidth: "2px",
+    borderRightWidth: "2px",
+    borderTopStyle: "dashed",
+    borderBottomStyle: "dashed",
+    borderLeftStyle: "dashed",
+    borderRightStyle: "dashed",
+    borderTopColor: tokens.colorNeutralStroke2,
+    borderBottomColor: tokens.colorNeutralStroke2,
+    borderLeftColor: tokens.colorNeutralStroke2,
+    borderRightColor: tokens.colorNeutralStroke2,
+    backgroundColor: tokens.colorNeutralBackground2,
+    minHeight: "64px",
+  },
+  subscriptionCardOver: {
+    borderTopColor: tokens.colorBrandBackground,
+    borderBottomColor: tokens.colorBrandBackground,
+    borderLeftColor: tokens.colorBrandBackground,
+    borderRightColor: tokens.colorBrandBackground,
+    backgroundColor: tokens.colorBrandBackground2,
+  },
+  subscriptionName: {
+    fontWeight: tokens.fontWeightSemibold,
+    fontSize: tokens.fontSizeBase300,
+  },
+  subscriptionPurpose: {
+    fontSize: tokens.fontSizeBase200,
+    color: tokens.colorNeutralForeground3,
+  },
+  assignedList: {
+    display: "flex",
+    flexDirection: "column",
+    gap: tokens.spacingVerticalXS,
+    marginTop: tokens.spacingVerticalXS,
+  },
+  assignedChip: {
+    display: "flex",
+    alignItems: "center",
+    gap: tokens.spacingHorizontalXS,
+    fontSize: tokens.fontSizeBase200,
+    padding: `${tokens.spacingVerticalXXS} ${tokens.spacingHorizontalXS}`,
+    borderRadius: tokens.borderRadiusSmall,
+    backgroundColor: tokens.colorNeutralBackground3,
+  },
+  warningsSection: {
+    display: "flex",
+    flexDirection: "column",
+    gap: tokens.spacingVerticalXS,
+  },
+  errorText: {
+    color: tokens.colorPaletteRedForeground1,
+  },
+  emptyHint: {
+    fontSize: tokens.fontSizeBase200,
+    color: tokens.colorNeutralForeground3,
+    fontStyle: "italic",
+  },
+  confidenceHigh: {
+    color: tokens.colorPaletteGreenForeground1,
+  },
+  confidenceMed: {
+    color: tokens.colorPaletteMarigoldForeground1,
+  },
+  confidenceLow: {
+    color: tokens.colorPaletteRedForeground1,
+  },
+  groupLabel: {
+    fontSize: tokens.fontSizeBase200,
+    fontWeight: tokens.fontWeightSemibold,
+    color: tokens.colorNeutralForeground2,
+    textTransform: "uppercase",
+    letterSpacing: "0.05em",
+    marginTop: tokens.spacingVerticalS,
+  },
+});
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+interface SubscriptionDef {
+  id: string;
+  name: string;
+  purpose: string;
+}
+
+interface WorkloadMapperProps {
+  projectId: string;
+  /** Optional architecture subscriptions — loaded externally or from state */
+  subscriptions?: SubscriptionDef[];
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function confidenceLabel(score: number): string {
+  if (score >= 0.8) return "High";
+  if (score >= 0.5) return "Medium";
+  return "Low";
+}
+
+function groupByType(workloads: WorkloadRecord[]): Record<string, WorkloadRecord[]> {
+  const groups: Record<string, WorkloadRecord[]> = {};
+  for (const wl of workloads) {
+    const key = wl.type || "other";
+    (groups[key] ??= []).push(wl);
+  }
+  return groups;
+}
+
+// ---------------------------------------------------------------------------
+// WorkloadMapper
+// ---------------------------------------------------------------------------
+
+export default function WorkloadMapper({ projectId, subscriptions = [] }: WorkloadMapperProps) {
+  const styles = useStyles();
+
+  const [workloads, setWorkloads] = useState<WorkloadRecord[]>([]);
+  const [mappings, setMappings] = useState<WorkloadMappingRecord[]>([]);
+  const [warnings, setWarnings] = useState<string[]>([]);
+  const [overrides, setOverrides] = useState<Record<string, string>>({});
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [draggingId, setDraggingId] = useState<string | null>(null);
+  const [dragOverSubId, setDragOverSubId] = useState<string | null>(null);
+
+  // Load workloads on mount
+  useEffect(() => {
+    api.workloads.list(projectId)
+      .then((res) => setWorkloads(res.workloads))
+      .catch(() => setWorkloads([]));
+  }, [projectId]);
+
+  // ---------------------------------------------------------------------------
+  // Generate Mapping
+  // ---------------------------------------------------------------------------
+
+  const handleGenerateMapping = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await api.workloads.generateMapping(projectId, "", true);
+      setMappings(res.mappings);
+      setWarnings(res.warnings);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to generate mapping");
+    } finally {
+      setLoading(false);
+    }
+  }, [projectId]);
+
+  // ---------------------------------------------------------------------------
+  // Drag-and-drop
+  // ---------------------------------------------------------------------------
+
+  const handleDragStart = useCallback((workloadId: string) => {
+    setDraggingId(workloadId);
+  }, []);
+
+  const handleDragEnd = useCallback(() => {
+    setDraggingId(null);
+    setDragOverSubId(null);
+  }, []);
+
+  const handleDrop = useCallback(
+    async (subscriptionId: string) => {
+      if (!draggingId) return;
+      setDragOverSubId(null);
+
+      const sub = subscriptions.find((s) => s.id === subscriptionId);
+      const subName = sub?.name ?? subscriptionId;
+
+      // Optimistic update
+      setOverrides((prev) => ({ ...prev, [draggingId]: subscriptionId }));
+
+      // Update mapping in local state
+      setMappings((prev) => {
+        const existing = prev.find((m) => m.workload_id === draggingId);
+        if (existing) {
+          return prev.map((m) =>
+            m.workload_id === draggingId
+              ? { ...m, recommended_subscription_id: subscriptionId, recommended_subscription_name: subName }
+              : m
+          );
+        }
+        // No existing mapping — create one
+        const wl = workloads.find((w) => w.id === draggingId);
+        return [
+          ...prev,
+          {
+            workload_id: draggingId,
+            workload_name: wl?.name ?? draggingId,
+            recommended_subscription_id: subscriptionId,
+            recommended_subscription_name: subName,
+            reasoning: "Manual assignment",
+            confidence_score: 1.0,
+            warnings: [],
+          },
+        ];
+      });
+
+      // Persist to backend
+      try {
+        await api.workloads.overrideMapping(draggingId, subscriptionId, "Manual drag-and-drop assignment");
+      } catch {
+        // Revert on failure — best-effort
+        setOverrides((prev) => {
+          const next = { ...prev };
+          delete next[draggingId];
+          return next;
+        });
+      }
+      setDraggingId(null);
+    },
+    [draggingId, subscriptions, workloads]
+  );
+
+  // ---------------------------------------------------------------------------
+  // Derived state
+  // ---------------------------------------------------------------------------
+
+  const mappingByWorkloadId: Record<string, WorkloadMappingRecord> = Object.fromEntries(
+    mappings.map((m) => [m.workload_id, m])
+  );
+
+  const workloadsBySubscription: Record<string, string[]> = {};
+  for (const m of mappings) {
+    const subId = overrides[m.workload_id] ?? m.recommended_subscription_id;
+    (workloadsBySubscription[subId] ??= []).push(m.workload_id);
+  }
+
+  const groupedWorkloads = groupByType(workloads);
+
+  // ---------------------------------------------------------------------------
+  // Render
+  // ---------------------------------------------------------------------------
+
+  return (
+    <div className={styles.root}>
+      {/* Header */}
+      <div className={styles.header}>
+        <Text className={styles.title}>Workload–Subscription Mapping</Text>
+        <Button
+          appearance="primary"
+          icon={loading ? <Spinner size="tiny" /> : <ArrowSyncRegular />}
+          disabled={loading || workloads.length === 0}
+          onClick={handleGenerateMapping}
+        >
+          {loading ? "Generating…" : "Generate Mapping"}
+        </Button>
+      </div>
+
+      {error && (
+        <MessageBar intent="error">
+          <MessageBarBody>{error}</MessageBarBody>
+        </MessageBar>
+      )}
+
+      {/* Split panes */}
+      <div className={styles.panes}>
+        {/* Left — workload list */}
+        <div className={styles.pane}>
+          <Text className={styles.paneTitle}>Workloads</Text>
+          {workloads.length === 0 && (
+            <Text className={styles.emptyHint}>No workloads found for this project.</Text>
+          )}
+          {Object.entries(groupedWorkloads).map(([type, wls]) => (
+            <div key={type}>
+              <Text className={styles.groupLabel}>{type}</Text>
+              {wls.map((wl) => {
+                const mapping = mappingByWorkloadId[wl.id];
+                const isDragging = draggingId === wl.id;
+                return (
+                  <div
+                    key={wl.id}
+                    className={`${styles.workloadCard}${isDragging ? ` ${styles.workloadCardDragging}` : ""}`}
+                    draggable
+                    onDragStart={() => handleDragStart(wl.id)}
+                    onDragEnd={handleDragEnd}
+                    data-testid={`workload-card-${wl.id}`}
+                  >
+                    <Text className={styles.workloadName}>{wl.name}</Text>
+                    <div className={styles.workloadMeta}>
+                      <Badge appearance="outline" size="small">{wl.criticality}</Badge>
+                      {wl.compliance_requirements.length > 0 && (
+                        <Badge appearance="tint" color="warning" size="small">
+                          {wl.compliance_requirements.join(", ")}
+                        </Badge>
+                      )}
+                    </div>
+                    {mapping && (
+                      <div className={styles.mappingRow}>
+                        <CheckmarkCircleRegular />
+                        <Text className={styles.mappingText}>
+                          {mapping.recommended_subscription_name}
+                        </Text>
+                        <Badge appearance="tint" color="success" size="small">
+                          Suggested
+                        </Badge>
+                        <Text
+                          className={
+                            mapping.confidence_score >= 0.8
+                              ? styles.confidenceHigh
+                              : mapping.confidence_score >= 0.5
+                              ? styles.confidenceMed
+                              : styles.confidenceLow
+                          }
+                        >
+                          {confidenceLabel(mapping.confidence_score)} (
+                          {Math.round(mapping.confidence_score * 100)}%)
+                        </Text>
+                      </div>
+                    )}
+                  </div>
+                );
+              })}
+            </div>
+          ))}
+        </div>
+
+        {/* Right — subscription targets */}
+        <div className={styles.pane}>
+          <Text className={styles.paneTitle}>Target Subscriptions</Text>
+          {subscriptions.length === 0 && (
+            <Text className={styles.emptyHint}>
+              No subscriptions available. Generate an architecture first.
+            </Text>
+          )}
+          {subscriptions.map((sub) => {
+            const assignedIds = workloadsBySubscription[sub.id] ?? [];
+            const isOver = dragOverSubId === sub.id;
+            return (
+              <div
+                key={sub.id}
+                className={`${styles.subscriptionCard}${isOver ? ` ${styles.subscriptionCardOver}` : ""}`}
+                onDragOver={(e) => {
+                  e.preventDefault();
+                  setDragOverSubId(sub.id);
+                }}
+                onDragLeave={() => setDragOverSubId(null)}
+                onDrop={() => handleDrop(sub.id)}
+                data-testid={`subscription-target-${sub.id}`}
+              >
+                <Text className={styles.subscriptionName}>{sub.name}</Text>
+                <Text className={styles.subscriptionPurpose}>{sub.purpose}</Text>
+                {assignedIds.length > 0 && (
+                  <div className={styles.assignedList}>
+                    {assignedIds.map((wlId) => {
+                      const m = mappingByWorkloadId[wlId];
+                      return (
+                        <div key={wlId} className={styles.assignedChip}>
+                          <CheckmarkCircleRegular fontSize="12px" />
+                          <Text>{m?.workload_name ?? wlId}</Text>
+                        </div>
+                      );
+                    })}
+                  </div>
+                )}
+                {assignedIds.length === 0 && (
+                  <Text className={styles.emptyHint}>Drop workloads here</Text>
+                )}
+              </div>
+            );
+          })}
+        </div>
+      </div>
+
+      {/* Validation warnings */}
+      {warnings.length > 0 && (
+        <div className={styles.warningsSection}>
+          {warnings.map((w, i) => (
+            <MessageBar key={i} intent="warning">
+              <MessageBarBody>
+                <WarningRegular /> {w}
+              </MessageBarBody>
+            </MessageBar>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/migration/WorkloadMapper.tsx
+++ b/frontend/src/components/migration/WorkloadMapper.tsx
@@ -227,10 +227,11 @@ function groupByType(workloads: WorkloadRecord[]): Record<string, WorkloadRecord
 // WorkloadMapper
 // ---------------------------------------------------------------------------
 
-export default function WorkloadMapper({ projectId, subscriptions = [] }: WorkloadMapperProps) {
+export default function WorkloadMapper({ projectId, subscriptions: propSubscriptions }: WorkloadMapperProps) {
   const styles = useStyles();
 
   const [workloads, setWorkloads] = useState<WorkloadRecord[]>([]);
+  const [subscriptions, setSubscriptions] = useState<SubscriptionDef[]>(propSubscriptions ?? []);
   const [mappings, setMappings] = useState<WorkloadMappingRecord[]>([]);
   const [warnings, setWarnings] = useState<string[]>([]);
   const [overrides, setOverrides] = useState<Record<string, string>>({});
@@ -245,6 +246,28 @@ export default function WorkloadMapper({ projectId, subscriptions = [] }: Worklo
       .then((res) => setWorkloads(res.workloads))
       .catch(() => setWorkloads([]));
   }, [projectId]);
+
+  // Load subscriptions from project architecture when not provided via props
+  useEffect(() => {
+    if (propSubscriptions && propSubscriptions.length > 0) {
+      setSubscriptions(propSubscriptions);
+      return;
+    }
+    api.architecture.getByProject(projectId)
+      .then((res) => {
+        const subs = res.architecture?.subscriptions;
+        if (Array.isArray(subs) && subs.length > 0) {
+          setSubscriptions(
+            subs.map((s, i) => ({
+              id: (s as { id?: string; name?: string }).id ?? (s as { name?: string }).name ?? `sub-${i}`,
+              name: (s as { name?: string }).name ?? `sub-${i}`,
+              purpose: (s as { purpose?: string }).purpose ?? "",
+            }))
+          );
+        }
+      })
+      .catch(() => {/* silently skip if no architecture */});
+  }, [projectId, propSubscriptions]);
 
   // ---------------------------------------------------------------------------
   // Generate Mapping
@@ -285,6 +308,10 @@ export default function WorkloadMapper({ projectId, subscriptions = [] }: Worklo
       const sub = subscriptions.find((s) => s.id === subscriptionId);
       const subName = sub?.name ?? subscriptionId;
 
+      // Capture previous state for revert on failure
+      const prevOverrides = overrides;
+      const prevMappings = mappings;
+
       // Optimistic update
       setOverrides((prev) => ({ ...prev, [draggingId]: subscriptionId }));
 
@@ -318,12 +345,10 @@ export default function WorkloadMapper({ projectId, subscriptions = [] }: Worklo
       try {
         await api.workloads.overrideMapping(draggingId, subscriptionId, "Manual drag-and-drop assignment");
       } catch {
-        // Revert on failure — best-effort
-        setOverrides((prev) => {
-          const next = { ...prev };
-          delete next[draggingId];
-          return next;
-        });
+        // Revert both overrides and mappings state on failure
+        setOverrides(prevOverrides);
+        setMappings(prevMappings);
+        setError("Failed to save mapping override — please try again.");
       }
       setDraggingId(null);
     },

--- a/frontend/src/pages/WorkloadsPage.tsx
+++ b/frontend/src/pages/WorkloadsPage.tsx
@@ -37,6 +37,7 @@ import {
   DeleteRegular,
   DocumentRegular,
   EditRegular,
+  LinkRegular,
   WarningRegular,
 } from "@fluentui/react-icons";
 import type {
@@ -45,6 +46,7 @@ import type {
   WorkloadRecord,
 } from "../services/api";
 import { api } from "../services/api";
+import WorkloadMapper from "../components/migration/WorkloadMapper";
 
 const useStyles = makeStyles({
   root: {
@@ -116,7 +118,7 @@ const useStyles = makeStyles({
   },
 });
 
-type TabValue = "import" | "inventory";
+type TabValue = "import" | "inventory" | "mapping";
 
 const WORKLOAD_TYPES = ["vm", "database", "web-app", "container", "other"];
 const SOURCE_PLATFORMS = ["vmware", "hyperv", "physical", "aws", "gcp", "other"];
@@ -310,6 +312,7 @@ export default function WorkloadsPage({ projectId: propProjectId }: WorkloadsPag
       <TabList selectedValue={activeTab} onTabSelect={handleTabChange}>
         <Tab value="import" icon={<ArrowUploadRegular />}>Import</Tab>
         <Tab value="inventory" icon={<DocumentRegular />}>Inventory</Tab>
+        <Tab value="mapping" icon={<LinkRegular />}>Mapping</Tab>
       </TabList>
 
       {/* ---- Import Tab ---- */}
@@ -731,6 +734,11 @@ export default function WorkloadsPage({ projectId: propProjectId }: WorkloadsPag
       </Dialog>
 
       <Label style={{ display: "none" }}>Workload import file picker</Label>
+
+      {/* ---- Mapping Tab ---- */}
+      {activeTab === "mapping" && (
+        <WorkloadMapper projectId={projectId} />
+      )}
     </div>
   );
 }

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -250,6 +250,16 @@ export const api = {
       }
       return res.json() as Promise<WorkloadImportResult>;
     },
+    generateMapping: (projectId: string, architectureId: string = "", useAi: boolean = true) =>
+      fetchApi<WorkloadMappingResponse>("/api/workloads/map", {
+        method: "POST",
+        body: JSON.stringify({ project_id: projectId, architecture_id: architectureId, use_ai: useAi }),
+      }),
+    overrideMapping: (workloadId: string, subscriptionId: string, reasoning: string = "Manual override") =>
+      fetchApi<WorkloadRecord>(`/api/workloads/${workloadId}/mapping`, {
+        method: "PATCH",
+        body: JSON.stringify({ target_subscription_id: subscriptionId, reasoning }),
+      }),
   },
 };
 
@@ -441,6 +451,8 @@ export interface WorkloadRecord {
   dependencies: string[];
   migration_strategy: string;
   notes: string | null;
+  target_subscription_id: string | null;
+  mapping_reasoning: string | null;
   created_at: string;
   updated_at: string;
 }
@@ -472,4 +484,19 @@ export interface WorkloadImportResult {
   failed_count: number;
   errors: string[];
   workloads: WorkloadRecord[];
+}
+
+export interface WorkloadMappingRecord {
+  workload_id: string;
+  workload_name: string;
+  recommended_subscription_id: string;
+  recommended_subscription_name: string;
+  reasoning: string;
+  confidence_score: number;
+  warnings: string[];
+}
+
+export interface WorkloadMappingResponse {
+  mappings: WorkloadMappingRecord[];
+  warnings: string[];
 }


### PR DESCRIPTION
Closes #45

## Summary

Implements the workload-to-subscription mapping feature end-to-end.

### Backend
- **WorkloadMapper service** (`backend/app/services/workload_mapper.py`): Rule-based and AI-powered mapping logic that scores each workload against available subscriptions based on criticality, compliance requirements, and workload type. Falls back gracefully to rule-based when AI is unavailable or returns invalid JSON.
- **Schemas** (`backend/app/schemas/workload_mapping.py`): `WorkloadMapping`, `MappingRequest`, `MappingResponse`, `MappingOverride` with full Pydantic v2 validation.
- **Routes**: `POST /api/workloads/map` and `PATCH /api/workloads/{id}/mapping` added to existing workload router.
- **Model update**: `target_subscription_id` (nullable str) and `mapping_reasoning` (nullable str) added to `Workload` model.
- **Migration**: `006_add_workload_mapping_fields.py` for the two new columns.
- **Validation**: `validate_mappings()` checks for subscription overload (>50 workloads), compliance mismatches (sensitive reqs in dev/sandbox), and split dependencies without a network path.

### Frontend
- **WorkloadMapper component** (`frontend/src/components/migration/WorkloadMapper.tsx`): Split-pane layout (workloads left, subscriptions right), grouped by type. Shows AI-suggested subscription with badge and colour-coded confidence score. HTML5 drag-and-drop reassignment with optimistic update and backend persistence via PATCH.
- **WorkloadsPage**: Third tab Mapping renders `<WorkloadMapper projectId={projectId} />`.
- **API**: `api.workloads.generateMapping()` and `api.workloads.overrideMapping()` added to `frontend/src/services/api.ts`.
- **Types**: `WorkloadMappingRecord`, `WorkloadMappingResponse` interfaces; `WorkloadRecord` updated with `target_subscription_id` and `mapping_reasoning` fields.

### Tests
- 21 new backend tests covering mapper service (rule-based, AI mode, AI fallback), validation logic, and route endpoints.
- 16 new frontend tests covering component render, workload loading, mapping generation, warnings display, error handling, and drag-and-drop readiness.
- Backend coverage: 75.5% (≥75% threshold met). Frontend statements: 84.9% (≥75% met).