### PR TITLE
feat: Dependency mapping visualization (#47)

### DIFF
--- a/backend/app/api/routes/workloads.py
+++ b/backend/app/api/routes/workloads.py
@@ -638,6 +638,63 @@ async def add_dependency(
 
 
 # ---------------------------------------------------------------------------
+# PATCH /api/workloads/{workload_id}/mapping — persist manual override
+# ---------------------------------------------------------------------------
+
+
+@router.patch("/{workload_id}/mapping", response_model=WorkloadResponse)
+async def override_workload_mapping(
+    workload_id: str,
+    override: MappingOverride,
+    user: dict = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+) -> WorkloadResponse:
+    """Manually override the AI-recommended subscription for a workload."""
+    if db is None:
+        raise HTTPException(status_code=404, detail="Database not configured")
+
+    try:
+        result = await db.execute(
+            select(Workload).where(Workload.id == workload_id)
+        )
+        workload = result.scalar_one_or_none()
+        if not workload:
+            raise HTTPException(status_code=404, detail="Workload not found")
+
+        tenant_id = user.get("tid", user.get("tenant_id", "dev-tenant"))
+        proj_result = await db.execute(
+            select(Project).where(
+                Project.id == workload.project_id,
+                Project.tenant_id == tenant_id,
+            )
+        )
+        if proj_result.scalar_one_or_none() is None:
+            raise HTTPException(
+                status_code=403, detail="Project not found or access denied"
+            )
+
+        workload.target_subscription_id = override.target_subscription_id
+        workload.mapping_reasoning = override.reasoning
+        workload.updated_at = datetime.now(timezone.utc)
+
+        await db.flush()
+        logger.info(
+            "Overrode mapping for workload %s → %s",
+            workload_id,
+            override.target_subscription_id,
+        )
+        return _to_response(workload)
+
+    except HTTPException:
+        raise
+    except Exception as exc:
+        logger.exception(
+            "Failed to override mapping for workload %s", workload_id
+        )
+        raise HTTPException(status_code=500, detail=str(exc)) from exc
+
+
+# ---------------------------------------------------------------------------
 # DELETE /api/workloads/{id}/dependencies/{target_id}
 # ---------------------------------------------------------------------------
 

--- a/backend/app/api/routes/workloads.py
+++ b/backend/app/api/routes/workloads.py
@@ -548,19 +548,15 @@ async def add_dependency(
         raise HTTPException(status_code=503, detail="Database not configured")
 
     try:
-        result = await db.execute(select(Workload).where(Workload.id == workload_id))
+        tenant_id = user.get("tid", user.get("tenant_id", "dev-tenant"))
+        result = await db.execute(
+            select(Workload)
+            .join(Project, Project.id == Workload.project_id)
+            .where(Workload.id == workload_id, Project.tenant_id == tenant_id)
+        )
         workload = result.scalar_one_or_none()
         if not workload:
             raise HTTPException(status_code=404, detail="Workload not found")
-
-        tenant_id = user.get("tid", user.get("tenant_id", "dev-tenant"))
-        proj_result = await db.execute(
-            select(Project).where(
-                Project.id == workload.project_id, Project.tenant_id == tenant_id
-            )
-        )
-        if proj_result.scalar_one_or_none() is None:
-            raise HTTPException(status_code=403, detail="Project not found or access denied")
 
         # Verify target exists in same project
         tgt_result = await db.execute(
@@ -664,19 +660,15 @@ async def remove_dependency(
         raise HTTPException(status_code=503, detail="Database not configured")
 
     try:
-        result = await db.execute(select(Workload).where(Workload.id == workload_id))
+        tenant_id = user.get("tid", user.get("tenant_id", "dev-tenant"))
+        result = await db.execute(
+            select(Workload)
+            .join(Project, Project.id == Workload.project_id)
+            .where(Workload.id == workload_id, Project.tenant_id == tenant_id)
+        )
         workload = result.scalar_one_or_none()
         if not workload:
             raise HTTPException(status_code=404, detail="Workload not found")
-
-        tenant_id = user.get("tid", user.get("tenant_id", "dev-tenant"))
-        proj_result = await db.execute(
-            select(Project).where(
-                Project.id == workload.project_id, Project.tenant_id == tenant_id
-            )
-        )
-        if proj_result.scalar_one_or_none() is None:
-            raise HTTPException(status_code=403, detail="Project not found or access denied")
 
         deps: list[str] = list(workload.dependencies or [])
         if target_id in deps:

--- a/backend/app/api/routes/workloads.py
+++ b/backend/app/api/routes/workloads.py
@@ -1,4 +1,4 @@
-"""Workload API routes — import, list, create, update, delete, map."""
+"""Workload API routes — import, list, create, update, delete, map, dependency graph."""
 
 import logging
 import uuid
@@ -12,6 +12,13 @@ from app.auth import get_current_user
 from app.db.session import get_db
 from app.models.project import Project
 from app.models.workload import Workload
+from app.schemas.dependency import (
+    AddDependencyRequest,
+    DependencyEdge,
+    DependencyGraph,
+    MigrationOrderResponse,
+    WorkloadSummary,
+)
 from app.schemas.workload import (
     WorkloadCreate,
     WorkloadImportResult,
@@ -19,6 +26,7 @@ from app.schemas.workload import (
     WorkloadUpdate,
 )
 from app.schemas.workload_mapping import MappingOverride, MappingRequest, MappingResponse
+from app.services.dependency_analyzer import DependencyAnalyzer
 from app.services.workload_importer import detect_format, parse_file
 
 logger = logging.getLogger(__name__)
@@ -445,6 +453,76 @@ async def map_workloads(
 
 
 # ---------------------------------------------------------------------------
+# Helper — tenant-scoped workload fetch
+# ---------------------------------------------------------------------------
+
+_analyzer = DependencyAnalyzer()
+
+
+async def _get_project_workloads(
+    project_id: str,
+    tenant_id: str,
+    db: AsyncSession,
+) -> list[Workload]:
+    """Return all workloads for *project_id*, verifying tenant ownership."""
+    proj_result = await db.execute(
+        select(Project).where(Project.id == project_id, Project.tenant_id == tenant_id)
+    )
+    if proj_result.scalar_one_or_none() is None:
+        raise HTTPException(status_code=403, detail="Project not found or access denied")
+
+    result = await db.execute(select(Workload).where(Workload.project_id == project_id))
+    return list(result.scalars().all())
+
+
+def _workloads_to_graph(workloads: list[Workload]) -> DependencyGraph:
+    """Build a DependencyGraph from a list of ORM Workload objects."""
+    summaries = [
+        WorkloadSummary(
+            id=w.id,
+            name=w.name,
+            criticality=w.criticality,
+            migration_strategy=w.migration_strategy,
+            project_id=w.project_id,
+        )
+        for w in workloads
+    ]
+    node_ids = {w.id for w in workloads}
+    edges: list[DependencyEdge] = []
+    for w in workloads:
+        for dep_id in w.dependencies or []:
+            if dep_id in node_ids:
+                edges.append(DependencyEdge(source=w.id, target=dep_id))
+    return _analyzer.get_dependency_graph(summaries, edges)
+
+
+# ---------------------------------------------------------------------------
+# GET /api/workloads/dependency-graph
+# ---------------------------------------------------------------------------
+
+
+@router.get("/dependency-graph", response_model=DependencyGraph)
+async def get_dependency_graph(
+    project_id: str = Query(..., description="Project ID"),
+    user: dict = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+) -> DependencyGraph:
+    """Return the dependency graph for a project."""
+    if db is None:
+        return DependencyGraph()
+
+    try:
+        tenant_id = user.get("tid", user.get("tenant_id", "dev-tenant"))
+        workloads = await _get_project_workloads(project_id, tenant_id, db)
+        return _workloads_to_graph(workloads)
+    except HTTPException:
+        raise
+    except Exception as exc:
+        logger.exception("Failed to build dependency graph for project %s", project_id)
+        raise HTTPException(status_code=500, detail=str(exc)) from exc
+
+
+# ---------------------------------------------------------------------------
 # PATCH /api/workloads/{workload_id}/mapping — persist manual override
 # ---------------------------------------------------------------------------
 
@@ -488,4 +566,149 @@ async def override_workload_mapping(
         raise
     except Exception as exc:
         logger.exception("Failed to override mapping for workload %s", workload_id)
+        raise HTTPException(status_code=500, detail=str(exc)) from exc
+
+
+# ---------------------------------------------------------------------------
+# POST /api/workloads/{id}/dependencies
+# ---------------------------------------------------------------------------
+
+
+@router.post("/{workload_id}/dependencies", response_model=WorkloadResponse)
+async def add_dependency(
+    workload_id: str,
+    body: AddDependencyRequest,
+    user: dict = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+) -> WorkloadResponse:
+    """Add a dependency link from *workload_id* → *target_workload_id*."""
+    if db is None:
+        raise HTTPException(status_code=503, detail="Database not configured")
+
+    try:
+        result = await db.execute(select(Workload).where(Workload.id == workload_id))
+        workload = result.scalar_one_or_none()
+        if not workload:
+            raise HTTPException(status_code=404, detail="Workload not found")
+
+        tenant_id = user.get("tid", user.get("tenant_id", "dev-tenant"))
+        proj_result = await db.execute(
+            select(Project).where(
+                Project.id == workload.project_id, Project.tenant_id == tenant_id
+            )
+        )
+        if proj_result.scalar_one_or_none() is None:
+            raise HTTPException(status_code=403, detail="Project not found or access denied")
+
+        # Verify target exists in same project
+        tgt_result = await db.execute(
+            select(Workload).where(
+                Workload.id == body.target_workload_id,
+                Workload.project_id == workload.project_id,
+            )
+        )
+        if tgt_result.scalar_one_or_none() is None:
+            raise HTTPException(status_code=404, detail="Target workload not found")
+
+        deps: list[str] = list(workload.dependencies or [])
+        if body.target_workload_id not in deps:
+            deps.append(body.target_workload_id)
+            workload.dependencies = deps
+            workload.updated_at = datetime.now(timezone.utc)
+            await db.flush()
+
+        return _to_response(workload)
+    except HTTPException:
+        raise
+    except Exception as exc:
+        logger.exception("Failed to add dependency for workload %s", workload_id)
+        raise HTTPException(status_code=500, detail=str(exc)) from exc
+
+
+# ---------------------------------------------------------------------------
+# DELETE /api/workloads/{id}/dependencies/{target_id}
+# ---------------------------------------------------------------------------
+
+
+@router.delete("/{workload_id}/dependencies/{target_id}", response_model=WorkloadResponse)
+async def remove_dependency(
+    workload_id: str,
+    target_id: str,
+    user: dict = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+) -> WorkloadResponse:
+    """Remove a dependency link from *workload_id* → *target_id*."""
+    if db is None:
+        raise HTTPException(status_code=503, detail="Database not configured")
+
+    try:
+        result = await db.execute(select(Workload).where(Workload.id == workload_id))
+        workload = result.scalar_one_or_none()
+        if not workload:
+            raise HTTPException(status_code=404, detail="Workload not found")
+
+        tenant_id = user.get("tid", user.get("tenant_id", "dev-tenant"))
+        proj_result = await db.execute(
+            select(Project).where(
+                Project.id == workload.project_id, Project.tenant_id == tenant_id
+            )
+        )
+        if proj_result.scalar_one_or_none() is None:
+            raise HTTPException(status_code=403, detail="Project not found or access denied")
+
+        deps: list[str] = list(workload.dependencies or [])
+        if target_id in deps:
+            deps.remove(target_id)
+            workload.dependencies = deps
+            workload.updated_at = datetime.now(timezone.utc)
+            await db.flush()
+
+        return _to_response(workload)
+    except HTTPException:
+        raise
+    except Exception as exc:
+        logger.exception("Failed to remove dependency for workload %s", workload_id)
+        raise HTTPException(status_code=500, detail=str(exc)) from exc
+
+
+# ---------------------------------------------------------------------------
+# GET /api/workloads/migration-order
+# ---------------------------------------------------------------------------
+
+
+@router.get("/migration-order", response_model=MigrationOrderResponse)
+async def get_migration_order(
+    project_id: str = Query(..., description="Project ID"),
+    user: dict = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+) -> MigrationOrderResponse:
+    """Return a suggested migration order plus migration groups and cycle warnings."""
+    if db is None:
+        return MigrationOrderResponse()
+
+    try:
+        tenant_id = user.get("tid", user.get("tenant_id", "dev-tenant"))
+        workloads = await _get_project_workloads(project_id, tenant_id, db)
+        graph = _workloads_to_graph(workloads)
+
+        workload_names = {w.id: w.name for w in workloads}
+        cycles = graph.circular_dependencies
+        groups = graph.migration_groups
+
+        try:
+            order = _analyzer.suggest_migration_order(graph)
+        except ValueError:
+            order = []
+
+        return MigrationOrderResponse(
+            order=order,
+            migration_groups=groups,
+            circular_dependencies=cycles,
+            has_circular=len(cycles) > 0,
+            workload_names=workload_names,
+        )
+    except HTTPException:
+        raise
+    except Exception as exc:
+        logger.exception("Failed to compute migration order for project %s", project_id)
         raise HTTPException(status_code=500, detail=str(exc)) from exc

--- a/backend/app/api/routes/workloads.py
+++ b/backend/app/api/routes/workloads.py
@@ -342,10 +342,10 @@ async def delete_workload(
         logger.exception("Failed to delete workload %s", workload_id)
         raise HTTPException(status_code=500, detail=str(exc)) from exc
 
-
 # ---------------------------------------------------------------------------
 # POST /api/workloads/map — generate workload-to-subscription mappings
 # ---------------------------------------------------------------------------
+
 
 @router.post("/map", response_model=MappingResponse)
 async def map_workloads(
@@ -528,53 +528,6 @@ async def get_dependency_graph(
         raise
     except Exception as exc:
         logger.exception("Failed to build dependency graph for project %s", project_id)
-        raise HTTPException(status_code=500, detail=str(exc)) from exc
-
-
-# ---------------------------------------------------------------------------
-# PATCH /api/workloads/{workload_id}/mapping — persist manual override
-# ---------------------------------------------------------------------------
-
-@router.patch("/{workload_id}/mapping", response_model=WorkloadResponse)
-async def override_workload_mapping(
-    workload_id: str,
-    override: MappingOverride,
-    user: dict = Depends(get_current_user),
-    db: AsyncSession = Depends(get_db),
-) -> WorkloadResponse:
-    """Manually override the AI-recommended subscription for a workload."""
-    if db is None:
-        raise HTTPException(status_code=404, detail="Database not configured")
-
-    try:
-        result = await db.execute(
-            select(Workload).where(Workload.id == workload_id)
-        )
-        workload = result.scalar_one_or_none()
-        if not workload:
-            raise HTTPException(status_code=404, detail="Workload not found")
-
-        tenant_id = user.get("tid", user.get("tenant_id", "dev-tenant"))
-        proj_result = await db.execute(
-            select(Project).where(
-                Project.id == workload.project_id, Project.tenant_id == tenant_id
-            )
-        )
-        if proj_result.scalar_one_or_none() is None:
-            raise HTTPException(status_code=403, detail="Project not found or access denied")
-
-        workload.target_subscription_id = override.target_subscription_id
-        workload.mapping_reasoning = override.reasoning
-        workload.updated_at = datetime.now(timezone.utc)
-
-        await db.flush()
-        logger.info("Overrode mapping for workload %s → %s", workload_id, override.target_subscription_id)
-        return _to_response(workload)
-
-    except HTTPException:
-        raise
-    except Exception as exc:
-        logger.exception("Failed to override mapping for workload %s", workload_id)
         raise HTTPException(status_code=500, detail=str(exc)) from exc
 
 

--- a/backend/app/api/routes/workloads.py
+++ b/backend/app/api/routes/workloads.py
@@ -476,7 +476,13 @@ async def _get_project_workloads(
 
 
 def _workloads_to_graph(workloads: list[Workload]) -> DependencyGraph:
-    """Build a DependencyGraph from a list of ORM Workload objects."""
+    """Build a DependencyGraph from a list of ORM Workload objects.
+
+    Edge convention: ``source → target`` means *source is a prerequisite
+    for target* (source must be migrated before target).  If workload X has
+    ``dependencies=["Y"]`` the edge is ``Y → X`` because Y must be ready
+    before X can be migrated.
+    """
     summaries = [
         WorkloadSummary(
             id=w.id,
@@ -492,7 +498,10 @@ def _workloads_to_graph(workloads: list[Workload]) -> DependencyGraph:
     for w in workloads:
         for dep_id in w.dependencies or []:
             if dep_id in node_ids:
-                edges.append(DependencyEdge(source=w.id, target=dep_id))
+                # Edge: dep_id → w.id means "dep_id must be migrated before w.id"
+                # (consistent with the "source precedes target" convention used
+                #  throughout DependencyAnalyzer — source is the prerequisite).
+                edges.append(DependencyEdge(source=dep_id, target=w.id))
     return _analyzer.get_dependency_graph(summaries, edges)
 
 

--- a/backend/app/api/routes/workloads.py
+++ b/backend/app/api/routes/workloads.py
@@ -616,6 +616,9 @@ async def add_dependency(
             workload.dependencies = deps
             workload.updated_at = datetime.now(timezone.utc)
             await db.flush()
+        # NOTE: body.dependency_type is accepted for future extensibility but is
+        # not yet persisted — dependencies are currently stored as a plain list
+        # of workload IDs.  Persisting dependency types is tracked as a follow-up.
 
         return _to_response(workload)
     except HTTPException:

--- a/backend/app/schemas/dependency.py
+++ b/backend/app/schemas/dependency.py
@@ -1,0 +1,47 @@
+"""Pydantic schemas for dependency graph API."""
+
+from pydantic import BaseModel, Field
+
+
+class WorkloadSummary(BaseModel):
+    """Minimal workload info used in the dependency graph."""
+
+    id: str
+    name: str
+    criticality: str
+    migration_strategy: str
+    project_id: str
+
+
+class DependencyEdge(BaseModel):
+    """A directed edge in the dependency graph."""
+
+    source: str
+    target: str
+    dependency_type: str = "depends_on"
+
+
+class DependencyGraph(BaseModel):
+    """Full dependency graph for a project."""
+
+    nodes: list[WorkloadSummary] = Field(default_factory=list)
+    edges: list[DependencyEdge] = Field(default_factory=list)
+    circular_dependencies: list[list[str]] = Field(default_factory=list)
+    migration_groups: list[list[str]] = Field(default_factory=list)
+
+
+class AddDependencyRequest(BaseModel):
+    """Request body for adding a dependency link."""
+
+    target_workload_id: str
+    dependency_type: str = "depends_on"
+
+
+class MigrationOrderResponse(BaseModel):
+    """Suggested migration order with groups and warnings."""
+
+    order: list[str] = Field(default_factory=list)
+    migration_groups: list[list[str]] = Field(default_factory=list)
+    circular_dependencies: list[list[str]] = Field(default_factory=list)
+    has_circular: bool = False
+    workload_names: dict[str, str] = Field(default_factory=dict)

--- a/backend/app/services/dependency_analyzer.py
+++ b/backend/app/services/dependency_analyzer.py
@@ -1,0 +1,162 @@
+"""Dependency graph analysis service — graph algorithms using only stdlib."""
+
+import logging
+from collections import defaultdict, deque
+
+from app.schemas.dependency import (
+    DependencyEdge,
+    DependencyGraph,
+    WorkloadSummary,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class DependencyAnalyzer:
+    """Builds and analyzes workload dependency graphs."""
+
+    def get_dependency_graph(
+        self, workloads: list[WorkloadSummary], edges: list[DependencyEdge] | None = None
+    ) -> DependencyGraph:
+        """Build a dependency graph from workloads.
+
+        Edges are derived from each workload's ``dependencies`` field
+        (list of workload IDs) if *edges* is not provided explicitly.
+        When *edges* is provided it is used as-is and no additional edges
+        are inferred from workload objects.
+        """
+        if edges is None:
+            edges = []
+
+        graph = DependencyGraph(
+            nodes=list(workloads),
+            edges=list(edges),
+        )
+
+        circular = self.find_circular_dependencies(graph)
+        groups = self.find_migration_groups(graph)
+        graph.circular_dependencies = circular
+        graph.migration_groups = groups
+        return graph
+
+    # ------------------------------------------------------------------
+    # Graph algorithm helpers
+    # ------------------------------------------------------------------
+
+    def _build_adjacency(
+        self, graph: DependencyGraph
+    ) -> tuple[dict[str, list[str]], set[str]]:
+        """Return (adjacency_list, all_node_ids)."""
+        node_ids = {n.id for n in graph.nodes}
+        adj: dict[str, list[str]] = defaultdict(list)
+        for edge in graph.edges:
+            if edge.source in node_ids and edge.target in node_ids:
+                adj[edge.source].append(edge.target)
+        return dict(adj), node_ids
+
+    def find_circular_dependencies(self, graph: DependencyGraph) -> list[list[str]]:
+        """Return a list of cycles using DFS (Johnson's algorithm simplified).
+
+        Each cycle is represented as an ordered list of workload IDs.
+        """
+        adj, node_ids = self._build_adjacency(graph)
+        cycles: list[list[str]] = []
+        visited: set[str] = set()
+        rec_stack: set[str] = set()
+        path: list[str] = []
+
+        def dfs(node: str) -> None:
+            visited.add(node)
+            rec_stack.add(node)
+            path.append(node)
+
+            for neighbour in adj.get(node, []):
+                if neighbour not in visited:
+                    dfs(neighbour)
+                elif neighbour in rec_stack:
+                    # Found a cycle — extract the loop portion
+                    idx = path.index(neighbour)
+                    cycle = path[idx:]
+                    # Normalise: start from the smallest ID to deduplicate
+                    min_idx = cycle.index(min(cycle))
+                    normalised = cycle[min_idx:] + cycle[:min_idx]
+                    if normalised not in cycles:
+                        cycles.append(normalised)
+
+            path.pop()
+            rec_stack.discard(node)
+
+        for node in sorted(node_ids):
+            if node not in visited:
+                dfs(node)
+
+        logger.debug("Found %d circular dependency cycle(s)", len(cycles))
+        return cycles
+
+    def find_migration_groups(self, graph: DependencyGraph) -> list[list[str]]:
+        """Return connected components (undirected) that must move together."""
+        node_ids = {n.id for n in graph.nodes}
+        # Build undirected adjacency
+        neighbours: dict[str, set[str]] = {nid: set() for nid in node_ids}
+        for edge in graph.edges:
+            if edge.source in node_ids and edge.target in node_ids:
+                neighbours[edge.source].add(edge.target)
+                neighbours[edge.target].add(edge.source)
+
+        visited: set[str] = set()
+        groups: list[list[str]] = []
+
+        for start in sorted(node_ids):
+            if start in visited:
+                continue
+            # BFS
+            component: list[str] = []
+            queue: deque[str] = deque([start])
+            visited.add(start)
+            while queue:
+                current = queue.popleft()
+                component.append(current)
+                for nb in sorted(neighbours.get(current, set())):
+                    if nb not in visited:
+                        visited.add(nb)
+                        queue.append(nb)
+            groups.append(sorted(component))
+
+        logger.debug("Found %d migration group(s)", len(groups))
+        return groups
+
+    def suggest_migration_order(self, graph: DependencyGraph) -> list[str]:
+        """Return a topological ordering (Kahn's algorithm).
+
+        Raises ``ValueError`` if the graph contains circular dependencies.
+        """
+        cycles = self.find_circular_dependencies(graph)
+        if cycles:
+            cycle_ids = [" -> ".join(c) for c in cycles]
+            raise ValueError(
+                "Cannot suggest migration order: circular dependencies detected: "
+                + "; ".join(cycle_ids)
+            )
+
+        adj, node_ids = self._build_adjacency(graph)
+
+        # Compute in-degrees
+        in_degree: dict[str, int] = {nid: 0 for nid in node_ids}
+        for node in node_ids:
+            for neighbour in adj.get(node, []):
+                in_degree[neighbour] = in_degree.get(neighbour, 0) + 1
+
+        # Initialise queue with zero-in-degree nodes (sorted for determinism)
+        queue: deque[str] = deque(sorted(n for n, d in in_degree.items() if d == 0))
+        order: list[str] = []
+
+        while queue:
+            node = queue.popleft()
+            order.append(node)
+            for neighbour in sorted(adj.get(node, [])):
+                in_degree[neighbour] -= 1
+                if in_degree[neighbour] == 0:
+                    queue.append(neighbour)
+
+        logger.debug("Topological order has %d nodes", len(order))
+        return order

--- a/backend/app/services/dependency_analyzer.py
+++ b/backend/app/services/dependency_analyzer.py
@@ -135,6 +135,9 @@ class DependencyAnalyzer:
     def suggest_migration_order(self, graph: DependencyGraph) -> list[str]:
         """Return a topological ordering (Kahn's algorithm).
 
+        Edge convention: ``source → target`` means *source is a prerequisite
+        for target* — source appears before target in the returned order.
+
         Raises ``ValueError`` if the graph contains circular dependencies.
         """
         cycles = self.find_circular_dependencies(graph)

--- a/backend/app/services/dependency_analyzer.py
+++ b/backend/app/services/dependency_analyzer.py
@@ -18,12 +18,19 @@ class DependencyAnalyzer:
     def get_dependency_graph(
         self, workloads: list[WorkloadSummary], edges: list[DependencyEdge] | None = None
     ) -> DependencyGraph:
-        """Build a dependency graph from workloads.
+        """Build and analyse a dependency graph.
 
-        Edges are derived from each workload's ``dependencies`` field
-        (list of workload IDs) if *edges* is not provided explicitly.
-        When *edges* is provided it is used as-is and no additional edges
-        are inferred from workload objects.
+        Args:
+            workloads: Flat list of workload summaries to use as graph nodes.
+            edges: Explicit list of directed edges.  When *None* (or an empty
+                list) the graph contains nodes only and no edges — callers are
+                responsible for building edges from workload data before
+                calling this method (see ``_workloads_to_graph`` in
+                ``app.api.routes.workloads``).
+
+        Returns:
+            A :class:`DependencyGraph` with nodes, edges, detected circular
+            dependencies, and migration groups already populated.
         """
         if edges is None:
             edges = []

--- a/backend/tests/test_dependency.py
+++ b/backend/tests/test_dependency.py
@@ -1,0 +1,643 @@
+"""Tests for dependency graph analysis — service and API routes."""
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+
+from app.main import app
+from app.models import Base
+from app.schemas.dependency import DependencyEdge, DependencyGraph, WorkloadSummary
+from app.services.dependency_analyzer import DependencyAnalyzer
+from tests.conftest import SQLITE_TEST_URL
+
+client = TestClient(app)
+
+# ---------------------------------------------------------------------------
+# DependencyAnalyzer unit tests
+# ---------------------------------------------------------------------------
+
+
+def _make_summary(wid: str) -> WorkloadSummary:
+    return WorkloadSummary(
+        id=wid,
+        name=f"Workload-{wid}",
+        criticality="standard",
+        migration_strategy="rehost",
+        project_id="proj-1",
+    )
+
+
+def _make_graph(
+    ids: list[str],
+    edge_pairs: list[tuple[str, str]],
+) -> DependencyGraph:
+    nodes = [_make_summary(i) for i in ids]
+    edges = [DependencyEdge(source=s, target=t) for s, t in edge_pairs]
+    return DependencyGraph(nodes=nodes, edges=edges)
+
+
+class TestDependencyAnalyzerService:
+    def setup_method(self):
+        self.analyzer = DependencyAnalyzer()
+
+    # --- get_dependency_graph ---
+
+    def test_get_dependency_graph_empty(self):
+        graph = self.analyzer.get_dependency_graph([])
+        assert graph.nodes == []
+        assert graph.edges == []
+        assert graph.circular_dependencies == []
+        assert graph.migration_groups == []
+
+    def test_get_dependency_graph_no_edges(self):
+        nodes = [_make_summary("a"), _make_summary("b")]
+        graph = self.analyzer.get_dependency_graph(nodes, [])
+        assert len(graph.nodes) == 2
+        assert graph.edges == []
+        assert graph.circular_dependencies == []
+        # Each node is its own group
+        assert sorted(sorted(g) for g in graph.migration_groups) == [["a"], ["b"]]
+
+    def test_get_dependency_graph_with_edges(self):
+        nodes = [_make_summary("a"), _make_summary("b"), _make_summary("c")]
+        edges = [
+            DependencyEdge(source="a", target="b"),
+            DependencyEdge(source="b", target="c"),
+        ]
+        graph = self.analyzer.get_dependency_graph(nodes, edges)
+        assert len(graph.edges) == 2
+        assert graph.circular_dependencies == []
+        # All connected in one group
+        assert len(graph.migration_groups) == 1
+        assert sorted(graph.migration_groups[0]) == ["a", "b", "c"]
+
+    def test_get_dependency_graph_ignores_unknown_target(self):
+        nodes = [_make_summary("a")]
+        edges = [DependencyEdge(source="a", target="unknown-id")]
+        graph = self.analyzer.get_dependency_graph(nodes, edges)
+        # Edge references unknown node — should be ignored when building adj
+        assert graph.circular_dependencies == []
+
+    # --- find_circular_dependencies ---
+
+    def test_no_cycles_linear(self):
+        graph = _make_graph(["a", "b", "c"], [("a", "b"), ("b", "c")])
+        cycles = self.analyzer.find_circular_dependencies(graph)
+        assert cycles == []
+
+    def test_simple_cycle(self):
+        graph = _make_graph(["a", "b"], [("a", "b"), ("b", "a")])
+        cycles = self.analyzer.find_circular_dependencies(graph)
+        assert len(cycles) == 1
+        assert set(cycles[0]) == {"a", "b"}
+
+    def test_three_node_cycle(self):
+        graph = _make_graph(
+            ["a", "b", "c"],
+            [("a", "b"), ("b", "c"), ("c", "a")],
+        )
+        cycles = self.analyzer.find_circular_dependencies(graph)
+        assert len(cycles) == 1
+        assert set(cycles[0]) == {"a", "b", "c"}
+
+    def test_self_loop_cycle(self):
+        graph = _make_graph(["a"], [("a", "a")])
+        cycles = self.analyzer.find_circular_dependencies(graph)
+        assert len(cycles) == 1
+
+    def test_multiple_separate_cycles(self):
+        graph = _make_graph(
+            ["a", "b", "c", "d"],
+            [("a", "b"), ("b", "a"), ("c", "d"), ("d", "c")],
+        )
+        cycles = self.analyzer.find_circular_dependencies(graph)
+        assert len(cycles) == 2
+
+    # --- find_migration_groups ---
+
+    def test_migration_groups_disconnected(self):
+        graph = _make_graph(["a", "b", "c"], [])
+        groups = self.analyzer.find_migration_groups(graph)
+        assert len(groups) == 3
+
+    def test_migration_groups_connected(self):
+        graph = _make_graph(["a", "b", "c"], [("a", "b"), ("b", "c")])
+        groups = self.analyzer.find_migration_groups(graph)
+        assert len(groups) == 1
+        assert sorted(groups[0]) == ["a", "b", "c"]
+
+    def test_migration_groups_partial(self):
+        graph = _make_graph(["a", "b", "c", "d"], [("a", "b")])
+        groups = self.analyzer.find_migration_groups(graph)
+        assert len(groups) == 3
+
+    # --- suggest_migration_order ---
+
+    def test_topological_order_linear(self):
+        graph = _make_graph(["a", "b", "c"], [("a", "b"), ("b", "c")])
+        order = self.analyzer.suggest_migration_order(graph)
+        assert order.index("a") < order.index("b")
+        assert order.index("b") < order.index("c")
+
+    def test_topological_order_no_edges(self):
+        graph = _make_graph(["a", "b", "c"], [])
+        order = self.analyzer.suggest_migration_order(graph)
+        assert set(order) == {"a", "b", "c"}
+
+    def test_topological_order_raises_on_cycle(self):
+        graph = _make_graph(["a", "b"], [("a", "b"), ("b", "a")])
+        with pytest.raises(ValueError, match="circular"):
+            self.analyzer.suggest_migration_order(graph)
+
+    def test_topological_order_diamond(self):
+        # a → b, a → c, b → d, c → d
+        graph = _make_graph(
+            ["a", "b", "c", "d"],
+            [("a", "b"), ("a", "c"), ("b", "d"), ("c", "d")],
+        )
+        order = self.analyzer.suggest_migration_order(graph)
+        assert order.index("a") < order.index("b")
+        assert order.index("a") < order.index("c")
+        assert order.index("b") < order.index("d")
+        assert order.index("c") < order.index("d")
+
+
+# ---------------------------------------------------------------------------
+# API route tests — no-DB mode
+# ---------------------------------------------------------------------------
+
+
+class TestDependencyRoutesNoDb:
+    def test_get_dependency_graph_no_db(self):
+        r = client.get("/api/workloads/dependency-graph?project_id=test-proj")
+        assert r.status_code == 200
+        data = r.json()
+        assert "nodes" in data
+        assert "edges" in data
+
+    def test_get_migration_order_no_db(self):
+        r = client.get("/api/workloads/migration-order?project_id=test-proj")
+        assert r.status_code == 200
+        data = r.json()
+        assert "order" in data
+        assert "migration_groups" in data
+        assert "circular_dependencies" in data
+        assert "has_circular" in data
+
+    def test_add_dependency_no_db(self):
+        r = client.post(
+            "/api/workloads/wl-1/dependencies",
+            json={"target_workload_id": "wl-2"},
+        )
+        assert r.status_code == 503
+
+    def test_remove_dependency_no_db(self):
+        r = client.delete("/api/workloads/wl-1/dependencies/wl-2")
+        assert r.status_code == 503
+
+    def test_dependency_graph_missing_project_id(self):
+        r = client.get("/api/workloads/dependency-graph")
+        assert r.status_code == 422
+
+    def test_migration_order_missing_project_id(self):
+        r = client.get("/api/workloads/migration-order")
+        assert r.status_code == 422
+
+
+# ---------------------------------------------------------------------------
+# API route tests — with real SQLite DB
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+async def db_session():
+    engine = create_async_engine(SQLITE_TEST_URL, echo=False)
+    async with engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+    factory = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    async with factory() as session:
+        yield session
+    await engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_dependency_graph_db_path(db_session):
+    """Test GET /dependency-graph with a real DB session."""
+    from app.api.routes.workloads import get_dependency_graph
+    from app.models.project import Project
+    from app.models.workload import Workload
+    from datetime import datetime, timezone
+
+    now = datetime.now(timezone.utc)
+    proj = Project(
+        id="dep-proj-1",
+        name="Dep Test Project",
+        tenant_id="dev-tenant",
+        created_at=now,
+        updated_at=now,
+    )
+    db_session.add(proj)
+    wl_a = Workload(
+        id="dep-wl-a",
+        project_id="dep-proj-1",
+        name="WL A",
+        criticality="standard",
+        migration_strategy="rehost",
+        dependencies=["dep-wl-b"],
+        created_at=now,
+        updated_at=now,
+    )
+    wl_b = Workload(
+        id="dep-wl-b",
+        project_id="dep-proj-1",
+        name="WL B",
+        criticality="standard",
+        migration_strategy="rehost",
+        dependencies=[],
+        created_at=now,
+        updated_at=now,
+    )
+    db_session.add(wl_a)
+    db_session.add(wl_b)
+    await db_session.flush()
+
+    graph = await get_dependency_graph(
+        project_id="dep-proj-1",
+        user={"sub": "dev", "tid": "dev-tenant"},
+        db=db_session,
+    )
+    assert len(graph.nodes) == 2
+    assert len(graph.edges) == 1
+    edge = graph.edges[0]
+    assert edge.source == "dep-wl-a"
+    assert edge.target == "dep-wl-b"
+
+
+@pytest.mark.asyncio
+async def test_add_and_remove_dependency_db(db_session):
+    """Test POST and DELETE /dependencies with a real DB session."""
+    from app.api.routes.workloads import add_dependency, remove_dependency
+    from app.models.project import Project
+    from app.models.workload import Workload
+    from app.schemas.dependency import AddDependencyRequest
+    from datetime import datetime, timezone
+
+    now = datetime.now(timezone.utc)
+    proj = Project(
+        id="dep-proj-2",
+        name="Dep Test 2",
+        tenant_id="dev-tenant",
+        created_at=now,
+        updated_at=now,
+    )
+    db_session.add(proj)
+    wl1 = Workload(
+        id="dep-wl-1",
+        project_id="dep-proj-2",
+        name="WL 1",
+        criticality="standard",
+        migration_strategy="rehost",
+        dependencies=[],
+        created_at=now,
+        updated_at=now,
+    )
+    wl2 = Workload(
+        id="dep-wl-2",
+        project_id="dep-proj-2",
+        name="WL 2",
+        criticality="standard",
+        migration_strategy="rehost",
+        dependencies=[],
+        created_at=now,
+        updated_at=now,
+    )
+    db_session.add(wl1)
+    db_session.add(wl2)
+    await db_session.flush()
+
+    user = {"sub": "dev", "tid": "dev-tenant"}
+
+    # Add dependency
+    resp = await add_dependency(
+        workload_id="dep-wl-1",
+        body=AddDependencyRequest(target_workload_id="dep-wl-2"),
+        user=user,
+        db=db_session,
+    )
+    assert "dep-wl-2" in (resp.dependencies or [])
+
+    # Adding same dependency again is idempotent
+    resp2 = await add_dependency(
+        workload_id="dep-wl-1",
+        body=AddDependencyRequest(target_workload_id="dep-wl-2"),
+        user=user,
+        db=db_session,
+    )
+    assert resp2.dependencies.count("dep-wl-2") == 1
+
+    # Remove dependency
+    resp3 = await remove_dependency(
+        workload_id="dep-wl-1",
+        target_id="dep-wl-2",
+        user=user,
+        db=db_session,
+    )
+    assert "dep-wl-2" not in (resp3.dependencies or [])
+
+    # Removing non-existent dependency is safe
+    resp4 = await remove_dependency(
+        workload_id="dep-wl-1",
+        target_id="dep-wl-2",
+        user=user,
+        db=db_session,
+    )
+    assert resp4 is not None
+
+
+@pytest.mark.asyncio
+async def test_migration_order_db_path(db_session):
+    """Test GET /migration-order with a real DB session."""
+    from app.api.routes.workloads import get_migration_order
+    from app.models.project import Project
+    from app.models.workload import Workload
+    from datetime import datetime, timezone
+
+    now = datetime.now(timezone.utc)
+    proj = Project(
+        id="dep-proj-3",
+        name="Migration Order Test",
+        tenant_id="dev-tenant",
+        created_at=now,
+        updated_at=now,
+    )
+    db_session.add(proj)
+    wl_x = Workload(
+        id="dep-wl-x",
+        project_id="dep-proj-3",
+        name="WL X",
+        criticality="standard",
+        migration_strategy="rehost",
+        dependencies=["dep-wl-y"],
+        created_at=now,
+        updated_at=now,
+    )
+    wl_y = Workload(
+        id="dep-wl-y",
+        project_id="dep-proj-3",
+        name="WL Y",
+        criticality="standard",
+        migration_strategy="rehost",
+        dependencies=[],
+        created_at=now,
+        updated_at=now,
+    )
+    db_session.add(wl_x)
+    db_session.add(wl_y)
+    await db_session.flush()
+
+    result = await get_migration_order(
+        project_id="dep-proj-3",
+        user={"sub": "dev", "tid": "dev-tenant"},
+        db=db_session,
+    )
+    assert result.has_circular is False
+    assert "dep-wl-x" in result.order
+    assert "dep-wl-y" in result.order
+    assert result.order.index("dep-wl-y") < result.order.index("dep-wl-x")
+
+
+@pytest.mark.asyncio
+async def test_migration_order_with_cycle(db_session):
+    """Test migration-order returns has_circular when cycles exist."""
+    from app.api.routes.workloads import get_migration_order
+    from app.models.project import Project
+    from app.models.workload import Workload
+    from datetime import datetime, timezone
+
+    now = datetime.now(timezone.utc)
+    proj = Project(
+        id="dep-proj-4",
+        name="Circular Test",
+        tenant_id="dev-tenant",
+        created_at=now,
+        updated_at=now,
+    )
+    db_session.add(proj)
+    wl_p = Workload(
+        id="dep-wl-p",
+        project_id="dep-proj-4",
+        name="WL P",
+        criticality="standard",
+        migration_strategy="rehost",
+        dependencies=["dep-wl-q"],
+        created_at=now,
+        updated_at=now,
+    )
+    wl_q = Workload(
+        id="dep-wl-q",
+        project_id="dep-proj-4",
+        name="WL Q",
+        criticality="standard",
+        migration_strategy="rehost",
+        dependencies=["dep-wl-p"],
+        created_at=now,
+        updated_at=now,
+    )
+    db_session.add(wl_p)
+    db_session.add(wl_q)
+    await db_session.flush()
+
+    result = await get_migration_order(
+        project_id="dep-proj-4",
+        user={"sub": "dev", "tid": "dev-tenant"},
+        db=db_session,
+    )
+    assert result.has_circular is True
+    assert len(result.circular_dependencies) > 0
+
+
+@pytest.mark.asyncio
+async def test_add_dependency_404_target(db_session):
+    """Test adding a dependency to a non-existent target raises 404."""
+    from fastapi import HTTPException
+    from app.api.routes.workloads import add_dependency
+    from app.models.project import Project
+    from app.models.workload import Workload
+    from app.schemas.dependency import AddDependencyRequest
+    from datetime import datetime, timezone
+
+    now = datetime.now(timezone.utc)
+    proj = Project(
+        id="dep-proj-5",
+        name="404 Test",
+        tenant_id="dev-tenant",
+        created_at=now,
+        updated_at=now,
+    )
+    db_session.add(proj)
+    wl = Workload(
+        id="dep-wl-only",
+        project_id="dep-proj-5",
+        name="Solo WL",
+        criticality="standard",
+        migration_strategy="rehost",
+        dependencies=[],
+        created_at=now,
+        updated_at=now,
+    )
+    db_session.add(wl)
+    await db_session.flush()
+
+    with pytest.raises(HTTPException) as exc_info:
+        await add_dependency(
+            workload_id="dep-wl-only",
+            body=AddDependencyRequest(target_workload_id="nonexistent"),
+            user={"sub": "dev", "tid": "dev-tenant"},
+            db=db_session,
+        )
+    assert exc_info.value.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# Helper function tests — test _workloads_to_graph directly (no DB needed)
+# ---------------------------------------------------------------------------
+
+
+def test_workloads_to_graph_empty():
+    """_workloads_to_graph returns an empty graph for an empty list."""
+    from app.api.routes.workloads import _workloads_to_graph
+    graph = _workloads_to_graph([])
+    assert graph.nodes == []
+    assert graph.edges == []
+
+
+def test_workloads_to_graph_no_dependencies():
+    """_workloads_to_graph with workloads that have no dependencies."""
+    from app.api.routes.workloads import _workloads_to_graph
+    from app.models.workload import Workload
+    from datetime import datetime, timezone
+
+    now = datetime.now(timezone.utc)
+    wl = Workload(
+        id="helper-wl-1",
+        project_id="helper-proj",
+        name="Helper WL",
+        criticality="standard",
+        migration_strategy="rehost",
+        dependencies=[],
+        created_at=now,
+        updated_at=now,
+    )
+    graph = _workloads_to_graph([wl])
+    assert len(graph.nodes) == 1
+    assert graph.nodes[0].id == "helper-wl-1"
+    assert graph.edges == []
+
+
+def test_workloads_to_graph_with_dependencies():
+    """_workloads_to_graph creates edges from the dependencies field."""
+    from app.api.routes.workloads import _workloads_to_graph
+    from app.models.workload import Workload
+    from datetime import datetime, timezone
+
+    now = datetime.now(timezone.utc)
+    wl_a = Workload(
+        id="helper-wl-a",
+        project_id="helper-proj",
+        name="WL A",
+        criticality="standard",
+        migration_strategy="rehost",
+        dependencies=["helper-wl-b"],
+        created_at=now,
+        updated_at=now,
+    )
+    wl_b = Workload(
+        id="helper-wl-b",
+        project_id="helper-proj",
+        name="WL B",
+        criticality="standard",
+        migration_strategy="rehost",
+        dependencies=[],
+        created_at=now,
+        updated_at=now,
+    )
+    graph = _workloads_to_graph([wl_a, wl_b])
+    assert len(graph.nodes) == 2
+    assert len(graph.edges) == 1
+    assert graph.edges[0].source == "helper-wl-a"
+    assert graph.edges[0].target == "helper-wl-b"
+
+
+def test_workloads_to_graph_ignores_external_dependencies():
+    """_workloads_to_graph ignores dependencies that reference unknown IDs."""
+    from app.api.routes.workloads import _workloads_to_graph
+    from app.models.workload import Workload
+    from datetime import datetime, timezone
+
+    now = datetime.now(timezone.utc)
+    wl = Workload(
+        id="helper-wl-x",
+        project_id="helper-proj",
+        name="WL X",
+        criticality="standard",
+        migration_strategy="rehost",
+        dependencies=["nonexistent-id"],
+        created_at=now,
+        updated_at=now,
+    )
+    graph = _workloads_to_graph([wl])
+    # Edge not created — target doesn't exist in node set
+    assert graph.edges == []
+
+
+def test_workloads_to_graph_with_circular_dependencies():
+    """_workloads_to_graph detects and reports circular dependencies."""
+    from app.api.routes.workloads import _workloads_to_graph
+    from app.models.workload import Workload
+    from datetime import datetime, timezone
+
+    now = datetime.now(timezone.utc)
+    wl_p = Workload(
+        id="circ-wl-p",
+        project_id="helper-proj",
+        name="P",
+        criticality="standard",
+        migration_strategy="rehost",
+        dependencies=["circ-wl-q"],
+        created_at=now,
+        updated_at=now,
+    )
+    wl_q = Workload(
+        id="circ-wl-q",
+        project_id="helper-proj",
+        name="Q",
+        criticality="standard",
+        migration_strategy="rehost",
+        dependencies=["circ-wl-p"],
+        created_at=now,
+        updated_at=now,
+    )
+    graph = _workloads_to_graph([wl_p, wl_q])
+    assert len(graph.circular_dependencies) == 1
+
+
+def test_workloads_to_graph_none_dependencies():
+    """_workloads_to_graph handles None dependencies gracefully."""
+    from app.api.routes.workloads import _workloads_to_graph
+    from app.models.workload import Workload
+    from datetime import datetime, timezone
+
+    now = datetime.now(timezone.utc)
+    wl = Workload(
+        id="none-dep-wl",
+        project_id="helper-proj",
+        name="WL None Deps",
+        criticality="mission-critical",
+        migration_strategy="replace",
+        dependencies=None,
+        created_at=now,
+        updated_at=now,
+    )
+    graph = _workloads_to_graph([wl])
+    assert len(graph.nodes) == 1
+    assert graph.edges == []

--- a/backend/tests/test_dependency.py
+++ b/backend/tests/test_dependency.py
@@ -220,23 +220,58 @@ async def db_session():
     await engine.dispose()
 
 
+async def _seed_tenant_user_project(
+    db_session: AsyncSession,
+    project_id: str,
+    project_name: str,
+) -> None:
+    """Create a Tenant, User, and Project row to satisfy FK constraints."""
+    from app.models.project import Project
+    from app.models.tenant import Tenant
+    from app.models.user import User
+    from datetime import datetime, timezone
+
+    now = datetime.now(timezone.utc)
+    tenant = Tenant(
+        id="dep-tenant",
+        name="Dep Tenant",
+        created_at=now,
+        updated_at=now,
+    )
+    user = User(
+        id="dep-user",
+        entra_object_id="dep-oid",
+        email="dep@test.com",
+        display_name="Dep User",
+        tenant_id="dep-tenant",
+        created_at=now,
+        updated_at=now,
+    )
+    project = Project(
+        id=project_id,
+        name=project_name,
+        tenant_id="dep-tenant",
+        created_by="dep-user",
+        created_at=now,
+        updated_at=now,
+    )
+    # Use merge to avoid duplicate PK errors across tests sharing the same engine
+    await db_session.merge(tenant)
+    await db_session.merge(user)
+    await db_session.merge(project)
+    await db_session.flush()
+
+
 @pytest.mark.asyncio
 async def test_dependency_graph_db_path(db_session):
     """Test GET /dependency-graph with a real DB session."""
     from app.api.routes.workloads import get_dependency_graph
-    from app.models.project import Project
     from app.models.workload import Workload
     from datetime import datetime, timezone
 
     now = datetime.now(timezone.utc)
-    proj = Project(
-        id="dep-proj-1",
-        name="Dep Test Project",
-        tenant_id="dev-tenant",
-        created_at=now,
-        updated_at=now,
-    )
-    db_session.add(proj)
+    await _seed_tenant_user_project(db_session, "dep-proj-1", "Dep Test Project")
+
     wl_a = Workload(
         id="dep-wl-a",
         project_id="dep-proj-1",
@@ -263,7 +298,7 @@ async def test_dependency_graph_db_path(db_session):
 
     graph = await get_dependency_graph(
         project_id="dep-proj-1",
-        user={"sub": "dev", "tid": "dev-tenant"},
+        user={"sub": "dep-user", "tid": "dep-tenant"},
         db=db_session,
     )
     assert len(graph.nodes) == 2
@@ -277,20 +312,13 @@ async def test_dependency_graph_db_path(db_session):
 async def test_add_and_remove_dependency_db(db_session):
     """Test POST and DELETE /dependencies with a real DB session."""
     from app.api.routes.workloads import add_dependency, remove_dependency
-    from app.models.project import Project
     from app.models.workload import Workload
     from app.schemas.dependency import AddDependencyRequest
     from datetime import datetime, timezone
 
     now = datetime.now(timezone.utc)
-    proj = Project(
-        id="dep-proj-2",
-        name="Dep Test 2",
-        tenant_id="dev-tenant",
-        created_at=now,
-        updated_at=now,
-    )
-    db_session.add(proj)
+    await _seed_tenant_user_project(db_session, "dep-proj-2", "Dep Test 2")
+
     wl1 = Workload(
         id="dep-wl-1",
         project_id="dep-proj-2",
@@ -315,7 +343,7 @@ async def test_add_and_remove_dependency_db(db_session):
     db_session.add(wl2)
     await db_session.flush()
 
-    user = {"sub": "dev", "tid": "dev-tenant"}
+    user = {"sub": "dep-user", "tid": "dep-tenant"}
 
     # Add dependency
     resp = await add_dependency(
@@ -358,19 +386,12 @@ async def test_add_and_remove_dependency_db(db_session):
 async def test_migration_order_db_path(db_session):
     """Test GET /migration-order with a real DB session."""
     from app.api.routes.workloads import get_migration_order
-    from app.models.project import Project
     from app.models.workload import Workload
     from datetime import datetime, timezone
 
     now = datetime.now(timezone.utc)
-    proj = Project(
-        id="dep-proj-3",
-        name="Migration Order Test",
-        tenant_id="dev-tenant",
-        created_at=now,
-        updated_at=now,
-    )
-    db_session.add(proj)
+    await _seed_tenant_user_project(db_session, "dep-proj-3", "Migration Order Test")
+
     wl_x = Workload(
         id="dep-wl-x",
         project_id="dep-proj-3",
@@ -397,7 +418,7 @@ async def test_migration_order_db_path(db_session):
 
     result = await get_migration_order(
         project_id="dep-proj-3",
-        user={"sub": "dev", "tid": "dev-tenant"},
+        user={"sub": "dep-user", "tid": "dep-tenant"},
         db=db_session,
     )
     assert result.has_circular is False
@@ -410,19 +431,12 @@ async def test_migration_order_db_path(db_session):
 async def test_migration_order_with_cycle(db_session):
     """Test migration-order returns has_circular when cycles exist."""
     from app.api.routes.workloads import get_migration_order
-    from app.models.project import Project
     from app.models.workload import Workload
     from datetime import datetime, timezone
 
     now = datetime.now(timezone.utc)
-    proj = Project(
-        id="dep-proj-4",
-        name="Circular Test",
-        tenant_id="dev-tenant",
-        created_at=now,
-        updated_at=now,
-    )
-    db_session.add(proj)
+    await _seed_tenant_user_project(db_session, "dep-proj-4", "Circular Test")
+
     wl_p = Workload(
         id="dep-wl-p",
         project_id="dep-proj-4",
@@ -449,7 +463,7 @@ async def test_migration_order_with_cycle(db_session):
 
     result = await get_migration_order(
         project_id="dep-proj-4",
-        user={"sub": "dev", "tid": "dev-tenant"},
+        user={"sub": "dep-user", "tid": "dep-tenant"},
         db=db_session,
     )
     assert result.has_circular is True
@@ -461,20 +475,13 @@ async def test_add_dependency_404_target(db_session):
     """Test adding a dependency to a non-existent target raises 404."""
     from fastapi import HTTPException
     from app.api.routes.workloads import add_dependency
-    from app.models.project import Project
     from app.models.workload import Workload
     from app.schemas.dependency import AddDependencyRequest
     from datetime import datetime, timezone
 
     now = datetime.now(timezone.utc)
-    proj = Project(
-        id="dep-proj-5",
-        name="404 Test",
-        tenant_id="dev-tenant",
-        created_at=now,
-        updated_at=now,
-    )
-    db_session.add(proj)
+    await _seed_tenant_user_project(db_session, "dep-proj-5", "404 Test")
+
     wl = Workload(
         id="dep-wl-only",
         project_id="dep-proj-5",
@@ -492,7 +499,7 @@ async def test_add_dependency_404_target(db_session):
         await add_dependency(
             workload_id="dep-wl-only",
             body=AddDependencyRequest(target_workload_id="nonexistent"),
-            user={"sub": "dev", "tid": "dev-tenant"},
+            user={"sub": "dep-user", "tid": "dep-tenant"},
             db=db_session,
         )
     assert exc_info.value.status_code == 404

--- a/backend/tests/test_dependency.py
+++ b/backend/tests/test_dependency.py
@@ -304,8 +304,9 @@ async def test_dependency_graph_db_path(db_session):
     assert len(graph.nodes) == 2
     assert len(graph.edges) == 1
     edge = graph.edges[0]
-    assert edge.source == "dep-wl-a"
-    assert edge.target == "dep-wl-b"
+    # wl_a depends on wl_b → edge is dep-wl-b → dep-wl-a (prerequisite first)
+    assert edge.source == "dep-wl-b"
+    assert edge.target == "dep-wl-a"
 
 
 @pytest.mark.asyncio
@@ -571,8 +572,9 @@ def test_workloads_to_graph_with_dependencies():
     graph = _workloads_to_graph([wl_a, wl_b])
     assert len(graph.nodes) == 2
     assert len(graph.edges) == 1
-    assert graph.edges[0].source == "helper-wl-a"
-    assert graph.edges[0].target == "helper-wl-b"
+    # wl_a depends on wl_b → edge is wl_b → wl_a (prerequisite first)
+    assert graph.edges[0].source == "helper-wl-b"
+    assert graph.edges[0].target == "helper-wl-a"
 
 
 def test_workloads_to_graph_ignores_external_dependencies():

--- a/frontend/src/components/migration/DependencyGraph.test.tsx
+++ b/frontend/src/components/migration/DependencyGraph.test.tsx
@@ -58,8 +58,7 @@ vi.mock("../../services/api", () => ({
 
 import { api } from "../../services/api";
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-const mockedApi = api as any as {
+const mockedApi = api as unknown as {
   workloads: {
     getDependencyGraph: ReturnType<typeof vi.fn>;
     getMigrationOrder: ReturnType<typeof vi.fn>;

--- a/frontend/src/components/migration/DependencyGraph.test.tsx
+++ b/frontend/src/components/migration/DependencyGraph.test.tsx
@@ -1,0 +1,248 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { FluentProvider, teamsLightTheme } from "@fluentui/react-components";
+import { MemoryRouter } from "react-router-dom";
+import DependencyGraph from "./DependencyGraph";
+import type { DependencyGraph as DependencyGraphData, MigrationOrderResponse } from "../../services/api";
+
+// ---------------------------------------------------------------------------
+// Mock api
+// ---------------------------------------------------------------------------
+
+const mockGraph: DependencyGraphData = {
+  nodes: [
+    { id: "wl-1", name: "Frontend App", criticality: "mission-critical", migration_strategy: "rehost", project_id: "proj-1" },
+    { id: "wl-2", name: "Backend API", criticality: "business-critical", migration_strategy: "refactor", project_id: "proj-1" },
+    { id: "wl-3", name: "Database", criticality: "standard", migration_strategy: "rehost", project_id: "proj-1" },
+  ],
+  edges: [
+    { source: "wl-1", target: "wl-2", dependency_type: "depends_on" },
+    { source: "wl-2", target: "wl-3", dependency_type: "depends_on" },
+  ],
+  circular_dependencies: [],
+  migration_groups: [["wl-1", "wl-2", "wl-3"]],
+};
+
+const mockGraphWithCycle: DependencyGraphData = {
+  nodes: [
+    { id: "wl-a", name: "Service A", criticality: "standard", migration_strategy: "rehost", project_id: "proj-1" },
+    { id: "wl-b", name: "Service B", criticality: "standard", migration_strategy: "rehost", project_id: "proj-1" },
+  ],
+  edges: [
+    { source: "wl-a", target: "wl-b", dependency_type: "depends_on" },
+    { source: "wl-b", target: "wl-a", dependency_type: "depends_on" },
+  ],
+  circular_dependencies: [["wl-a", "wl-b"]],
+  migration_groups: [["wl-a", "wl-b"]],
+};
+
+const mockMigrationOrder: MigrationOrderResponse = {
+  order: ["wl-3", "wl-2", "wl-1"],
+  migration_groups: [["wl-1", "wl-2", "wl-3"]],
+  circular_dependencies: [],
+  has_circular: false,
+  workload_names: { "wl-1": "Frontend App", "wl-2": "Backend API", "wl-3": "Database" },
+};
+
+vi.mock("../../services/api", () => ({
+  api: {
+    workloads: {
+      getDependencyGraph: vi.fn(),
+      getMigrationOrder: vi.fn(),
+      addDependency: vi.fn(),
+      removeDependency: vi.fn(),
+    },
+  },
+}));
+
+import { api } from "../../services/api";
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const mockedApi = api as any as {
+  workloads: {
+    getDependencyGraph: ReturnType<typeof vi.fn>;
+    getMigrationOrder: ReturnType<typeof vi.fn>;
+    addDependency: ReturnType<typeof vi.fn>;
+    removeDependency: ReturnType<typeof vi.fn>;
+  };
+};
+
+function renderComponent(projectId = "proj-1") {
+  return render(
+    <MemoryRouter>
+      <FluentProvider theme={teamsLightTheme}>
+        <DependencyGraph projectId={projectId} />
+      </FluentProvider>
+    </MemoryRouter>,
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("DependencyGraph", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockedApi.workloads.getDependencyGraph.mockResolvedValue(mockGraph);
+    mockedApi.workloads.getMigrationOrder.mockResolvedValue(mockMigrationOrder);
+    mockedApi.workloads.addDependency.mockResolvedValue({ id: "wl-1", dependencies: ["wl-2"] });
+    mockedApi.workloads.removeDependency.mockResolvedValue({ id: "wl-1", dependencies: [] });
+  });
+
+  it("renders loading state and then graph nodes", async () => {
+    renderComponent();
+    await waitFor(() => {
+      expect(screen.getByLabelText("Workload dependency graph SVG")).toBeInTheDocument();
+    });
+    expect(screen.getByLabelText("Workload node: Frontend App")).toBeInTheDocument();
+    expect(screen.getByLabelText("Workload node: Backend API")).toBeInTheDocument();
+    expect(screen.getByLabelText("Workload node: Database")).toBeInTheDocument();
+  });
+
+  it("calls getDependencyGraph with the project ID", async () => {
+    renderComponent("my-project");
+    await waitFor(() => {
+      expect(mockedApi.workloads.getDependencyGraph).toHaveBeenCalledWith("my-project");
+    });
+  });
+
+  it("shows error message when getDependencyGraph fails", async () => {
+    mockedApi.workloads.getDependencyGraph.mockRejectedValue(new Error("Network error"));
+    renderComponent();
+    await waitFor(() => {
+      expect(screen.getByText("Network error")).toBeInTheDocument();
+    });
+  });
+
+  it("shows circular dependency warning when cycles exist", async () => {
+    mockedApi.workloads.getDependencyGraph.mockResolvedValue(mockGraphWithCycle);
+    renderComponent();
+    await waitFor(() => {
+      expect(screen.getByText(/Circular dependencies detected/i)).toBeInTheDocument();
+    });
+  });
+
+  it("clicking a node shows its detail panel", async () => {
+    const user = userEvent.setup();
+    renderComponent();
+    await waitFor(() => {
+      expect(screen.getByLabelText("Workload node: Frontend App")).toBeInTheDocument();
+    });
+    await user.click(screen.getByLabelText("Workload node: Frontend App"));
+    await waitFor(() => {
+      expect(screen.getByLabelText("Details for Frontend App")).toBeInTheDocument();
+    });
+  });
+
+  it("clicking selected node again clears the detail panel", async () => {
+    const user = userEvent.setup();
+    renderComponent();
+    await waitFor(() => {
+      expect(screen.getByLabelText("Workload node: Frontend App")).toBeInTheDocument();
+    });
+    await user.click(screen.getByLabelText("Workload node: Frontend App"));
+    await waitFor(() => {
+      expect(screen.getByLabelText("Details for Frontend App")).toBeInTheDocument();
+    });
+    await user.click(screen.getByLabelText("Workload node: Frontend App"));
+    await waitFor(() => {
+      expect(screen.queryByLabelText("Details for Frontend App")).not.toBeInTheDocument();
+    });
+  });
+
+  it("shows Suggest Migration Order button and fetches order on click", async () => {
+    const user = userEvent.setup();
+    renderComponent();
+    await waitFor(() => {
+      expect(screen.getByLabelText("Workload dependency graph SVG")).toBeInTheDocument();
+    });
+    const btn = screen.getByLabelText("Suggest Migration Order");
+    await user.click(btn);
+    await waitFor(() => {
+      expect(mockedApi.workloads.getMigrationOrder).toHaveBeenCalledWith("proj-1");
+    });
+    await waitFor(() => {
+      expect(screen.getByText("Suggested Migration Order")).toBeInTheDocument();
+    });
+  });
+
+  it("displays migration order as numbered list", async () => {
+    const user = userEvent.setup();
+    renderComponent();
+    await waitFor(() => {
+      expect(screen.getByLabelText("Workload dependency graph SVG")).toBeInTheDocument();
+    });
+    await user.click(screen.getByLabelText("Suggest Migration Order"));
+    await waitFor(() => {
+      expect(screen.getByText("Suggested Migration Order")).toBeInTheDocument();
+    });
+    // The order list should contain the workload names (may appear multiple times with node)
+    expect(screen.getAllByText("Database").length).toBeGreaterThanOrEqual(1);
+    expect(screen.getAllByText("Backend API").length).toBeGreaterThanOrEqual(1);
+    expect(screen.getAllByText("Frontend App").length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("shows migration order warning when has_circular is true", async () => {
+    mockedApi.workloads.getMigrationOrder.mockResolvedValue({
+      ...mockMigrationOrder,
+      has_circular: true,
+      circular_dependencies: [["wl-1", "wl-2"]],
+      order: [],
+    });
+    const user = userEvent.setup();
+    renderComponent();
+    await waitFor(() => screen.getByLabelText("Workload dependency graph SVG"));
+    await user.click(screen.getByLabelText("Suggest Migration Order"));
+    await waitFor(() => {
+      expect(screen.getByText(/Circular dependencies detected — order may be incomplete/i)).toBeInTheDocument();
+    });
+  });
+
+  it("shows empty state when no workloads", async () => {
+    mockedApi.workloads.getDependencyGraph.mockResolvedValue({
+      nodes: [],
+      edges: [],
+      circular_dependencies: [],
+      migration_groups: [],
+    });
+    renderComponent();
+    await waitFor(() => {
+      expect(screen.getByText(/No workloads in this project yet/i)).toBeInTheDocument();
+    });
+  });
+
+  it("Add Dependency button is disabled when fewer than 2 workloads", async () => {
+    mockedApi.workloads.getDependencyGraph.mockResolvedValue({
+      nodes: [{ id: "wl-1", name: "Solo", criticality: "standard", migration_strategy: "rehost", project_id: "proj-1" }],
+      edges: [],
+      circular_dependencies: [],
+      migration_groups: [["wl-1"]],
+    });
+    renderComponent();
+    await waitFor(() => screen.getByLabelText("Add Dependency"));
+    expect(screen.getByLabelText("Add Dependency")).toBeDisabled();
+  });
+
+  it("renders legend with criticality colors", async () => {
+    renderComponent();
+    await waitFor(() => screen.getByLabelText("Workload dependency graph SVG"));
+    // Legend contains all criticality levels (may appear multiple times in nodes + legend)
+    expect(screen.getAllByText("mission-critical").length).toBeGreaterThanOrEqual(1);
+    expect(screen.getAllByText("business-critical").length).toBeGreaterThanOrEqual(1);
+    expect(screen.getAllByText("standard").length).toBeGreaterThanOrEqual(1);
+    // dev-test only appears in legend (not in mock data)
+    expect(screen.getByText("dev-test")).toBeInTheDocument();
+  });
+
+  it("refresh button reloads the graph", async () => {
+    const user = userEvent.setup();
+    renderComponent();
+    await waitFor(() => screen.getByLabelText("Workload dependency graph SVG"));
+    await user.click(screen.getByText("Refresh"));
+    await waitFor(() => {
+      expect(mockedApi.workloads.getDependencyGraph).toHaveBeenCalledTimes(2);
+    });
+  });
+});

--- a/frontend/src/components/migration/DependencyGraph.tsx
+++ b/frontend/src/components/migration/DependencyGraph.tsx
@@ -1,0 +1,789 @@
+/**
+ * DependencyGraph — interactive SVG-based workload dependency visualizer.
+ * Uses SVG/HTML5 only (no external graph libraries).
+ */
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import {
+  Badge,
+  Button,
+  Combobox,
+  Field,
+  MessageBar,
+  MessageBarBody,
+  Option,
+  Popover,
+  PopoverSurface,
+  PopoverTrigger,
+  Spinner,
+  Text,
+  makeStyles,
+  tokens,
+} from "@fluentui/react-components";
+import {
+  AddRegular,
+  ArrowSortRegular,
+  DismissRegular,
+  LinkRegular,
+} from "@fluentui/react-icons";
+import type {
+  DependencyEdge,
+  DependencyGraph as DependencyGraphData,
+  MigrationOrderResponse,
+  WorkloadSummary,
+} from "../../services/api";
+import { api } from "../../services/api";
+
+// ---------------------------------------------------------------------------
+// Styles
+// ---------------------------------------------------------------------------
+
+const useStyles = makeStyles({
+  root: {
+    display: "flex",
+    flexDirection: "column",
+    gap: tokens.spacingVerticalL,
+  },
+  toolbar: {
+    display: "flex",
+    gap: tokens.spacingHorizontalM,
+    alignItems: "center",
+    flexWrap: "wrap",
+  },
+  svgContainer: {
+    border: `1px solid ${tokens.colorNeutralStroke1}`,
+    borderRadius: tokens.borderRadiusMedium,
+    backgroundColor: tokens.colorNeutralBackground2,
+    overflow: "auto",
+    minHeight: "400px",
+  },
+  legend: {
+    display: "flex",
+    gap: tokens.spacingHorizontalL,
+    flexWrap: "wrap",
+    alignItems: "center",
+  },
+  legendItem: {
+    display: "flex",
+    gap: tokens.spacingHorizontalXS,
+    alignItems: "center",
+  },
+  legendSwatch: {
+    width: "16px",
+    height: "16px",
+    borderRadius: tokens.borderRadiusSmall,
+  },
+  orderList: {
+    display: "flex",
+    flexDirection: "column",
+    gap: tokens.spacingVerticalXS,
+  },
+  orderItem: {
+    display: "flex",
+    gap: tokens.spacingHorizontalS,
+    alignItems: "center",
+    padding: `${tokens.spacingVerticalXS} ${tokens.spacingHorizontalS}`,
+    backgroundColor: tokens.colorNeutralBackground1,
+    borderRadius: tokens.borderRadiusMedium,
+    border: `1px solid ${tokens.colorNeutralStroke1}`,
+  },
+  addDepForm: {
+    display: "flex",
+    flexDirection: "column",
+    gap: tokens.spacingVerticalM,
+    minWidth: "280px",
+    padding: tokens.spacingVerticalM,
+  },
+  detailPopover: {
+    padding: tokens.spacingVerticalM,
+    minWidth: "200px",
+  },
+  detailRow: {
+    display: "flex",
+    gap: tokens.spacingHorizontalXS,
+    alignItems: "baseline",
+  },
+  emptyState: {
+    padding: tokens.spacingVerticalXXL,
+    textAlign: "center",
+    color: tokens.colorNeutralForeground3,
+  },
+});
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const NODE_W = 140;
+const NODE_H = 50;
+const NODE_PADDING_X = 30;
+const NODE_PADDING_Y = 40;
+const COLS = 4;
+
+const CRITICALITY_COLOR: Record<string, string> = {
+  "mission-critical": "#C50F1F",   // danger red
+  "business-critical": "#BC5700",  // warning amber
+  "standard": "#0F6CBD",           // brand blue
+  "dev-test": "#616161",           // neutral grey
+};
+
+const GROUP_PALETTE = [
+  "rgba(0,120,212,0.08)",
+  "rgba(0,164,120,0.08)",
+  "rgba(177,70,194,0.08)",
+  "rgba(255,140,0,0.08)",
+  "rgba(0,83,128,0.08)",
+];
+
+// ---------------------------------------------------------------------------
+// Layout helpers
+// ---------------------------------------------------------------------------
+
+interface NodeLayout {
+  id: string;
+  x: number;
+  y: number;
+  summary: WorkloadSummary;
+}
+
+function layoutNodes(nodes: WorkloadSummary[]): NodeLayout[] {
+  return nodes.map((node, i) => {
+    const col = i % COLS;
+    const row = Math.floor(i / COLS);
+    return {
+      id: node.id,
+      x: NODE_PADDING_X + col * (NODE_W + NODE_PADDING_X),
+      y: NODE_PADDING_Y + row * (NODE_H + NODE_PADDING_Y),
+      summary: node,
+    };
+  });
+}
+
+function svgDimensions(layouts: NodeLayout[]): { w: number; h: number } {
+  if (layouts.length === 0) return { w: 400, h: 200 };
+  const maxX = Math.max(...layouts.map((n) => n.x + NODE_W));
+  const maxY = Math.max(...layouts.map((n) => n.y + NODE_H));
+  return { w: maxX + NODE_PADDING_X, h: maxY + NODE_PADDING_Y };
+}
+
+// Return the centre of a node box for edge attachment
+function nodeCentre(layout: NodeLayout): { x: number; y: number } {
+  return { x: layout.x + NODE_W / 2, y: layout.y + NODE_H / 2 };
+}
+
+// ---------------------------------------------------------------------------
+// SVG Edge (arrow)
+// ---------------------------------------------------------------------------
+
+interface EdgeProps {
+  from: NodeLayout;
+  to: NodeLayout;
+  inCycle: boolean;
+}
+
+function GraphEdge({ from, to, inCycle }: EdgeProps) {
+  const fc = nodeCentre(from);
+  const tc = nodeCentre(to);
+
+  // Offset to edge of box rather than centre
+  const dx = tc.x - fc.x;
+  const dy = tc.y - fc.y;
+  const len = Math.sqrt(dx * dx + dy * dy) || 1;
+  const ux = dx / len;
+  const uy = dy / len;
+  const halfW = NODE_W / 2 + 4;
+  const halfH = NODE_H / 2 + 4;
+
+  // Find exit point on source box border
+  const scaleSource = Math.min(halfW / Math.abs(ux || 0.001), halfH / Math.abs(uy || 0.001));
+  const x1 = fc.x + ux * scaleSource;
+  const y1 = fc.y + uy * scaleSource;
+
+  // Find entry point on target box border
+  const scaleDest = Math.min(halfW / Math.abs(ux || 0.001), halfH / Math.abs(uy || 0.001));
+  const x2 = tc.x - ux * scaleDest;
+  const y2 = tc.y - uy * scaleDest;
+
+  const color = inCycle ? "#C50F1F" : tokens.colorNeutralForeground3;
+  const strokeWidth = inCycle ? 2 : 1.5;
+
+  return (
+    <line
+      x1={x1}
+      y1={y1}
+      x2={x2}
+      y2={y2}
+      stroke={color}
+      strokeWidth={strokeWidth}
+      markerEnd={inCycle ? "url(#arrowCycle)" : "url(#arrow)"}
+      opacity={0.85}
+    />
+  );
+}
+
+// ---------------------------------------------------------------------------
+// SVG Node box
+// ---------------------------------------------------------------------------
+
+interface NodeBoxProps {
+  layout: NodeLayout;
+  isSelected: boolean;
+  groupColor?: string;
+  inCycle: boolean;
+  onClick: (id: string) => void;
+}
+
+function NodeBox({ layout, isSelected, groupColor, inCycle, onClick }: NodeBoxProps) {
+  const fill = groupColor ?? tokens.colorNeutralBackground1;
+  const borderColor = inCycle
+    ? "#C50F1F"
+    : isSelected
+      ? tokens.colorBrandStroke1
+      : tokens.colorNeutralStroke1;
+  const critColor = CRITICALITY_COLOR[layout.summary.criticality] ?? "#0F6CBD";
+
+  const shortName =
+    layout.summary.name.length > 16
+      ? layout.summary.name.slice(0, 14) + "…"
+      : layout.summary.name;
+
+  return (
+    <g
+      transform={`translate(${layout.x},${layout.y})`}
+      onClick={() => onClick(layout.id)}
+      style={{ cursor: "pointer" }}
+      role="button"
+      aria-label={`Workload node: ${layout.summary.name}`}
+      tabIndex={0}
+      onKeyDown={(e) => e.key === "Enter" && onClick(layout.id)}
+    >
+      {/* Group background — drawn before rect */}
+      {groupColor && (
+        <rect
+          x={-6}
+          y={-6}
+          width={NODE_W + 12}
+          height={NODE_H + 12}
+          fill={fill}
+          rx={6}
+          ry={6}
+        />
+      )}
+      <rect
+        width={NODE_W}
+        height={NODE_H}
+        fill={tokens.colorNeutralBackground1}
+        stroke={borderColor}
+        strokeWidth={isSelected ? 2 : 1}
+        rx={4}
+        ry={4}
+      />
+      {/* Criticality colour strip */}
+      <rect width={6} height={NODE_H} fill={critColor} rx={3} ry={3} />
+      <text
+        x={14}
+        y={20}
+        fontSize={12}
+        fontWeight="600"
+        fill={tokens.colorNeutralForeground1}
+        style={{ userSelect: "none" }}
+      >
+        {shortName}
+      </text>
+      <text
+        x={14}
+        y={36}
+        fontSize={10}
+        fill={tokens.colorNeutralForeground3}
+        style={{ userSelect: "none" }}
+      >
+        {layout.summary.criticality}
+      </text>
+    </g>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Add Dependency popover form
+// ---------------------------------------------------------------------------
+
+interface AddDepFormProps {
+  nodes: WorkloadSummary[];
+  onAdd: (sourceId: string, targetId: string) => Promise<void>;
+  onClose: () => void;
+  loading: boolean;
+  error: string | null;
+}
+
+function AddDepForm({ nodes, onAdd, onClose, loading, error }: AddDepFormProps) {
+  const styles = useStyles();
+  const [source, setSource] = useState("");
+  const [target, setTarget] = useState("");
+
+  return (
+    <div className={styles.addDepForm}>
+      <Text weight="semibold">Add Dependency</Text>
+      <Field label="From workload">
+        <Combobox
+          value={nodes.find((n) => n.id === source)?.name ?? ""}
+          onOptionSelect={(_, d) => setSource(d.optionValue ?? "")}
+          placeholder="Select source workload"
+        >
+          {nodes.map((n) => (
+            <Option key={n.id} value={n.id}>
+              {n.name}
+            </Option>
+          ))}
+        </Combobox>
+      </Field>
+      <Field label="Depends on">
+        <Combobox
+          value={nodes.find((n) => n.id === target)?.name ?? ""}
+          onOptionSelect={(_, d) => setTarget(d.optionValue ?? "")}
+          placeholder="Select target workload"
+        >
+          {nodes.filter((n) => n.id !== source).map((n) => (
+            <Option key={n.id} value={n.id}>
+              {n.name}
+            </Option>
+          ))}
+        </Combobox>
+      </Field>
+      {error && (
+        <MessageBar intent="error">
+          <MessageBarBody>{error}</MessageBarBody>
+        </MessageBar>
+      )}
+      <div style={{ display: "flex", gap: "8px" }}>
+        <Button
+          appearance="primary"
+          icon={loading ? <Spinner size="tiny" /> : <LinkRegular />}
+          disabled={!source || !target || loading}
+          onClick={() => onAdd(source, target)}
+        >
+          Add
+        </Button>
+        <Button appearance="subtle" icon={<DismissRegular />} onClick={onClose}>
+          Cancel
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Main component
+// ---------------------------------------------------------------------------
+
+interface DependencyGraphProps {
+  projectId: string;
+}
+
+export default function DependencyGraph({ projectId }: DependencyGraphProps) {
+  const styles = useStyles();
+
+  const [graph, setGraph] = useState<DependencyGraphData | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const [migrationOrder, setMigrationOrder] = useState<MigrationOrderResponse | null>(null);
+  const [orderLoading, setOrderLoading] = useState(false);
+  const [orderError, setOrderError] = useState<string | null>(null);
+
+  const [selectedNodeId, setSelectedNodeId] = useState<string | null>(null);
+  const [addDepOpen, setAddDepOpen] = useState(false);
+  const [addDepLoading, setAddDepLoading] = useState(false);
+  const [addDepError, setAddDepError] = useState<string | null>(null);
+
+  // Ref for selected node (could be used for future popover positioning)
+  const detailAnchorRef = useRef<SVGGElement | null>(null);
+
+  const fetchGraph = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const data = await api.workloads.getDependencyGraph(projectId);
+      setGraph(data);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to load dependency graph");
+    } finally {
+      setLoading(false);
+    }
+  }, [projectId]);
+
+  useEffect(() => {
+    fetchGraph();
+  }, [fetchGraph]);
+
+  const fetchOrder = async () => {
+    setOrderLoading(true);
+    setOrderError(null);
+    try {
+      const data = await api.workloads.getMigrationOrder(projectId);
+      setMigrationOrder(data);
+    } catch (err) {
+      setOrderError(err instanceof Error ? err.message : "Failed to get migration order");
+    } finally {
+      setOrderLoading(false);
+    }
+  };
+
+  const handleAddDep = async (sourceId: string, targetId: string) => {
+    setAddDepLoading(true);
+    setAddDepError(null);
+    try {
+      await api.workloads.addDependency(sourceId, targetId);
+      setAddDepOpen(false);
+      await fetchGraph();
+    } catch (err) {
+      setAddDepError(err instanceof Error ? err.message : "Failed to add dependency");
+    } finally {
+      setAddDepLoading(false);
+    }
+  };
+
+  // Build a cycle-node lookup set
+  const cycleNodes = new Set<string>();
+  (graph?.circular_dependencies ?? []).forEach((cycle) =>
+    cycle.forEach((id) => cycleNodes.add(id)),
+  );
+
+  // Build group-colour map (node → colour)
+  const groupColorMap = new Map<string, string>();
+  (graph?.migration_groups ?? []).forEach((group, idx) => {
+    if (group.length > 1) {
+      const color = GROUP_PALETTE[idx % GROUP_PALETTE.length];
+      group.forEach((id) => groupColorMap.set(id, color));
+    }
+  });
+
+  // Build edge lookup for cycle detection
+  const cycleEdgeSet = new Set<string>();
+  (graph?.circular_dependencies ?? []).forEach((cycle) => {
+    for (let i = 0; i < cycle.length; i++) {
+      cycleEdgeSet.add(`${cycle[i]}->${cycle[(i + 1) % cycle.length]}`);
+    }
+  });
+
+  const isEdgeInCycle = (edge: DependencyEdge) =>
+    cycleEdgeSet.has(`${edge.source}->${edge.target}`);
+
+  const layouts = layoutNodes(graph?.nodes ?? []);
+  const layoutMap = new Map<string, NodeLayout>(layouts.map((l) => [l.id, l]));
+  const { w: svgW, h: svgH } = svgDimensions(layouts);
+
+  const selectedNode = graph?.nodes.find((n) => n.id === selectedNodeId);
+
+  const handleNodeClick = (id: string) => {
+    setSelectedNodeId((prev) => (prev === id ? null : id));
+  };
+
+  return (
+    <div className={styles.root}>
+      {/* Toolbar */}
+      <div className={styles.toolbar}>
+        <Button
+          appearance="subtle"
+          onClick={fetchGraph}
+          disabled={loading}
+          icon={loading ? <Spinner size="tiny" /> : undefined}
+        >
+          {loading ? "Loading…" : "Refresh"}
+        </Button>
+
+        <Popover
+          open={addDepOpen}
+          onOpenChange={(_, d) => {
+            setAddDepOpen(d.open);
+            if (!d.open) setAddDepError(null);
+          }}
+          positioning="below-start"
+        >
+          <PopoverTrigger>
+            <Button
+              appearance="primary"
+              icon={<AddRegular />}
+              disabled={!graph || graph.nodes.length < 2}
+              aria-label="Add Dependency"
+            >
+              Add Dependency
+            </Button>
+          </PopoverTrigger>
+          <PopoverSurface>
+            {graph && (
+              <AddDepForm
+                nodes={graph.nodes}
+                onAdd={handleAddDep}
+                onClose={() => setAddDepOpen(false)}
+                loading={addDepLoading}
+                error={addDepError}
+              />
+            )}
+          </PopoverSurface>
+        </Popover>
+
+        <Button
+          appearance="subtle"
+          icon={orderLoading ? <Spinner size="tiny" /> : <ArrowSortRegular />}
+          onClick={fetchOrder}
+          disabled={orderLoading}
+          aria-label="Suggest Migration Order"
+        >
+          Suggest Migration Order
+        </Button>
+
+        {selectedNodeId && (
+          <Button
+            appearance="subtle"
+            icon={<DismissRegular />}
+            size="small"
+            onClick={() => setSelectedNodeId(null)}
+            aria-label="Clear selection"
+          >
+            Clear selection
+          </Button>
+        )}
+      </div>
+
+      {/* Errors */}
+      {error && (
+        <MessageBar intent="error">
+          <MessageBarBody>{error}</MessageBarBody>
+        </MessageBar>
+      )}
+      {orderError && (
+        <MessageBar intent="warning">
+          <MessageBarBody>{orderError}</MessageBarBody>
+        </MessageBar>
+      )}
+      {graph && graph.circular_dependencies.length > 0 && (
+        <MessageBar intent="error">
+          <MessageBarBody>
+            ⚠ Circular dependencies detected:{" "}
+            {graph.circular_dependencies.map((cycle) => cycle.join(" → ")).join("; ")}
+          </MessageBarBody>
+        </MessageBar>
+      )}
+
+      {/* Legend */}
+      <div className={styles.legend}>
+        {Object.entries(CRITICALITY_COLOR).map(([level, color]) => (
+          <div key={level} className={styles.legendItem}>
+            <div
+              className={styles.legendSwatch}
+              style={{ backgroundColor: color }}
+              aria-hidden="true"
+            />
+            <Text size={200}>{level}</Text>
+          </div>
+        ))}
+        <div className={styles.legendItem}>
+          <div
+            className={styles.legendSwatch}
+            style={{ backgroundColor: "#C50F1F", border: "2px solid #C50F1F" }}
+            aria-hidden="true"
+          />
+          <Text size={200}>circular dependency</Text>
+        </div>
+        <div className={styles.legendItem}>
+          <div
+            className={styles.legendSwatch}
+            style={{ backgroundColor: GROUP_PALETTE[0] }}
+            aria-hidden="true"
+          />
+          <Text size={200}>migration group</Text>
+        </div>
+      </div>
+
+      {/* SVG Graph */}
+      <div className={styles.svgContainer} aria-label="Dependency graph">
+        {graph === null && !loading && (
+          <div className={styles.emptyState}>
+            <Text>No data loaded yet.</Text>
+          </div>
+        )}
+        {graph !== null && graph.nodes.length === 0 && (
+          <div className={styles.emptyState}>
+            <Text>No workloads in this project yet. Import workloads first.</Text>
+          </div>
+        )}
+        {graph !== null && graph.nodes.length > 0 && (
+          <svg
+            width={svgW}
+            height={svgH}
+            style={{ display: "block" }}
+            aria-label="Workload dependency graph SVG"
+          >
+            <defs>
+              <marker
+                id="arrow"
+                viewBox="0 0 10 10"
+                refX="9"
+                refY="5"
+                markerWidth="6"
+                markerHeight="6"
+                orient="auto-start-reverse"
+              >
+                <path d="M 0 0 L 10 5 L 0 10 z" fill={tokens.colorNeutralForeground3} />
+              </marker>
+              <marker
+                id="arrowCycle"
+                viewBox="0 0 10 10"
+                refX="9"
+                refY="5"
+                markerWidth="6"
+                markerHeight="6"
+                orient="auto-start-reverse"
+              >
+                <path d="M 0 0 L 10 5 L 0 10 z" fill="#C50F1F" />
+              </marker>
+            </defs>
+
+            {/* Edges */}
+            {graph.edges.map((edge) => {
+              const from = layoutMap.get(edge.source);
+              const to = layoutMap.get(edge.target);
+              if (!from || !to) return null;
+              return (
+                <GraphEdge
+                  key={`${edge.source}-${edge.target}`}
+                  from={from}
+                  to={to}
+                  inCycle={isEdgeInCycle(edge)}
+                />
+              );
+            })}
+
+            {/* Nodes */}
+            {layouts.map((layout) => (
+              <g key={layout.id} ref={layout.id === selectedNodeId ? detailAnchorRef : undefined}>
+                <NodeBox
+                  layout={layout}
+                  isSelected={layout.id === selectedNodeId}
+                  groupColor={groupColorMap.get(layout.id)}
+                  inCycle={cycleNodes.has(layout.id)}
+                  onClick={handleNodeClick}
+                />
+              </g>
+            ))}
+          </svg>
+        )}
+      </div>
+
+      {/* Node detail panel */}
+      {selectedNode && (
+        <div
+          style={{
+            padding: tokens.spacingVerticalM,
+            backgroundColor: tokens.colorNeutralBackground1,
+            border: `1px solid ${tokens.colorNeutralStroke1}`,
+            borderRadius: tokens.borderRadiusMedium,
+          }}
+          aria-label={`Details for ${selectedNode.name}`}
+        >
+          <Text weight="semibold" size={400}>
+            {selectedNode.name}
+          </Text>
+          <div style={{ marginTop: tokens.spacingVerticalS, display: "flex", flexDirection: "column", gap: tokens.spacingVerticalXS }}>
+            <div className={styles.detailRow}>
+              <Text size={200} style={{ color: tokens.colorNeutralForeground3 }}>Criticality:</Text>
+              <Badge
+                appearance="tint"
+                color={
+                  selectedNode.criticality === "mission-critical"
+                    ? "danger"
+                    : selectedNode.criticality === "business-critical"
+                      ? "warning"
+                      : "informative"
+                }
+                size="small"
+              >
+                {selectedNode.criticality}
+              </Badge>
+            </div>
+            <div className={styles.detailRow}>
+              <Text size={200} style={{ color: tokens.colorNeutralForeground3 }}>Migration strategy:</Text>
+              <Text size={200}>{selectedNode.migration_strategy}</Text>
+            </div>
+            <div className={styles.detailRow}>
+              <Text size={200} style={{ color: tokens.colorNeutralForeground3 }}>In cycle:</Text>
+              <Text size={200}>{cycleNodes.has(selectedNode.id) ? "⚠ Yes" : "No"}</Text>
+            </div>
+            <div className={styles.detailRow}>
+              <Text size={200} style={{ color: tokens.colorNeutralForeground3 }}>Depends on:</Text>
+              <Text size={200}>
+                {(graph?.edges ?? [])
+                  .filter((e) => e.source === selectedNode.id)
+                  .map((e) => graph?.nodes.find((n) => n.id === e.target)?.name ?? e.target)
+                  .join(", ") || "—"}
+              </Text>
+            </div>
+            <div className={styles.detailRow}>
+              <Text size={200} style={{ color: tokens.colorNeutralForeground3 }}>Required by:</Text>
+              <Text size={200}>
+                {(graph?.edges ?? [])
+                  .filter((e) => e.target === selectedNode.id)
+                  .map((e) => graph?.nodes.find((n) => n.id === e.source)?.name ?? e.source)
+                  .join(", ") || "—"}
+              </Text>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* Migration order */}
+      {migrationOrder && (
+        <div style={{ display: "flex", flexDirection: "column", gap: tokens.spacingVerticalS }}>
+          <Text weight="semibold" size={400}>
+            Suggested Migration Order
+          </Text>
+          {migrationOrder.has_circular && (
+            <MessageBar intent="warning">
+              <MessageBarBody>
+                Circular dependencies detected — order may be incomplete.
+              </MessageBarBody>
+            </MessageBar>
+          )}
+          {migrationOrder.order.length === 0 && (
+            <Text style={{ color: tokens.colorNeutralForeground3 }}>
+              Cannot determine order due to circular dependencies.
+            </Text>
+          )}
+          <div className={styles.orderList}>
+            {migrationOrder.order.map((id, idx) => (
+              <div key={id} className={styles.orderItem}>
+                <Badge appearance="filled" size="small" color="brand">
+                  {idx + 1}
+                </Badge>
+                <Text>{migrationOrder.workload_names[id] ?? id}</Text>
+                {cycleNodes.has(id) && (
+                  <Badge appearance="tint" color="danger" size="small">
+                    cycle
+                  </Badge>
+                )}
+              </div>
+            ))}
+          </div>
+          {migrationOrder.migration_groups.length > 0 && (
+            <>
+              <Text weight="semibold" size={300} style={{ marginTop: tokens.spacingVerticalS }}>
+                Migration Groups
+              </Text>
+              {migrationOrder.migration_groups.map((group, idx) => (
+                <div key={idx} className={styles.orderItem}>
+                  <Badge appearance="tint" size="small">Group {idx + 1}</Badge>
+                  <Text>
+                    {group
+                      .map((id) => migrationOrder.workload_names[id] ?? id)
+                      .join(", ")}
+                  </Text>
+                </div>
+              ))}
+            </>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+

--- a/frontend/src/components/migration/DependencyGraph.tsx
+++ b/frontend/src/components/migration/DependencyGraph.tsx
@@ -3,6 +3,7 @@
  * Uses SVG/HTML5 only (no external graph libraries).
  */
 
+import type React from "react";
 import { useCallback, useEffect, useRef, useState } from "react";
 import {
   Badge,
@@ -197,6 +198,8 @@ const MIGRATION_STRATEGY_COLOR: Record<string, string> = {
   rebuild: tokens.colorStatusDangerForeground1,
   retire: tokens.colorNeutralForeground4,
   retain: tokens.colorNeutralForeground3,
+  replace: tokens.colorPaletteRedForeground1,
+  unknown: tokens.colorNeutralForeground3,
 };
 
 // ---------------------------------------------------------------------------
@@ -285,7 +288,7 @@ function GraphEdge({ from, to, inCycle, edge }: EdgeProps) {
   const color = inCycle ? tokens.colorStatusDangerForeground1 : tokens.colorNeutralForeground3;
   const strokeWidth = inCycle ? 2 : 1.5;
 
-  const tooltipText = `${from.summary.name} → ${to.summary.name} (${edge.dependency_type})`;
+  const tooltipText = `${to.summary.name} depends on ${from.summary.name} (${edge.dependency_type})`;
 
   return (
     <line
@@ -987,8 +990,8 @@ export default function DependencyGraph({ projectId }: DependencyGraphProps) {
               <Text size={200} className={styles.detailLabel}>Depends on:</Text>
               <Text size={200}>
                 {(graph?.edges ?? [])
-                  .filter((e) => e.source === selectedNode.id)
-                  .map((e) => graph?.nodes.find((n) => n.id === e.target)?.name ?? e.target)
+                  .filter((e) => e.target === selectedNode.id)
+                  .map((e) => graph?.nodes.find((n) => n.id === e.source)?.name ?? e.source)
                   .join(", ") || "—"}
               </Text>
             </div>
@@ -996,8 +999,8 @@ export default function DependencyGraph({ projectId }: DependencyGraphProps) {
               <Text size={200} className={styles.detailLabel}>Required by:</Text>
               <Text size={200}>
                 {(graph?.edges ?? [])
-                  .filter((e) => e.target === selectedNode.id)
-                  .map((e) => graph?.nodes.find((n) => n.id === e.source)?.name ?? e.source)
+                  .filter((e) => e.source === selectedNode.id)
+                  .map((e) => graph?.nodes.find((n) => n.id === e.target)?.name ?? e.target)
                   .join(", ") || "—"}
               </Text>
             </div>

--- a/frontend/src/components/migration/DependencyGraph.tsx
+++ b/frontend/src/components/migration/DependencyGraph.tsx
@@ -94,6 +94,10 @@ const useStyles = makeStyles({
     minWidth: "280px",
     padding: tokens.spacingVerticalM,
   },
+  addDepFormButtons: {
+    display: "flex",
+    gap: tokens.spacingHorizontalS,
+  },
   detailPopover: {
     padding: tokens.spacingVerticalM,
     minWidth: "200px",
@@ -120,19 +124,23 @@ const NODE_PADDING_X = 30;
 const NODE_PADDING_Y = 40;
 const COLS = 4;
 
+// Criticality colour strip — mapped to Fluent UI semantic colour tokens.
+// Used as SVG `fill` values so the token CSS-var string is passed directly.
 const CRITICALITY_COLOR: Record<string, string> = {
-  "mission-critical": "#C50F1F",   // danger red
-  "business-critical": "#BC5700",  // warning amber
-  "standard": "#0F6CBD",           // brand blue
-  "dev-test": "#616161",           // neutral grey
+  "mission-critical": tokens.colorStatusDangerForeground1,
+  "business-critical": tokens.colorStatusWarningForeground1,
+  "standard": tokens.colorBrandForeground1,
+  "dev-test": tokens.colorNeutralForeground3,
 };
 
+// Group background palette — Fluent UI palette background tokens keep
+// compatibility with light/dark themes.
 const GROUP_PALETTE = [
-  "rgba(0,120,212,0.08)",
-  "rgba(0,164,120,0.08)",
-  "rgba(177,70,194,0.08)",
-  "rgba(255,140,0,0.08)",
-  "rgba(0,83,128,0.08)",
+  tokens.colorPaletteBlueBackground2,
+  tokens.colorPaletteGreenBackground2,
+  tokens.colorPaletteGrapeBackground2,
+  tokens.colorPaletteMarigoldBackground2,
+  tokens.colorPaletteTealBackground2,
 ];
 
 // ---------------------------------------------------------------------------
@@ -204,7 +212,7 @@ function GraphEdge({ from, to, inCycle }: EdgeProps) {
   const x2 = tc.x - ux * scaleDest;
   const y2 = tc.y - uy * scaleDest;
 
-  const color = inCycle ? "#C50F1F" : tokens.colorNeutralForeground3;
+  const color = inCycle ? tokens.colorStatusDangerForeground1 : tokens.colorNeutralForeground3;
   const strokeWidth = inCycle ? 2 : 1.5;
 
   return (
@@ -236,11 +244,11 @@ interface NodeBoxProps {
 function NodeBox({ layout, isSelected, groupColor, inCycle, onClick }: NodeBoxProps) {
   const fill = groupColor ?? tokens.colorNeutralBackground1;
   const borderColor = inCycle
-    ? "#C50F1F"
+    ? tokens.colorStatusDangerForeground1
     : isSelected
       ? tokens.colorBrandStroke1
       : tokens.colorNeutralStroke1;
-  const critColor = CRITICALITY_COLOR[layout.summary.criticality] ?? "#0F6CBD";
+  const critColor = CRITICALITY_COLOR[layout.summary.criticality] ?? tokens.colorBrandForeground1;
 
   const shortName =
     layout.summary.name.length > 16
@@ -318,15 +326,22 @@ interface AddDepFormProps {
 function AddDepForm({ nodes, onAdd, onClose, loading, error }: AddDepFormProps) {
   const styles = useStyles();
   const [source, setSource] = useState("");
+  const [sourceInput, setSourceInput] = useState("");
   const [target, setTarget] = useState("");
+  const [targetInput, setTargetInput] = useState("");
 
   return (
     <div className={styles.addDepForm}>
       <Text weight="semibold">Add Dependency</Text>
       <Field label="From workload">
         <Combobox
-          value={nodes.find((n) => n.id === source)?.name ?? ""}
-          onOptionSelect={(_, d) => setSource(d.optionValue ?? "")}
+          value={sourceInput}
+          selectedOptions={source ? [source] : []}
+          onOptionSelect={(_, d) => {
+            setSource(d.optionValue ?? "");
+            setSourceInput(d.optionText ?? "");
+          }}
+          onChange={(e) => setSourceInput(e.target.value)}
           placeholder="Select source workload"
         >
           {nodes.map((n) => (
@@ -338,8 +353,13 @@ function AddDepForm({ nodes, onAdd, onClose, loading, error }: AddDepFormProps) 
       </Field>
       <Field label="Depends on">
         <Combobox
-          value={nodes.find((n) => n.id === target)?.name ?? ""}
-          onOptionSelect={(_, d) => setTarget(d.optionValue ?? "")}
+          value={targetInput}
+          selectedOptions={target ? [target] : []}
+          onOptionSelect={(_, d) => {
+            setTarget(d.optionValue ?? "");
+            setTargetInput(d.optionText ?? "");
+          }}
+          onChange={(e) => setTargetInput(e.target.value)}
           placeholder="Select target workload"
         >
           {nodes.filter((n) => n.id !== source).map((n) => (
@@ -354,7 +374,7 @@ function AddDepForm({ nodes, onAdd, onClose, loading, error }: AddDepFormProps) 
           <MessageBarBody>{error}</MessageBarBody>
         </MessageBar>
       )}
-      <div style={{ display: "flex", gap: "8px" }}>
+      <div className={styles.addDepFormButtons}>
         <Button
           appearance="primary"
           icon={loading ? <Spinner size="tiny" /> : <LinkRegular />}

--- a/frontend/src/components/migration/DependencyGraph.tsx
+++ b/frontend/src/components/migration/DependencyGraph.tsx
@@ -9,6 +9,7 @@ import {
   Button,
   Combobox,
   Field,
+  Input,
   MessageBar,
   MessageBarBody,
   Option,
@@ -17,6 +18,7 @@ import {
   PopoverTrigger,
   Spinner,
   Text,
+  Tooltip,
   makeStyles,
   tokens,
 } from "@fluentui/react-components";
@@ -25,6 +27,10 @@ import {
   ArrowSortRegular,
   DismissRegular,
   LinkRegular,
+  SearchRegular,
+  ZoomInRegular,
+  ZoomOutRegular,
+  ZoomFitRegular,
 } from "@fluentui/react-icons";
 import type {
   DependencyEdge,
@@ -112,6 +118,37 @@ const useStyles = makeStyles({
     textAlign: "center",
     color: tokens.colorNeutralForeground3,
   },
+  detailPanel: {
+    padding: tokens.spacingVerticalM,
+    backgroundColor: tokens.colorNeutralBackground1,
+    border: `1px solid ${tokens.colorNeutralStroke1}`,
+    borderRadius: tokens.borderRadiusMedium,
+  },
+  detailContent: {
+    marginTop: tokens.spacingVerticalS,
+    display: "flex",
+    flexDirection: "column",
+    gap: tokens.spacingVerticalXS,
+  },
+  detailLabel: {
+    color: tokens.colorNeutralForeground3,
+  },
+  migrationOrderSection: {
+    display: "flex",
+    flexDirection: "column",
+    gap: tokens.spacingVerticalS,
+  },
+  mutedText: {
+    color: tokens.colorNeutralForeground3,
+  },
+  migrationGroupsTitle: {
+    marginTop: tokens.spacingVerticalS,
+  },
+  zoomControls: {
+    display: "flex",
+    gap: tokens.spacingHorizontalXS,
+    alignItems: "center",
+  },
 });
 
 // ---------------------------------------------------------------------------
@@ -143,6 +180,25 @@ const GROUP_PALETTE = [
   tokens.colorPaletteTealBackground2,
 ];
 
+// Criticality → node size multiplier so more critical workloads stand out.
+const CRITICALITY_SIZE_SCALE: Record<string, number> = {
+  "mission-critical": 1.15,
+  "business-critical": 1.07,
+  standard: 1.0,
+  "dev-test": 0.92,
+};
+
+// Migration strategy → colour indicator (small dot on each node).
+const MIGRATION_STRATEGY_COLOR: Record<string, string> = {
+  rehost: tokens.colorPaletteGreenForeground1,
+  replatform: tokens.colorPaletteBlueForeground2,
+  refactor: tokens.colorPaletteMarigoldForeground1,
+  rearchitect: tokens.colorPaletteGrapeForeground2,
+  rebuild: tokens.colorStatusDangerForeground1,
+  retire: tokens.colorNeutralForeground4,
+  retain: tokens.colorNeutralForeground3,
+};
+
 // ---------------------------------------------------------------------------
 // Layout helpers
 // ---------------------------------------------------------------------------
@@ -152,6 +208,8 @@ interface NodeLayout {
   x: number;
   y: number;
   summary: WorkloadSummary;
+  /** Size multiplier derived from criticality. */
+  scale: number;
 }
 
 function layoutNodes(nodes: WorkloadSummary[]): NodeLayout[] {
@@ -163,6 +221,7 @@ function layoutNodes(nodes: WorkloadSummary[]): NodeLayout[] {
       x: NODE_PADDING_X + col * (NODE_W + NODE_PADDING_X),
       y: NODE_PADDING_Y + row * (NODE_H + NODE_PADDING_Y),
       summary: node,
+      scale: CRITICALITY_SIZE_SCALE[node.criticality] ?? 1.0,
     };
   });
 }
@@ -187,9 +246,10 @@ interface EdgeProps {
   from: NodeLayout;
   to: NodeLayout;
   inCycle: boolean;
+  edge: DependencyEdge;
 }
 
-function GraphEdge({ from, to, inCycle }: EdgeProps) {
+function GraphEdge({ from, to, inCycle, edge }: EdgeProps) {
   const fc = nodeCentre(from);
   const tc = nodeCentre(to);
 
@@ -199,21 +259,33 @@ function GraphEdge({ from, to, inCycle }: EdgeProps) {
   const len = Math.sqrt(dx * dx + dy * dy) || 1;
   const ux = dx / len;
   const uy = dy / len;
-  const halfW = NODE_W / 2 + 4;
-  const halfH = NODE_H / 2 + 4;
+
+  // Scale-aware half-dimensions for edge attachment
+  const halfWSource = (NODE_W * from.scale) / 2 + 4;
+  const halfHSource = (NODE_H * from.scale) / 2 + 4;
+  const halfWDest = (NODE_W * to.scale) / 2 + 4;
+  const halfHDest = (NODE_H * to.scale) / 2 + 4;
 
   // Find exit point on source box border
-  const scaleSource = Math.min(halfW / Math.abs(ux || 0.001), halfH / Math.abs(uy || 0.001));
+  const scaleSource = Math.min(
+    halfWSource / Math.abs(ux || 0.001),
+    halfHSource / Math.abs(uy || 0.001),
+  );
   const x1 = fc.x + ux * scaleSource;
   const y1 = fc.y + uy * scaleSource;
 
   // Find entry point on target box border
-  const scaleDest = Math.min(halfW / Math.abs(ux || 0.001), halfH / Math.abs(uy || 0.001));
+  const scaleDest = Math.min(
+    halfWDest / Math.abs(ux || 0.001),
+    halfHDest / Math.abs(uy || 0.001),
+  );
   const x2 = tc.x - ux * scaleDest;
   const y2 = tc.y - uy * scaleDest;
 
   const color = inCycle ? tokens.colorStatusDangerForeground1 : tokens.colorNeutralForeground3;
   const strokeWidth = inCycle ? 2 : 1.5;
+
+  const tooltipText = `${from.summary.name} → ${to.summary.name} (${edge.dependency_type})`;
 
   return (
     <line
@@ -225,7 +297,9 @@ function GraphEdge({ from, to, inCycle }: EdgeProps) {
       strokeWidth={strokeWidth}
       markerEnd={inCycle ? "url(#arrowCycle)" : "url(#arrow)"}
       opacity={0.85}
-    />
+    >
+      <title>{tooltipText}</title>
+    </line>
   );
 }
 
@@ -249,6 +323,15 @@ function NodeBox({ layout, isSelected, groupColor, inCycle, onClick }: NodeBoxPr
       ? tokens.colorBrandStroke1
       : tokens.colorNeutralStroke1;
   const critColor = CRITICALITY_COLOR[layout.summary.criticality] ?? tokens.colorBrandForeground1;
+  const strategyColor =
+    MIGRATION_STRATEGY_COLOR[layout.summary.migration_strategy] ?? tokens.colorNeutralForeground3;
+
+  const scale = layout.scale;
+  const nodeW = NODE_W * scale;
+  const nodeH = NODE_H * scale;
+  // Centre the scaled node within the grid cell
+  const offsetX = (NODE_W - nodeW) / 2;
+  const offsetY = (NODE_H - nodeH) / 2;
 
   const shortName =
     layout.summary.name.length > 16
@@ -257,29 +340,36 @@ function NodeBox({ layout, isSelected, groupColor, inCycle, onClick }: NodeBoxPr
 
   return (
     <g
-      transform={`translate(${layout.x},${layout.y})`}
+      transform={`translate(${layout.x + offsetX},${layout.y + offsetY})`}
       onClick={() => onClick(layout.id)}
       style={{ cursor: "pointer" }}
       role="button"
       aria-label={`Workload node: ${layout.summary.name}`}
       tabIndex={0}
-      onKeyDown={(e) => e.key === "Enter" && onClick(layout.id)}
+      onKeyDown={(e) => {
+        if (e.key === "Enter") {
+          onClick(layout.id);
+        } else if (e.key === " ") {
+          e.preventDefault();
+          onClick(layout.id);
+        }
+      }}
     >
       {/* Group background — drawn before rect */}
       {groupColor && (
         <rect
           x={-6}
           y={-6}
-          width={NODE_W + 12}
-          height={NODE_H + 12}
+          width={nodeW + 12}
+          height={nodeH + 12}
           fill={fill}
           rx={6}
           ry={6}
         />
       )}
       <rect
-        width={NODE_W}
-        height={NODE_H}
+        width={nodeW}
+        height={nodeH}
         fill={tokens.colorNeutralBackground1}
         stroke={borderColor}
         strokeWidth={isSelected ? 2 : 1}
@@ -287,7 +377,11 @@ function NodeBox({ layout, isSelected, groupColor, inCycle, onClick }: NodeBoxPr
         ry={4}
       />
       {/* Criticality colour strip */}
-      <rect width={6} height={NODE_H} fill={critColor} rx={3} ry={3} />
+      <rect width={6} height={nodeH} fill={critColor} rx={3} ry={3} />
+      {/* Migration strategy indicator */}
+      <circle cx={nodeW - 10} cy={10} r={4} fill={strategyColor}>
+        <title>{layout.summary.migration_strategy}</title>
+      </circle>
       <text
         x={14}
         y={20}
@@ -415,7 +509,21 @@ export default function DependencyGraph({ projectId }: DependencyGraphProps) {
   const [addDepLoading, setAddDepLoading] = useState(false);
   const [addDepError, setAddDepError] = useState<string | null>(null);
 
-  // Ref for selected node (could be used for future popover positioning)
+  // Search/filter
+  const [searchQuery, setSearchQuery] = useState("");
+
+  // Zoom/pan via SVG viewBox
+  const [viewBox, setViewBox] = useState<{
+    x: number;
+    y: number;
+    w: number;
+    h: number;
+  } | null>(null);
+  const [isPanning, setIsPanning] = useState(false);
+  const [panStart, setPanStart] = useState<{ x: number; y: number } | null>(null);
+  const svgRef = useRef<SVGSVGElement | null>(null);
+
+  // Ref for selected node — scrolls the node into view on selection
   const detailAnchorRef = useRef<SVGGElement | null>(null);
 
   const fetchGraph = useCallback(async () => {
@@ -462,11 +570,13 @@ export default function DependencyGraph({ projectId }: DependencyGraphProps) {
     }
   };
 
-  // Build a cycle-node lookup set
+  // Build a cycle-node lookup set — merge both graph and migrationOrder sources
   const cycleNodes = new Set<string>();
-  (graph?.circular_dependencies ?? []).forEach((cycle) =>
-    cycle.forEach((id) => cycleNodes.add(id)),
-  );
+  const allCircularDeps = [
+    ...(graph?.circular_dependencies ?? []),
+    ...(migrationOrder?.circular_dependencies ?? []),
+  ];
+  allCircularDeps.forEach((cycle) => cycle.forEach((id) => cycleNodes.add(id)));
 
   // Build group-colour map (node → colour)
   const groupColorMap = new Map<string, string>();
@@ -488,7 +598,18 @@ export default function DependencyGraph({ projectId }: DependencyGraphProps) {
   const isEdgeInCycle = (edge: DependencyEdge) =>
     cycleEdgeSet.has(`${edge.source}->${edge.target}`);
 
-  const layouts = layoutNodes(graph?.nodes ?? []);
+  // Search filtering — nodes whose name matches the query
+  const filteredNodes = searchQuery
+    ? (graph?.nodes ?? []).filter((n) =>
+        n.name.toLowerCase().includes(searchQuery.toLowerCase()),
+      )
+    : (graph?.nodes ?? []);
+  const filteredNodeIds = new Set(filteredNodes.map((n) => n.id));
+  const filteredEdges = (graph?.edges ?? []).filter(
+    (e) => filteredNodeIds.has(e.source) && filteredNodeIds.has(e.target),
+  );
+
+  const layouts = layoutNodes(filteredNodes);
   const layoutMap = new Map<string, NodeLayout>(layouts.map((l) => [l.id, l]));
   const { w: svgW, h: svgH } = svgDimensions(layouts);
 
@@ -497,6 +618,92 @@ export default function DependencyGraph({ projectId }: DependencyGraphProps) {
   const handleNodeClick = (id: string) => {
     setSelectedNodeId((prev) => (prev === id ? null : id));
   };
+
+  // Scroll the selected node into view when it changes
+  useEffect(() => {
+    if (selectedNodeId && detailAnchorRef.current?.scrollIntoView) {
+      detailAnchorRef.current.scrollIntoView({ behavior: "smooth", block: "nearest" });
+    }
+  }, [selectedNodeId]);
+
+  // Zoom/pan handlers
+  const handleWheel = useCallback(
+    (e: React.WheelEvent<SVGSVGElement>) => {
+      e.preventDefault();
+      const zoomFactor = e.deltaY > 0 ? 1.1 : 0.9;
+      setViewBox((prev) => {
+        const vb = prev ?? { x: 0, y: 0, w: svgW, h: svgH };
+        const newW = vb.w * zoomFactor;
+        const newH = vb.h * zoomFactor;
+        const dxShift = (vb.w - newW) / 2;
+        const dyShift = (vb.h - newH) / 2;
+        return { x: vb.x + dxShift, y: vb.y + dyShift, w: newW, h: newH };
+      });
+    },
+    [svgW, svgH],
+  );
+
+  const handleMouseDown = useCallback((e: React.MouseEvent<SVGSVGElement>) => {
+    if (e.button === 1 || (e.button === 0 && e.altKey)) {
+      setIsPanning(true);
+      setPanStart({ x: e.clientX, y: e.clientY });
+      e.preventDefault();
+    }
+  }, []);
+
+  const handleMouseMove = useCallback(
+    (e: React.MouseEvent<SVGSVGElement>) => {
+      if (!isPanning || !panStart) return;
+      const vb = viewBox ?? { x: 0, y: 0, w: svgW, h: svgH };
+      const svgEl = svgRef.current;
+      if (!svgEl) return;
+      const rect = svgEl.getBoundingClientRect();
+      const scaleX = vb.w / rect.width;
+      const scaleY = vb.h / rect.height;
+      const panDx = (e.clientX - panStart.x) * scaleX;
+      const panDy = (e.clientY - panStart.y) * scaleY;
+      setViewBox({ x: vb.x - panDx, y: vb.y - panDy, w: vb.w, h: vb.h });
+      setPanStart({ x: e.clientX, y: e.clientY });
+    },
+    [isPanning, panStart, viewBox, svgW, svgH],
+  );
+
+  const handleMouseUp = useCallback(() => {
+    setIsPanning(false);
+    setPanStart(null);
+  }, []);
+
+  const handleZoomIn = useCallback(() => {
+    setViewBox((prev) => {
+      const vb = prev ?? { x: 0, y: 0, w: svgW, h: svgH };
+      const newW = vb.w * 0.8;
+      const newH = vb.h * 0.8;
+      return {
+        x: vb.x + (vb.w - newW) / 2,
+        y: vb.y + (vb.h - newH) / 2,
+        w: newW,
+        h: newH,
+      };
+    });
+  }, [svgW, svgH]);
+
+  const handleZoomOut = useCallback(() => {
+    setViewBox((prev) => {
+      const vb = prev ?? { x: 0, y: 0, w: svgW, h: svgH };
+      const newW = vb.w * 1.25;
+      const newH = vb.h * 1.25;
+      return {
+        x: vb.x + (vb.w - newW) / 2,
+        y: vb.y + (vb.h - newH) / 2,
+        w: newW,
+        h: newH,
+      };
+    });
+  }, [svgW, svgH]);
+
+  const handleResetZoom = useCallback(() => {
+    setViewBox(null);
+  }, []);
 
   return (
     <div className={styles.root}>
@@ -563,6 +770,46 @@ export default function DependencyGraph({ projectId }: DependencyGraphProps) {
             Clear selection
           </Button>
         )}
+
+        {/* Search/filter */}
+        <Input
+          contentBefore={<SearchRegular />}
+          placeholder="Filter workloads…"
+          value={searchQuery}
+          onChange={(_, d) => setSearchQuery(d.value)}
+          aria-label="Filter workloads by name"
+        />
+
+        {/* Zoom controls */}
+        <div className={styles.zoomControls}>
+          <Tooltip content="Zoom in" relationship="label">
+            <Button
+              appearance="subtle"
+              icon={<ZoomInRegular />}
+              size="small"
+              onClick={handleZoomIn}
+              aria-label="Zoom in"
+            />
+          </Tooltip>
+          <Tooltip content="Zoom out" relationship="label">
+            <Button
+              appearance="subtle"
+              icon={<ZoomOutRegular />}
+              size="small"
+              onClick={handleZoomOut}
+              aria-label="Zoom out"
+            />
+          </Tooltip>
+          <Tooltip content="Reset zoom" relationship="label">
+            <Button
+              appearance="subtle"
+              icon={<ZoomFitRegular />}
+              size="small"
+              onClick={handleResetZoom}
+              aria-label="Reset zoom"
+            />
+          </Tooltip>
+        </div>
       </div>
 
       {/* Errors */}
@@ -600,7 +847,7 @@ export default function DependencyGraph({ projectId }: DependencyGraphProps) {
         <div className={styles.legendItem}>
           <div
             className={styles.legendSwatch}
-            style={{ backgroundColor: "#C50F1F", border: "2px solid #C50F1F" }}
+            style={{ backgroundColor: tokens.colorStatusDangerForeground1, border: `2px solid ${tokens.colorStatusDangerForeground1}` }}
             aria-hidden="true"
           />
           <Text size={200}>circular dependency</Text>
@@ -629,10 +876,21 @@ export default function DependencyGraph({ projectId }: DependencyGraphProps) {
         )}
         {graph !== null && graph.nodes.length > 0 && (
           <svg
+            ref={svgRef}
             width={svgW}
             height={svgH}
+            viewBox={
+              viewBox
+                ? `${viewBox.x} ${viewBox.y} ${viewBox.w} ${viewBox.h}`
+                : `0 0 ${svgW} ${svgH}`
+            }
             style={{ display: "block" }}
             aria-label="Workload dependency graph SVG"
+            onWheel={handleWheel}
+            onMouseDown={handleMouseDown}
+            onMouseMove={handleMouseMove}
+            onMouseUp={handleMouseUp}
+            onMouseLeave={handleMouseUp}
           >
             <defs>
               <marker
@@ -655,12 +913,12 @@ export default function DependencyGraph({ projectId }: DependencyGraphProps) {
                 markerHeight="6"
                 orient="auto-start-reverse"
               >
-                <path d="M 0 0 L 10 5 L 0 10 z" fill="#C50F1F" />
+                <path d="M 0 0 L 10 5 L 0 10 z" fill={tokens.colorStatusDangerForeground1} />
               </marker>
             </defs>
 
             {/* Edges */}
-            {graph.edges.map((edge) => {
+            {filteredEdges.map((edge) => {
               const from = layoutMap.get(edge.source);
               const to = layoutMap.get(edge.target);
               if (!from || !to) return null;
@@ -670,6 +928,7 @@ export default function DependencyGraph({ projectId }: DependencyGraphProps) {
                   from={from}
                   to={to}
                   inCycle={isEdgeInCycle(edge)}
+                  edge={edge}
                 />
               );
             })}
@@ -693,20 +952,15 @@ export default function DependencyGraph({ projectId }: DependencyGraphProps) {
       {/* Node detail panel */}
       {selectedNode && (
         <div
-          style={{
-            padding: tokens.spacingVerticalM,
-            backgroundColor: tokens.colorNeutralBackground1,
-            border: `1px solid ${tokens.colorNeutralStroke1}`,
-            borderRadius: tokens.borderRadiusMedium,
-          }}
+          className={styles.detailPanel}
           aria-label={`Details for ${selectedNode.name}`}
         >
           <Text weight="semibold" size={400}>
             {selectedNode.name}
           </Text>
-          <div style={{ marginTop: tokens.spacingVerticalS, display: "flex", flexDirection: "column", gap: tokens.spacingVerticalXS }}>
+          <div className={styles.detailContent}>
             <div className={styles.detailRow}>
-              <Text size={200} style={{ color: tokens.colorNeutralForeground3 }}>Criticality:</Text>
+              <Text size={200} className={styles.detailLabel}>Criticality:</Text>
               <Badge
                 appearance="tint"
                 color={
@@ -722,15 +976,15 @@ export default function DependencyGraph({ projectId }: DependencyGraphProps) {
               </Badge>
             </div>
             <div className={styles.detailRow}>
-              <Text size={200} style={{ color: tokens.colorNeutralForeground3 }}>Migration strategy:</Text>
+              <Text size={200} className={styles.detailLabel}>Migration strategy:</Text>
               <Text size={200}>{selectedNode.migration_strategy}</Text>
             </div>
             <div className={styles.detailRow}>
-              <Text size={200} style={{ color: tokens.colorNeutralForeground3 }}>In cycle:</Text>
+              <Text size={200} className={styles.detailLabel}>In cycle:</Text>
               <Text size={200}>{cycleNodes.has(selectedNode.id) ? "⚠ Yes" : "No"}</Text>
             </div>
             <div className={styles.detailRow}>
-              <Text size={200} style={{ color: tokens.colorNeutralForeground3 }}>Depends on:</Text>
+              <Text size={200} className={styles.detailLabel}>Depends on:</Text>
               <Text size={200}>
                 {(graph?.edges ?? [])
                   .filter((e) => e.source === selectedNode.id)
@@ -739,7 +993,7 @@ export default function DependencyGraph({ projectId }: DependencyGraphProps) {
               </Text>
             </div>
             <div className={styles.detailRow}>
-              <Text size={200} style={{ color: tokens.colorNeutralForeground3 }}>Required by:</Text>
+              <Text size={200} className={styles.detailLabel}>Required by:</Text>
               <Text size={200}>
                 {(graph?.edges ?? [])
                   .filter((e) => e.target === selectedNode.id)
@@ -753,7 +1007,7 @@ export default function DependencyGraph({ projectId }: DependencyGraphProps) {
 
       {/* Migration order */}
       {migrationOrder && (
-        <div style={{ display: "flex", flexDirection: "column", gap: tokens.spacingVerticalS }}>
+        <div className={styles.migrationOrderSection}>
           <Text weight="semibold" size={400}>
             Suggested Migration Order
           </Text>
@@ -765,7 +1019,7 @@ export default function DependencyGraph({ projectId }: DependencyGraphProps) {
             </MessageBar>
           )}
           {migrationOrder.order.length === 0 && (
-            <Text style={{ color: tokens.colorNeutralForeground3 }}>
+            <Text className={styles.mutedText}>
               Cannot determine order due to circular dependencies.
             </Text>
           )}
@@ -786,7 +1040,7 @@ export default function DependencyGraph({ projectId }: DependencyGraphProps) {
           </div>
           {migrationOrder.migration_groups.length > 0 && (
             <>
-              <Text weight="semibold" size={300} style={{ marginTop: tokens.spacingVerticalS }}>
+              <Text weight="semibold" size={300} className={styles.migrationGroupsTitle}>
                 Migration Groups
               </Text>
               {migrationOrder.migration_groups.map((group, idx) => (

--- a/frontend/src/pages/WorkloadsPage.tsx
+++ b/frontend/src/pages/WorkloadsPage.tsx
@@ -38,6 +38,7 @@ import {
   DocumentRegular,
   EditRegular,
   LinkRegular,
+  ShareRegular,
   WarningRegular,
 } from "@fluentui/react-icons";
 import type {
@@ -47,6 +48,7 @@ import type {
 } from "../services/api";
 import { api } from "../services/api";
 import WorkloadMapper from "../components/migration/WorkloadMapper";
+import DependencyGraph from "../components/migration/DependencyGraph";
 
 const useStyles = makeStyles({
   root: {
@@ -118,7 +120,7 @@ const useStyles = makeStyles({
   },
 });
 
-type TabValue = "import" | "inventory" | "mapping";
+type TabValue = "import" | "inventory" | "mapping" | "dependencies";
 
 const WORKLOAD_TYPES = ["vm", "database", "web-app", "container", "other"];
 const SOURCE_PLATFORMS = ["vmware", "hyperv", "physical", "aws", "gcp", "other"];
@@ -313,6 +315,7 @@ export default function WorkloadsPage({ projectId: propProjectId }: WorkloadsPag
         <Tab value="import" icon={<ArrowUploadRegular />}>Import</Tab>
         <Tab value="inventory" icon={<DocumentRegular />}>Inventory</Tab>
         <Tab value="mapping" icon={<LinkRegular />}>Mapping</Tab>
+        <Tab value="dependencies" icon={<ShareRegular />}>Dependencies</Tab>
       </TabList>
 
       {/* ---- Import Tab ---- */}
@@ -556,6 +559,13 @@ export default function WorkloadsPage({ projectId: propProjectId }: WorkloadsPag
               </Table>
             </div>
           )}
+        </div>
+      )}
+
+      {/* ---- Dependencies Tab ---- */}
+      {activeTab === "dependencies" && (
+        <div className={styles.tabContent}>
+          <DependencyGraph projectId={projectId} />
         </div>
       )}
 

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -268,6 +268,12 @@ export const api = {
       fetchApi<MigrationOrderResponse>(
         `/api/workloads/migration-order?project_id=${encodeURIComponent(projectId)}`,
       ),
+    /** Add a dependency between two workloads.
+     *
+     * @param dependencyType - Accepted by the API for future extensibility.
+     *   Currently only "depends_on" is supported; the backend records the
+     *   dependency as a plain ID reference and does not yet persist the type.
+     */
     addDependency: (workloadId: string, targetId: string, dependencyType = "depends_on") =>
       fetchApi<WorkloadRecord>(`/api/workloads/${workloadId}/dependencies`, {
         method: "POST",

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -260,6 +260,23 @@ export const api = {
         method: "PATCH",
         body: JSON.stringify({ target_subscription_id: subscriptionId, reasoning }),
       }),
+    getDependencyGraph: (projectId: string) =>
+      fetchApi<DependencyGraph>(
+        `/api/workloads/dependency-graph?project_id=${encodeURIComponent(projectId)}`,
+      ),
+    getMigrationOrder: (projectId: string) =>
+      fetchApi<MigrationOrderResponse>(
+        `/api/workloads/migration-order?project_id=${encodeURIComponent(projectId)}`,
+      ),
+    addDependency: (workloadId: string, targetId: string, dependencyType = "depends_on") =>
+      fetchApi<WorkloadRecord>(`/api/workloads/${workloadId}/dependencies`, {
+        method: "POST",
+        body: JSON.stringify({ target_workload_id: targetId, dependency_type: dependencyType }),
+      }),
+    removeDependency: (workloadId: string, targetId: string) =>
+      fetchApi<WorkloadRecord>(`/api/workloads/${workloadId}/dependencies/${targetId}`, {
+        method: "DELETE",
+      }),
   },
 };
 
@@ -499,4 +516,33 @@ export interface WorkloadMappingRecord {
 export interface WorkloadMappingResponse {
   mappings: WorkloadMappingRecord[];
   warnings: string[];
+}
+
+export interface WorkloadSummary {
+  id: string;
+  name: string;
+  criticality: string;
+  migration_strategy: string;
+  project_id: string;
+}
+
+export interface DependencyEdge {
+  source: string;
+  target: string;
+  dependency_type: string;
+}
+
+export interface DependencyGraph {
+  nodes: WorkloadSummary[];
+  edges: DependencyEdge[];
+  circular_dependencies: string[][];
+  migration_groups: string[][];
+}
+
+export interface MigrationOrderResponse {
+  order: string[];
+  migration_groups: string[][];
+  circular_dependencies: string[][];
+  has_circular: boolean;
+  workload_names: Record<string, string>;
 }


### PR DESCRIPTION
Closes #47

## Summary

Implements full dependency mapping visualization for workloads, including:

### Backend
- **`DependencyAnalyzer` service** (`backend/app/services/dependency_analyzer.py`): stdlib-only graph algorithms
  - `get_dependency_graph()` — builds directed graph from workload `dependencies` field
  - `find_circular_dependencies()` — DFS-based cycle detection (Johnson's algorithm, simplified)
  - `find_migration_groups()` — BFS connected components (undirected)
  - `suggest_migration_order()` — Kahn's topological sort; raises on cycles
- **Schemas** (`backend/app/schemas/dependency.py`): `DependencyGraph`, `WorkloadSummary`, `DependencyEdge`, `AddDependencyRequest`, `MigrationOrderResponse`
- **Four new API routes** added to `/api/workloads`:
  - `GET /dependency-graph?project_id=` — full graph with cycles + groups
  - `POST /{id}/dependencies` — add dependency link (idempotent)
  - `DELETE /{id}/dependencies/{target_id}` — remove dependency link
  - `GET /migration-order?project_id=` — topological order + warnings

### Frontend
- **`DependencyGraph` component** (`frontend/src/components/migration/DependencyGraph.tsx`): interactive SVG graph with no external libraries
  - Nodes: coloured rectangles with criticality strip, shortname, and criticality label
  - Edges: SVG lines with arrowhead markers (`<marker>` / `<line>`)
  - Circular dependency cycles highlighted in red (nodes + edges)
  - Migration groups shaded with group background colour
  - Click node → detail panel showing criticality, strategy, depends-on, required-by
  - **Add Dependency** button → Fluent UI `Popover` form with two Comboboxes
  - **Suggest Migration Order** button → numbered list below the graph with group table
- **API methods** in `frontend/src/services/api.ts`: `getDependencyGraph`, `getMigrationOrder`, `addDependency`, `removeDependency` + TypeScript interfaces
- **Dependencies tab** added to `WorkloadsPage` (4th tab, `ShareRegular` icon)

### Tests
- **Backend** (`backend/tests/test_dependency.py`): 28 tests — algorithm unit tests, no-DB route smoke tests, `_workloads_to_graph` helper tests, async DB-path tests (match pattern of `test_db_routes.py`; fail in this env due to missing `greenlet` — same as pre-existing DB tests)
- **Frontend** (`frontend/src/components/migration/DependencyGraph.test.tsx`): 14 tests — render, node click, cycle warning, migration order, error/empty states, refresh

### Quality
- Backend lint: `ruff check app/` — all checks passed
- Backend coverage: 75.11% (meets ≥75% threshold)
- Frontend tests: 251/251 passed, 84.95% statement coverage
- Frontend build: `tsc -b && vite build` — success