### PR TITLE
feat: Migration wave planner with auto-generation, drag-and-drop, and export (#46)

### DIFF
--- a/backend/app/api/routes/migration.py
+++ b/backend/app/api/routes/migration.py
@@ -6,7 +6,7 @@ from datetime import datetime, timezone
 
 from fastapi import APIRouter, Depends, HTTPException, Query
 from fastapi.responses import PlainTextResponse
-from sqlalchemy import select
+from sqlalchemy import select, update
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import selectinload
 
@@ -24,6 +24,7 @@ from app.schemas.migration_wave import (
     WavePlanResponse,
     WaveResponse,
     WaveUpdateRequest,
+    WaveValidateRequest,
     WaveWorkloadResponse,
 )
 from app.services.wave_planner import wave_planner
@@ -155,6 +156,16 @@ async def generate_waves(
             summaries, edges, payload.strategy, payload.max_wave_size
         )
 
+        # Deactivate existing active plans for this project
+        await db.execute(
+            update(MigrationPlan)
+            .where(
+                MigrationPlan.project_id == payload.project_id,
+                MigrationPlan.is_active == True,  # noqa: E712
+            )
+            .values(is_active=False)
+        )
+
         # Persist plan
         plan = MigrationPlan(
             id=str(uuid.uuid4()),
@@ -215,6 +226,21 @@ async def generate_waves(
 
         await db.flush()
 
+        # Auto-validate the generated plan
+        wave_dicts = []
+        for wr in wave_responses:
+            wave_dicts.append({
+                "id": wr.id,
+                "name": wr.name,
+                "order": wr.order,
+                "workload_ids": [wl.workload_id for wl in wr.workloads],
+            })
+        summary_map = {s.id: s for s in summaries}
+        warnings_raw = wave_planner.validate_waves(
+            wave_dicts, summary_map, edges, payload.max_wave_size
+        )
+        gen_warnings = [ValidationWarning(**w) for w in warnings_raw]
+
         return WavePlanResponse(
             id=plan.id,
             project_id=payload.project_id,
@@ -222,7 +248,7 @@ async def generate_waves(
             strategy=plan.strategy,
             is_active=plan.is_active,
             waves=wave_responses,
-            warnings=[],
+            warnings=gen_warnings,
             created_at=now,
             updated_at=now,
         )
@@ -340,10 +366,16 @@ async def get_wave(
         raise HTTPException(status_code=404, detail="Database not configured")
 
     try:
+        tenant_id = user.get("tid", user.get("tenant_id", "dev-tenant"))
         result = await db.execute(
             select(MigrationWave)
+            .join(MigrationPlan, MigrationWave.plan_id == MigrationPlan.id)
+            .join(Project, MigrationPlan.project_id == Project.id)
             .options(selectinload(MigrationWave.wave_workloads))
-            .where(MigrationWave.id == wave_id)
+            .where(
+                MigrationWave.id == wave_id,
+                Project.tenant_id == tenant_id,
+            )
         )
         wave = result.scalar_one_or_none()
         if wave is None:
@@ -377,10 +409,16 @@ async def update_wave(
         raise HTTPException(status_code=404, detail="Database not configured")
 
     try:
+        tenant_id = user.get("tid", user.get("tenant_id", "dev-tenant"))
         result = await db.execute(
             select(MigrationWave)
+            .join(MigrationPlan, MigrationWave.plan_id == MigrationPlan.id)
+            .join(Project, MigrationPlan.project_id == Project.id)
             .options(selectinload(MigrationWave.wave_workloads))
-            .where(MigrationWave.id == wave_id)
+            .where(
+                MigrationWave.id == wave_id,
+                Project.tenant_id == tenant_id,
+            )
         )
         wave = result.scalar_one_or_none()
         if wave is None:
@@ -434,10 +472,15 @@ async def move_workload(
         )
 
     try:
-        # Find the target wave and its plan
+        tenant_id = user.get("tid", user.get("tenant_id", "dev-tenant"))
+        # Find the target wave and verify tenant ownership
         target_result = await db.execute(
-            select(MigrationWave).where(
-                MigrationWave.id == payload.target_wave_id
+            select(MigrationWave)
+            .join(MigrationPlan, MigrationWave.plan_id == MigrationPlan.id)
+            .join(Project, MigrationPlan.project_id == Project.id)
+            .where(
+                MigrationWave.id == payload.target_wave_id,
+                Project.tenant_id == tenant_id,
             )
         )
         target_wave = target_result.scalar_one_or_none()
@@ -508,13 +551,13 @@ async def move_workload(
 
 @router.post("/waves/validate", response_model=WavePlanResponse)
 async def validate_plan(
-    payload: dict,
+    payload: WaveValidateRequest,
     user: dict = Depends(get_current_user),
     db: AsyncSession = Depends(get_db),
 ) -> WavePlanResponse:
     """Validate the current wave plan for dependency violations."""
     now = datetime.now(timezone.utc)
-    project_id = payload.get("project_id", "")
+    project_id = payload.project_id
 
     if db is None:
         return WavePlanResponse(
@@ -746,8 +789,15 @@ async def delete_wave(
         raise HTTPException(status_code=404, detail="Database not configured")
 
     try:
+        tenant_id = user.get("tid", user.get("tenant_id", "dev-tenant"))
         result = await db.execute(
-            select(MigrationWave).where(MigrationWave.id == wave_id)
+            select(MigrationWave)
+            .join(MigrationPlan, MigrationWave.plan_id == MigrationPlan.id)
+            .join(Project, MigrationPlan.project_id == Project.id)
+            .where(
+                MigrationWave.id == wave_id,
+                Project.tenant_id == tenant_id,
+            )
         )
         wave = result.scalar_one_or_none()
         if wave is None:

--- a/backend/app/api/routes/migration.py
+++ b/backend/app/api/routes/migration.py
@@ -1,0 +1,763 @@
+"""Migration wave planning API routes."""
+
+import logging
+import uuid
+from datetime import datetime, timezone
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+from fastapi.responses import PlainTextResponse
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import selectinload
+
+from app.auth import get_current_user
+from app.db.session import get_db
+from app.models.migration_wave import MigrationPlan, MigrationWave, WaveWorkload
+from app.models.project import Project
+from app.models.workload import Workload
+from app.schemas.dependency import DependencyEdge, WorkloadSummary
+from app.schemas.migration_wave import (
+    MoveWorkloadRequest,
+    ValidationWarning,
+    WaveExportRequest,
+    WaveGenerateRequest,
+    WavePlanResponse,
+    WaveResponse,
+    WaveUpdateRequest,
+    WaveWorkloadResponse,
+)
+from app.services.wave_planner import wave_planner
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/api/migration", tags=["migration"])
+
+
+def _wave_to_response(
+    wave: MigrationWave,
+    workload_map: dict[str, Workload] | None = None,
+) -> WaveResponse:
+    """Convert a MigrationWave ORM object to a WaveResponse."""
+    wl_responses: list[WaveWorkloadResponse] = []
+    for ww in wave.wave_workloads:
+        wl = workload_map.get(ww.workload_id) if workload_map else None
+        wl_responses.append(WaveWorkloadResponse(
+            id=ww.id,
+            workload_id=ww.workload_id,
+            name=wl.name if wl else ww.workload_id,
+            type=wl.type if wl else "unknown",
+            criticality=wl.criticality if wl else "standard",
+            migration_strategy=wl.migration_strategy if wl else "unknown",
+            position=ww.position,
+            dependencies=(wl.dependencies or []) if wl else [],
+        ))
+    return WaveResponse(
+        id=wave.id,
+        name=wave.name,
+        order=wave.order,
+        status=wave.status,
+        notes=wave.notes,
+        workloads=wl_responses,
+        created_at=wave.created_at,
+        updated_at=wave.updated_at,
+    )
+
+
+def _build_workload_summaries(
+    workloads: list[Workload],
+) -> tuple[list[WorkloadSummary], list[DependencyEdge]]:
+    """Build summaries and edges from workload ORM objects."""
+    summaries = []
+    edges = []
+    id_set = {w.id for w in workloads}
+    for w in workloads:
+        summaries.append(WorkloadSummary(
+            id=w.id,
+            name=w.name,
+            criticality=w.criticality,
+            migration_strategy=w.migration_strategy,
+            project_id=w.project_id,
+        ))
+        for dep_id in w.dependencies or []:
+            if dep_id in id_set:
+                edges.append(DependencyEdge(source=dep_id, target=w.id))
+    return summaries, edges
+
+
+@router.post("/waves/generate", response_model=WavePlanResponse)
+async def generate_waves(
+    payload: WaveGenerateRequest,
+    user: dict = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+) -> WavePlanResponse:
+    """Auto-generate migration waves from a project's workloads."""
+    now = datetime.now(timezone.utc)
+
+    if db is None:
+        # Return mock plan with no waves when no DB is available
+        plan_id = str(uuid.uuid4())
+        return WavePlanResponse(
+            id=plan_id,
+            project_id=payload.project_id,
+            name=payload.plan_name,
+            strategy=payload.strategy,
+            is_active=True,
+            waves=[],
+            warnings=[],
+            created_at=now,
+            updated_at=now,
+        )
+
+    try:
+        tenant_id = user.get("tid", user.get("tenant_id", "dev-tenant"))
+        proj_result = await db.execute(
+            select(Project).where(
+                Project.id == payload.project_id,
+                Project.tenant_id == tenant_id,
+            )
+        )
+        if proj_result.scalar_one_or_none() is None:
+            raise HTTPException(
+                status_code=403, detail="Project not found or access denied"
+            )
+
+        # Load workloads
+        wl_result = await db.execute(
+            select(Workload).where(
+                Workload.project_id == payload.project_id
+            )
+        )
+        workloads = list(wl_result.scalars().all())
+        if not workloads:
+            plan_id = str(uuid.uuid4())
+            return WavePlanResponse(
+                id=plan_id,
+                project_id=payload.project_id,
+                name=payload.plan_name,
+                strategy=payload.strategy,
+                is_active=True,
+                waves=[],
+                warnings=[
+                    ValidationWarning(
+                        type="missing_workload",
+                        message="No workloads found for this project",
+                    )
+                ],
+                created_at=now,
+                updated_at=now,
+            )
+
+        summaries, edges = _build_workload_summaries(workloads)
+        wl_map = {w.id: w for w in workloads}
+
+        # Generate waves
+        wave_lists = wave_planner.generate_waves(
+            summaries, edges, payload.strategy, payload.max_wave_size
+        )
+
+        # Persist plan
+        plan = MigrationPlan(
+            id=str(uuid.uuid4()),
+            project_id=payload.project_id,
+            name=payload.plan_name,
+            strategy=payload.strategy,
+            max_wave_size=payload.max_wave_size,
+            is_active=True,
+        )
+        db.add(plan)
+        await db.flush()
+
+        wave_responses: list[WaveResponse] = []
+        for idx, wave_workloads in enumerate(wave_lists):
+            wave = MigrationWave(
+                id=str(uuid.uuid4()),
+                plan_id=plan.id,
+                name=f"Wave {idx + 1}",
+                order=idx,
+                status="planned",
+            )
+            db.add(wave)
+            await db.flush()
+
+            wl_responses: list[WaveWorkloadResponse] = []
+            for pos, ws in enumerate(wave_workloads):
+                ww = WaveWorkload(
+                    id=str(uuid.uuid4()),
+                    wave_id=wave.id,
+                    workload_id=ws.id,
+                    plan_id=plan.id,
+                    position=pos,
+                )
+                db.add(ww)
+
+                wl = wl_map.get(ws.id)
+                wl_responses.append(WaveWorkloadResponse(
+                    id=ww.id,
+                    workload_id=ws.id,
+                    name=ws.name,
+                    type=wl.type if wl else "unknown",
+                    criticality=ws.criticality,
+                    migration_strategy=ws.migration_strategy,
+                    position=pos,
+                    dependencies=(wl.dependencies or []) if wl else [],
+                ))
+
+            wave_responses.append(WaveResponse(
+                id=wave.id,
+                name=wave.name,
+                order=wave.order,
+                status=wave.status,
+                notes=wave.notes,
+                workloads=wl_responses,
+                created_at=now,
+                updated_at=now,
+            ))
+
+        await db.flush()
+
+        return WavePlanResponse(
+            id=plan.id,
+            project_id=payload.project_id,
+            name=plan.name,
+            strategy=plan.strategy,
+            is_active=plan.is_active,
+            waves=wave_responses,
+            warnings=[],
+            created_at=now,
+            updated_at=now,
+        )
+    except HTTPException:
+        raise
+    except Exception as exc:
+        logger.exception("Failed to generate waves")
+        raise HTTPException(status_code=500, detail=str(exc)) from exc
+
+
+@router.get("/waves", response_model=WavePlanResponse)
+async def list_waves(
+    project_id: str = Query(..., description="Project ID"),
+    user: dict = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+) -> WavePlanResponse:
+    """Get the active wave plan for a project."""
+    now = datetime.now(timezone.utc)
+
+    if db is None:
+        return WavePlanResponse(
+            id="mock-plan",
+            project_id=project_id,
+            name="Migration Plan",
+            strategy="complexity_first",
+            is_active=True,
+            waves=[],
+            warnings=[],
+            created_at=now,
+            updated_at=now,
+        )
+
+    try:
+        tenant_id = user.get("tid", user.get("tenant_id", "dev-tenant"))
+        proj_result = await db.execute(
+            select(Project).where(
+                Project.id == project_id,
+                Project.tenant_id == tenant_id,
+            )
+        )
+        if proj_result.scalar_one_or_none() is None:
+            raise HTTPException(
+                status_code=403, detail="Project not found or access denied"
+            )
+
+        plan_result = await db.execute(
+            select(MigrationPlan)
+            .options(
+                selectinload(MigrationPlan.waves).selectinload(
+                    MigrationWave.wave_workloads
+                )
+            )
+            .where(
+                MigrationPlan.project_id == project_id,
+                MigrationPlan.is_active.is_(True),
+            )
+        )
+        plan = plan_result.scalar_one_or_none()
+        if plan is None:
+            return WavePlanResponse(
+                id="",
+                project_id=project_id,
+                name="No Plan",
+                strategy="complexity_first",
+                is_active=False,
+                waves=[],
+                warnings=[],
+                created_at=now,
+                updated_at=now,
+            )
+
+        # Load workloads for enrichment
+        wl_ids = [
+            ww.workload_id
+            for wave in plan.waves
+            for ww in wave.wave_workloads
+        ]
+        wl_map: dict[str, Workload] = {}
+        if wl_ids:
+            wl_result = await db.execute(
+                select(Workload).where(Workload.id.in_(wl_ids))
+            )
+            wl_map = {w.id: w for w in wl_result.scalars().all()}
+
+        wave_responses = [
+            _wave_to_response(wave, wl_map) for wave in plan.waves
+        ]
+
+        return WavePlanResponse(
+            id=plan.id,
+            project_id=project_id,
+            name=plan.name,
+            strategy=plan.strategy,
+            is_active=plan.is_active,
+            waves=wave_responses,
+            warnings=[],
+            created_at=plan.created_at,
+            updated_at=plan.updated_at,
+        )
+    except HTTPException:
+        raise
+    except Exception as exc:
+        logger.exception("Failed to list waves")
+        raise HTTPException(status_code=500, detail=str(exc)) from exc
+
+
+@router.get("/waves/{wave_id}", response_model=WaveResponse)
+async def get_wave(
+    wave_id: str,
+    user: dict = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+) -> WaveResponse:
+    """Get a single wave by ID."""
+    if db is None:
+        raise HTTPException(status_code=404, detail="Database not configured")
+
+    try:
+        result = await db.execute(
+            select(MigrationWave)
+            .options(selectinload(MigrationWave.wave_workloads))
+            .where(MigrationWave.id == wave_id)
+        )
+        wave = result.scalar_one_or_none()
+        if wave is None:
+            raise HTTPException(status_code=404, detail="Wave not found")
+
+        wl_ids = [ww.workload_id for ww in wave.wave_workloads]
+        wl_map: dict[str, Workload] = {}
+        if wl_ids:
+            wl_result = await db.execute(
+                select(Workload).where(Workload.id.in_(wl_ids))
+            )
+            wl_map = {w.id: w for w in wl_result.scalars().all()}
+
+        return _wave_to_response(wave, wl_map)
+    except HTTPException:
+        raise
+    except Exception as exc:
+        logger.exception("Failed to get wave")
+        raise HTTPException(status_code=500, detail=str(exc)) from exc
+
+
+@router.patch("/waves/{wave_id}", response_model=WaveResponse)
+async def update_wave(
+    wave_id: str,
+    updates: WaveUpdateRequest,
+    user: dict = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+) -> WaveResponse:
+    """Update a wave's name, status, or notes."""
+    if db is None:
+        raise HTTPException(status_code=404, detail="Database not configured")
+
+    try:
+        result = await db.execute(
+            select(MigrationWave)
+            .options(selectinload(MigrationWave.wave_workloads))
+            .where(MigrationWave.id == wave_id)
+        )
+        wave = result.scalar_one_or_none()
+        if wave is None:
+            raise HTTPException(status_code=404, detail="Wave not found")
+
+        if updates.name is not None:
+            wave.name = updates.name
+        if updates.status is not None:
+            wave.status = updates.status
+        if updates.notes is not None:
+            wave.notes = updates.notes
+
+        await db.flush()
+
+        wl_ids = [ww.workload_id for ww in wave.wave_workloads]
+        wl_map: dict[str, Workload] = {}
+        if wl_ids:
+            wl_result = await db.execute(
+                select(Workload).where(Workload.id.in_(wl_ids))
+            )
+            wl_map = {w.id: w for w in wl_result.scalars().all()}
+
+        return _wave_to_response(wave, wl_map)
+    except HTTPException:
+        raise
+    except Exception as exc:
+        logger.exception("Failed to update wave")
+        raise HTTPException(status_code=500, detail=str(exc)) from exc
+
+
+@router.post("/waves/move", response_model=WavePlanResponse)
+async def move_workload(
+    payload: MoveWorkloadRequest,
+    user: dict = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+) -> WavePlanResponse:
+    """Move a workload to a different wave."""
+    now = datetime.now(timezone.utc)
+
+    if db is None:
+        return WavePlanResponse(
+            id="mock-plan",
+            project_id="",
+            name="Migration Plan",
+            strategy="complexity_first",
+            is_active=True,
+            waves=[],
+            warnings=[],
+            created_at=now,
+            updated_at=now,
+        )
+
+    try:
+        # Find the target wave and its plan
+        target_result = await db.execute(
+            select(MigrationWave).where(
+                MigrationWave.id == payload.target_wave_id
+            )
+        )
+        target_wave = target_result.scalar_one_or_none()
+        if target_wave is None:
+            raise HTTPException(
+                status_code=404, detail="Target wave not found"
+            )
+
+        # Find the wave-workload entry
+        ww_result = await db.execute(
+            select(WaveWorkload).where(
+                WaveWorkload.workload_id == payload.workload_id,
+                WaveWorkload.plan_id == target_wave.plan_id,
+            )
+        )
+        ww = ww_result.scalar_one_or_none()
+        if ww is None:
+            raise HTTPException(
+                status_code=404,
+                detail="Workload not found in plan",
+            )
+
+        ww.wave_id = payload.target_wave_id
+        ww.position = payload.position
+        await db.flush()
+
+        # Return full plan
+        plan_result = await db.execute(
+            select(MigrationPlan)
+            .options(
+                selectinload(MigrationPlan.waves).selectinload(
+                    MigrationWave.wave_workloads
+                )
+            )
+            .where(MigrationPlan.id == target_wave.plan_id)
+        )
+        plan = plan_result.scalar_one()
+
+        wl_ids = [
+            ww2.workload_id
+            for w in plan.waves
+            for ww2 in w.wave_workloads
+        ]
+        wl_map: dict[str, Workload] = {}
+        if wl_ids:
+            wl_result = await db.execute(
+                select(Workload).where(Workload.id.in_(wl_ids))
+            )
+            wl_map = {w.id: w for w in wl_result.scalars().all()}
+
+        return WavePlanResponse(
+            id=plan.id,
+            project_id=plan.project_id,
+            name=plan.name,
+            strategy=plan.strategy,
+            is_active=plan.is_active,
+            waves=[_wave_to_response(w, wl_map) for w in plan.waves],
+            warnings=[],
+            created_at=plan.created_at,
+            updated_at=plan.updated_at,
+        )
+    except HTTPException:
+        raise
+    except Exception as exc:
+        logger.exception("Failed to move workload")
+        raise HTTPException(status_code=500, detail=str(exc)) from exc
+
+
+@router.post("/waves/validate", response_model=WavePlanResponse)
+async def validate_plan(
+    payload: dict,
+    user: dict = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+) -> WavePlanResponse:
+    """Validate the current wave plan for dependency violations."""
+    now = datetime.now(timezone.utc)
+    project_id = payload.get("project_id", "")
+
+    if db is None:
+        return WavePlanResponse(
+            id="mock-plan",
+            project_id=project_id,
+            name="Migration Plan",
+            strategy="complexity_first",
+            is_active=True,
+            waves=[],
+            warnings=[],
+            created_at=now,
+            updated_at=now,
+        )
+
+    try:
+        tenant_id = user.get("tid", user.get("tenant_id", "dev-tenant"))
+        proj_result = await db.execute(
+            select(Project).where(
+                Project.id == project_id,
+                Project.tenant_id == tenant_id,
+            )
+        )
+        if proj_result.scalar_one_or_none() is None:
+            raise HTTPException(
+                status_code=403, detail="Project not found or access denied"
+            )
+
+        plan_result = await db.execute(
+            select(MigrationPlan)
+            .options(
+                selectinload(MigrationPlan.waves).selectinload(
+                    MigrationWave.wave_workloads
+                )
+            )
+            .where(
+                MigrationPlan.project_id == project_id,
+                MigrationPlan.is_active.is_(True),
+            )
+        )
+        plan = plan_result.scalar_one_or_none()
+        if plan is None:
+            return WavePlanResponse(
+                id="",
+                project_id=project_id,
+                name="No Plan",
+                strategy="complexity_first",
+                is_active=False,
+                waves=[],
+                warnings=[],
+                created_at=now,
+                updated_at=now,
+            )
+
+        # Load workloads
+        wl_result = await db.execute(
+            select(Workload).where(
+                Workload.project_id == project_id
+            )
+        )
+        workloads = list(wl_result.scalars().all())
+        wl_map_orm = {w.id: w for w in workloads}
+
+        summaries, edges = _build_workload_summaries(workloads)
+        summary_map = {s.id: s for s in summaries}
+
+        # Build wave dicts for validation
+        wave_dicts = []
+        for wave in plan.waves:
+            wave_dicts.append({
+                "id": wave.id,
+                "name": wave.name,
+                "order": wave.order,
+                "workload_ids": [
+                    ww.workload_id for ww in wave.wave_workloads
+                ],
+            })
+
+        warnings_raw = wave_planner.validate_waves(
+            wave_dicts, summary_map, edges, plan.max_wave_size
+        )
+
+        warnings = [
+            ValidationWarning(**w) for w in warnings_raw
+        ]
+
+        wave_responses = [
+            _wave_to_response(w, wl_map_orm) for w in plan.waves
+        ]
+
+        return WavePlanResponse(
+            id=plan.id,
+            project_id=project_id,
+            name=plan.name,
+            strategy=plan.strategy,
+            is_active=plan.is_active,
+            waves=wave_responses,
+            warnings=warnings,
+            created_at=plan.created_at,
+            updated_at=plan.updated_at,
+        )
+    except HTTPException:
+        raise
+    except Exception as exc:
+        logger.exception("Failed to validate plan")
+        raise HTTPException(status_code=500, detail=str(exc)) from exc
+
+
+@router.post("/waves/export")
+async def export_plan(
+    payload: WaveExportRequest,
+    user: dict = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+) -> PlainTextResponse:
+    """Export the wave plan as CSV or Markdown."""
+    if db is None:
+        # Return empty export
+        if payload.format == "csv":
+            header = (
+                "Wave,Wave Status,Workload,Type,"
+                "Criticality,Strategy,Dependencies\r\n"
+            )
+            return PlainTextResponse(
+                content=header, media_type="text/csv"
+            )
+        return PlainTextResponse(
+            content="# Migration Wave Plan\n\n*No waves generated*\n",
+            media_type="text/markdown",
+        )
+
+    try:
+        tenant_id = user.get("tid", user.get("tenant_id", "dev-tenant"))
+        proj_result = await db.execute(
+            select(Project).where(
+                Project.id == payload.project_id,
+                Project.tenant_id == tenant_id,
+            )
+        )
+        if proj_result.scalar_one_or_none() is None:
+            raise HTTPException(
+                status_code=403, detail="Project not found or access denied"
+            )
+
+        plan_result = await db.execute(
+            select(MigrationPlan)
+            .options(
+                selectinload(MigrationPlan.waves).selectinload(
+                    MigrationWave.wave_workloads
+                )
+            )
+            .where(
+                MigrationPlan.project_id == payload.project_id,
+                MigrationPlan.is_active.is_(True),
+            )
+        )
+        plan = plan_result.scalar_one_or_none()
+        if plan is None:
+            if payload.format == "csv":
+                return PlainTextResponse(
+                    content="No plan found\r\n",
+                    media_type="text/csv",
+                )
+            return PlainTextResponse(
+                content="# Migration Wave Plan\n\n*No plan found*\n",
+                media_type="text/markdown",
+            )
+
+        # Build export data
+        wl_ids = [
+            ww.workload_id
+            for wave in plan.waves
+            for ww in wave.wave_workloads
+        ]
+        wl_map: dict[str, Workload] = {}
+        if wl_ids:
+            wl_result = await db.execute(
+                select(Workload).where(Workload.id.in_(wl_ids))
+            )
+            wl_map = {w.id: w for w in wl_result.scalars().all()}
+
+        waves_data = []
+        for wave in plan.waves:
+            wl_data = []
+            for ww in wave.wave_workloads:
+                wl = wl_map.get(ww.workload_id)
+                wl_data.append({
+                    "name": wl.name if wl else ww.workload_id,
+                    "type": wl.type if wl else "unknown",
+                    "criticality": (
+                        wl.criticality if wl else "standard"
+                    ),
+                    "migration_strategy": (
+                        wl.migration_strategy if wl else "unknown"
+                    ),
+                    "dependencies": (
+                        (wl.dependencies or []) if wl else []
+                    ),
+                })
+            waves_data.append({
+                "name": wave.name,
+                "status": wave.status,
+                "workloads": wl_data,
+            })
+
+        if payload.format == "csv":
+            content = wave_planner.export_csv(waves_data)
+            return PlainTextResponse(
+                content=content, media_type="text/csv"
+            )
+        else:
+            content = wave_planner.export_markdown(waves_data)
+            return PlainTextResponse(
+                content=content, media_type="text/markdown"
+            )
+    except HTTPException:
+        raise
+    except Exception as exc:
+        logger.exception("Failed to export plan")
+        raise HTTPException(status_code=500, detail=str(exc)) from exc
+
+
+@router.delete("/waves/{wave_id}")
+async def delete_wave(
+    wave_id: str,
+    user: dict = Depends(get_current_user),
+    db: AsyncSession = Depends(get_db),
+) -> dict:
+    """Delete a wave from a plan."""
+    if db is None:
+        raise HTTPException(status_code=404, detail="Database not configured")
+
+    try:
+        result = await db.execute(
+            select(MigrationWave).where(MigrationWave.id == wave_id)
+        )
+        wave = result.scalar_one_or_none()
+        if wave is None:
+            raise HTTPException(status_code=404, detail="Wave not found")
+
+        await db.delete(wave)
+        await db.flush()
+        return {"deleted": True}
+    except HTTPException:
+        raise
+    except Exception as exc:
+        logger.exception("Failed to delete wave")
+        raise HTTPException(status_code=500, detail=str(exc)) from exc

--- a/backend/app/db/migrations/versions/007_migration_waves.py
+++ b/backend/app/db/migrations/versions/007_migration_waves.py
@@ -1,0 +1,118 @@
+"""Add migration wave planning tables.
+
+Revision ID: 007
+Revises: 006
+Create Date: 2026-07-22
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "007"
+down_revision: str | None = "006"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "migration_plans",
+        sa.Column("id", sa.String(36), primary_key=True),
+        sa.Column(
+            "project_id",
+            sa.String(36),
+            sa.ForeignKey("projects.id"),
+            nullable=False,
+        ),
+        sa.Column(
+            "name", sa.String(255), nullable=False, server_default="Migration Plan"
+        ),
+        sa.Column(
+            "strategy", sa.String(50), nullable=False, server_default="complexity_first"
+        ),
+        sa.Column("max_wave_size", sa.Integer, nullable=True),
+        sa.Column("is_active", sa.Boolean, nullable=False, server_default=sa.text("1")),
+        sa.Column("notes", sa.Text, nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime,
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime,
+            server_default=sa.func.now(),
+            onupdate=sa.func.now(),
+            nullable=False,
+        ),
+    )
+    op.create_index("ix_migration_plans_project_id", "migration_plans", ["project_id"])
+
+    op.create_table(
+        "migration_waves",
+        sa.Column("id", sa.String(36), primary_key=True),
+        sa.Column(
+            "plan_id",
+            sa.String(36),
+            sa.ForeignKey("migration_plans.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column("name", sa.String(255), nullable=False),
+        sa.Column("order", sa.Integer, nullable=False),
+        sa.Column(
+            "status", sa.String(50), nullable=False, server_default="planned"
+        ),
+        sa.Column("notes", sa.Text, nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime,
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime,
+            server_default=sa.func.now(),
+            onupdate=sa.func.now(),
+            nullable=False,
+        ),
+    )
+    op.create_index("ix_migration_waves_plan_id", "migration_waves", ["plan_id"])
+
+    op.create_table(
+        "wave_workloads",
+        sa.Column("id", sa.String(36), primary_key=True),
+        sa.Column(
+            "wave_id",
+            sa.String(36),
+            sa.ForeignKey("migration_waves.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column(
+            "workload_id",
+            sa.String(36),
+            sa.ForeignKey("workloads.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column(
+            "plan_id",
+            sa.String(36),
+            sa.ForeignKey("migration_plans.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column("position", sa.Integer, nullable=False, server_default=sa.text("0")),
+        sa.UniqueConstraint("workload_id", "plan_id", name="uq_workload_per_plan"),
+    )
+    op.create_index("ix_wave_workloads_wave_id", "wave_workloads", ["wave_id"])
+
+
+def downgrade() -> None:
+    op.drop_index("ix_wave_workloads_wave_id", table_name="wave_workloads")
+    op.drop_table("wave_workloads")
+    op.drop_index("ix_migration_waves_plan_id", table_name="migration_waves")
+    op.drop_table("migration_waves")
+    op.drop_index("ix_migration_plans_project_id", table_name="migration_plans")
+    op.drop_table("migration_plans")

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -8,6 +8,7 @@ from app.api.routes.bicep import router as bicep_router
 from app.api.routes.compliance import router as compliance_router
 from app.api.routes.deployment import router as deployment_router
 from app.api.routes.discovery import router as discovery_router
+from app.api.routes.migration import router as migration_router
 from app.api.routes.projects import router as projects_router
 from app.api.routes.questionnaire import router as questionnaire_router
 from app.api.routes.questionnaire_state import router as questionnaire_state_router
@@ -76,6 +77,7 @@ app.include_router(scoring_router)
 app.include_router(questionnaire_state_router)
 app.include_router(discovery_router)
 app.include_router(workloads_router)
+app.include_router(migration_router)
 
 
 @app.get("/health")

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -6,6 +6,7 @@ from app.models.compliance import ComplianceControl, ComplianceFramework
 from app.models.compliance_result import ComplianceResult
 from app.models.deployment import Deployment
 from app.models.discovery import DiscoveredResource, DiscoveryScan
+from app.models.migration_wave import MigrationPlan, MigrationWave, WaveWorkload
 from app.models.project import Project
 from app.models.questionnaire import Question, QuestionCategory, QuestionnaireResponse
 from app.models.tenant import Tenant
@@ -30,4 +31,7 @@ __all__ = [
     "DiscoveryScan",
     "DiscoveredResource",
     "Workload",
+    "MigrationPlan",
+    "MigrationWave",
+    "WaveWorkload",
 ]

--- a/backend/app/models/migration_wave.py
+++ b/backend/app/models/migration_wave.py
@@ -1,0 +1,91 @@
+"""Migration wave planning models."""
+
+from sqlalchemy import ForeignKey, Integer, String, Text, UniqueConstraint
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from app.models.base import Base, TimestampMixin, generate_uuid
+
+WAVE_STATUSES = ["planned", "in_progress", "completed"]
+
+
+class MigrationPlan(Base, TimestampMixin):
+    """A migration plan contains ordered waves for a project."""
+
+    __tablename__ = "migration_plans"
+
+    id: Mapped[str] = mapped_column(
+        String(36), primary_key=True, default=generate_uuid
+    )
+    project_id: Mapped[str] = mapped_column(
+        String(36), ForeignKey("projects.id"), nullable=False, index=True
+    )
+    name: Mapped[str] = mapped_column(String(255), default="Migration Plan")
+    strategy: Mapped[str] = mapped_column(String(50), default="complexity_first")
+    max_wave_size: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    is_active: Mapped[bool] = mapped_column(default=True)
+    notes: Mapped[str | None] = mapped_column(Text, nullable=True)
+
+    waves: Mapped[list["MigrationWave"]] = relationship(
+        back_populates="plan",
+        cascade="all, delete-orphan",
+        order_by="MigrationWave.order",
+    )
+
+
+class MigrationWave(Base, TimestampMixin):
+    """A single wave within a migration plan."""
+
+    __tablename__ = "migration_waves"
+
+    id: Mapped[str] = mapped_column(
+        String(36), primary_key=True, default=generate_uuid
+    )
+    plan_id: Mapped[str] = mapped_column(
+        String(36),
+        ForeignKey("migration_plans.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    name: Mapped[str] = mapped_column(String(255), nullable=False)
+    order: Mapped[int] = mapped_column(Integer, nullable=False)
+    status: Mapped[str] = mapped_column(String(50), default="planned")
+    notes: Mapped[str | None] = mapped_column(Text, nullable=True)
+
+    plan: Mapped["MigrationPlan"] = relationship(back_populates="waves")
+    wave_workloads: Mapped[list["WaveWorkload"]] = relationship(
+        back_populates="wave",
+        cascade="all, delete-orphan",
+        order_by="WaveWorkload.position",
+    )
+
+
+class WaveWorkload(Base):
+    """Association between a wave and a workload with ordering."""
+
+    __tablename__ = "wave_workloads"
+    __table_args__ = (
+        UniqueConstraint("workload_id", "plan_id", name="uq_workload_per_plan"),
+    )
+
+    id: Mapped[str] = mapped_column(
+        String(36), primary_key=True, default=generate_uuid
+    )
+    wave_id: Mapped[str] = mapped_column(
+        String(36),
+        ForeignKey("migration_waves.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    workload_id: Mapped[str] = mapped_column(
+        String(36),
+        ForeignKey("workloads.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    plan_id: Mapped[str] = mapped_column(
+        String(36),
+        ForeignKey("migration_plans.id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    position: Mapped[int] = mapped_column(Integer, default=0)
+
+    wave: Mapped["MigrationWave"] = relationship(back_populates="wave_workloads")

--- a/backend/app/schemas/migration_wave.py
+++ b/backend/app/schemas/migration_wave.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from datetime import datetime
+from typing import Literal
 
 from pydantic import BaseModel, Field
 
@@ -52,7 +53,6 @@ class WaveUpdateRequest(BaseModel):
     name: str | None = None
     status: str | None = None
     notes: str | None = None
-    workload_ids: list[str] | None = None
 
 
 class MoveWorkloadRequest(BaseModel):
@@ -92,4 +92,10 @@ class WaveExportRequest(BaseModel):
     """Request to export wave plan."""
 
     project_id: str
-    format: str = "markdown"
+    format: Literal["csv", "markdown"] = "markdown"
+
+
+class WaveValidateRequest(BaseModel):
+    """Request to validate a wave plan."""
+
+    project_id: str

--- a/backend/app/schemas/migration_wave.py
+++ b/backend/app/schemas/migration_wave.py
@@ -1,0 +1,95 @@
+"""Pydantic schemas for migration wave planning."""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+from pydantic import BaseModel, Field
+
+
+class WaveGenerateRequest(BaseModel):
+    """Request to auto-generate a migration wave plan."""
+
+    project_id: str
+    strategy: str = "complexity_first"
+    max_wave_size: int | None = None
+    plan_name: str = "Migration Plan"
+
+
+class WaveWorkloadResponse(BaseModel):
+    """A workload within a wave."""
+
+    id: str
+    workload_id: str
+    name: str
+    type: str
+    criticality: str
+    migration_strategy: str
+    position: int
+    dependencies: list[str] = Field(default_factory=list)
+
+    model_config = {"from_attributes": True}
+
+
+class WaveResponse(BaseModel):
+    """A single migration wave."""
+
+    id: str
+    name: str
+    order: int
+    status: str
+    notes: str | None = None
+    workloads: list[WaveWorkloadResponse] = Field(default_factory=list)
+    created_at: datetime
+    updated_at: datetime
+
+    model_config = {"from_attributes": True}
+
+
+class WaveUpdateRequest(BaseModel):
+    """Request to update a wave."""
+
+    name: str | None = None
+    status: str | None = None
+    notes: str | None = None
+    workload_ids: list[str] | None = None
+
+
+class MoveWorkloadRequest(BaseModel):
+    """Request to move a workload between waves."""
+
+    workload_id: str
+    target_wave_id: str
+    position: int = 0
+
+
+class ValidationWarning(BaseModel):
+    """A warning about the wave plan."""
+
+    type: str
+    message: str
+    wave_id: str | None = None
+    workload_id: str | None = None
+
+
+class WavePlanResponse(BaseModel):
+    """Full wave plan with validation."""
+
+    id: str
+    project_id: str
+    name: str
+    strategy: str
+    is_active: bool
+    waves: list[WaveResponse] = Field(default_factory=list)
+    warnings: list[ValidationWarning] = Field(default_factory=list)
+    created_at: datetime
+    updated_at: datetime
+
+    model_config = {"from_attributes": True}
+
+
+class WaveExportRequest(BaseModel):
+    """Request to export wave plan."""
+
+    project_id: str
+    format: str = "markdown"

--- a/backend/app/services/wave_planner.py
+++ b/backend/app/services/wave_planner.py
@@ -1,0 +1,375 @@
+"""Migration wave planning service."""
+
+import csv
+import io
+import logging
+from collections import defaultdict
+
+from app.schemas.dependency import DependencyEdge, WorkloadSummary
+
+logger = logging.getLogger(__name__)
+
+COMPLEXITY_SCORES: dict[str, int] = {
+    "rehost": 1,
+    "refactor": 2,
+    "rearchitect": 3,
+    "rebuild": 4,
+    "replace": 5,
+    "unknown": 3,
+}
+
+CRITICALITY_ORDER_SAFE: dict[str, int] = {
+    "dev-test": 0,
+    "standard": 1,
+    "business-critical": 2,
+    "mission-critical": 3,
+}
+
+CRITICALITY_ORDER_PRIORITY: dict[str, int] = {
+    "mission-critical": 0,
+    "business-critical": 1,
+    "standard": 2,
+    "dev-test": 3,
+}
+
+
+class WavePlanner:
+    """Groups workloads into migration waves."""
+
+    @staticmethod
+    def _find_cycles(
+        nodes: set[str],
+        edges: list[DependencyEdge],
+    ) -> list[list[str]]:
+        """Detect circular dependencies using iterative DFS.
+
+        Returns a list of cycles, each a list of node IDs.
+        """
+        adj: dict[str, list[str]] = defaultdict(list)
+        for edge in edges:
+            if edge.source in nodes and edge.target in nodes:
+                adj[edge.source].append(edge.target)
+
+        visited: set[str] = set()
+        in_stack: set[str] = set()
+        cycles: list[list[str]] = []
+
+        for start in sorted(nodes):
+            if start in visited:
+                continue
+            # Iterative DFS with explicit stack
+            stack: list[tuple[str, int]] = [(start, 0)]
+            path: list[str] = []
+            while stack:
+                node, idx = stack.pop()
+                # If we're backtracking
+                if idx == 0:
+                    if node in visited and node not in in_stack:
+                        continue
+                    if node in in_stack:
+                        # Found a cycle
+                        if node in path:
+                            cycle_start = path.index(node)
+                            cycles.append(path[cycle_start:] + [node])
+                        continue
+                    visited.add(node)
+                    in_stack.add(node)
+                    path.append(node)
+                neighbors = adj.get(node, [])
+                if idx < len(neighbors):
+                    # Push current node back with next index
+                    stack.append((node, idx + 1))
+                    # Push neighbor
+                    stack.append((neighbors[idx], 0))
+                else:
+                    # Done with this node
+                    in_stack.discard(node)
+                    if path and path[-1] == node:
+                        path.pop()
+
+        return cycles
+
+    def generate_waves(
+        self,
+        workloads: list[WorkloadSummary],
+        edges: list[DependencyEdge] | None = None,
+        strategy: str = "complexity_first",
+        max_wave_size: int | None = None,
+    ) -> list[list[WorkloadSummary]]:
+        """Generate migration waves from workloads and dependencies.
+
+        Args:
+            workloads: List of workload summaries.
+            edges: Dependency edges.  If None, uses empty list.
+            strategy: "complexity_first" (simple first) or
+                "priority_first" (critical first).
+            max_wave_size: Max workloads per wave.  None = unlimited.
+
+        Returns:
+            List of waves, each a list of WorkloadSummary objects.
+        """
+        if not workloads:
+            return []
+
+        edges = edges or []
+        workload_map = {w.id: w for w in workloads}
+
+        # Detect cycles using built-in DFS
+        all_ids = {w.id for w in workloads}
+        cycles = self._find_cycles(all_ids, edges)
+        cycle_nodes: set[str] = set()
+        for cycle in cycles:
+            cycle_nodes.update(cycle)
+
+        # Get topological layers (respecting dependencies)
+        layers = self._topological_layers(workloads, edges, cycle_nodes)
+
+        # Sort within each layer by strategy
+        criticality_order = (
+            CRITICALITY_ORDER_PRIORITY
+            if strategy == "priority_first"
+            else CRITICALITY_ORDER_SAFE
+        )
+
+        for layer in layers:
+            layer.sort(
+                key=lambda wid: (
+                    criticality_order.get(
+                        workload_map[wid].criticality, 2
+                    ),
+                    COMPLEXITY_SCORES.get(
+                        workload_map[wid].migration_strategy, 3
+                    ),
+                    workload_map[wid].name,
+                )
+            )
+
+        # Split into waves respecting max_wave_size
+        waves: list[list[WorkloadSummary]] = []
+        for layer in layers:
+            layer_workloads = [
+                workload_map[wid]
+                for wid in layer
+                if wid in workload_map
+            ]
+            if not layer_workloads:
+                continue
+            if max_wave_size and len(layer_workloads) > max_wave_size:
+                for i in range(0, len(layer_workloads), max_wave_size):
+                    chunk = layer_workloads[i : i + max_wave_size]
+                    if chunk:
+                        waves.append(chunk)
+            else:
+                waves.append(layer_workloads)
+
+        return waves
+
+    def _topological_layers(
+        self,
+        workloads: list[WorkloadSummary],
+        edges: list[DependencyEdge],
+        cycle_nodes: set[str],
+    ) -> list[list[str]]:
+        """Compute topological layers using Kahn's algorithm variant.
+
+        Each layer contains workloads whose dependencies are all in
+        earlier layers.  Cyclic workloads are placed together in their
+        own layer at the end.
+
+        Args:
+            workloads: All workloads.
+            edges: Dependency edges (source is prerequisite of target).
+            cycle_nodes: IDs of workloads involved in cycles.
+
+        Returns:
+            List of layers, each a list of workload IDs.
+        """
+        all_ids = {w.id for w in workloads}
+        non_cycle_ids = all_ids - cycle_nodes
+
+        # Build adjacency for non-cycle nodes only
+        in_degree: dict[str, int] = {wid: 0 for wid in non_cycle_ids}
+        dependents: dict[str, list[str]] = {wid: [] for wid in non_cycle_ids}
+
+        for edge in edges:
+            if edge.source in non_cycle_ids and edge.target in non_cycle_ids:
+                in_degree[edge.target] = in_degree.get(edge.target, 0) + 1
+                dependents.setdefault(edge.source, []).append(edge.target)
+
+        layers: list[list[str]] = []
+
+        # Process non-cycle nodes in topological layers
+        current_layer = [
+            wid for wid in non_cycle_ids if in_degree.get(wid, 0) == 0
+        ]
+        while current_layer:
+            layers.append(sorted(current_layer))
+            next_layer: list[str] = []
+            for wid in current_layer:
+                for dep in dependents.get(wid, []):
+                    in_degree[dep] -= 1
+                    if in_degree[dep] == 0:
+                        next_layer.append(dep)
+            current_layer = next_layer
+
+        # Add cycle nodes as a separate layer at the end
+        if cycle_nodes:
+            layers.append(sorted(cycle_nodes))
+
+        return layers
+
+    def validate_waves(
+        self,
+        waves: list[dict],
+        workload_map: dict[str, WorkloadSummary],
+        edges: list[DependencyEdge],
+        max_wave_size: int | None = None,
+    ) -> list[dict]:
+        """Validate a wave plan for dependency violations and sizing.
+
+        Args:
+            waves: List of wave dicts with "id", "order", "workload_ids".
+            workload_map: Map of workload_id to WorkloadSummary.
+            edges: Dependency edges.
+            max_wave_size: Optional max workloads per wave.
+
+        Returns:
+            List of warning dicts.
+        """
+        warnings: list[dict] = []
+
+        # Build wave assignment map: workload_id -> wave_order
+        wave_assignment: dict[str, int] = {}
+        for wave in waves:
+            for wid in wave.get("workload_ids", []):
+                wave_assignment[wid] = wave["order"]
+
+        # Check dependency violations
+        for edge in edges:
+            source_wave = wave_assignment.get(edge.source)
+            target_wave = wave_assignment.get(edge.target)
+            if source_wave is not None and target_wave is not None:
+                if source_wave > target_wave:
+                    source_name = workload_map.get(edge.source)
+                    target_name = workload_map.get(edge.target)
+                    s_name = source_name.name if source_name else edge.source
+                    t_name = target_name.name if target_name else edge.target
+                    warnings.append({
+                        "type": "dependency_violation",
+                        "message": (
+                            f"'{t_name}' is in Wave {target_wave + 1} "
+                            f"but depends on '{s_name}' in "
+                            f"Wave {source_wave + 1}"
+                        ),
+                        "wave_id": None,
+                        "workload_id": edge.target,
+                    })
+
+        # Check wave sizes
+        if max_wave_size:
+            for wave in waves:
+                wl_count = len(wave.get("workload_ids", []))
+                if wl_count > max_wave_size:
+                    warnings.append({
+                        "type": "oversize_wave",
+                        "message": (
+                            f"Wave '{wave.get('name', '')}' has "
+                            f"{wl_count} workloads, exceeds max of "
+                            f"{max_wave_size}"
+                        ),
+                        "wave_id": wave.get("id"),
+                        "workload_id": None,
+                    })
+
+        # Check for unassigned workloads
+        assigned = set(wave_assignment.keys())
+        all_workloads = set(workload_map.keys())
+        missing = all_workloads - assigned
+        for wid in sorted(missing):
+            w = workload_map.get(wid)
+            warnings.append({
+                "type": "missing_workload",
+                "message": (
+                    f"Workload '{w.name if w else wid}' "
+                    f"is not assigned to any wave"
+                ),
+                "wave_id": None,
+                "workload_id": wid,
+            })
+
+        return warnings
+
+    def export_csv(self, waves_data: list[dict]) -> str:
+        """Export wave plan as CSV.
+
+        Args:
+            waves_data: List of wave dicts with workload details.
+
+        Returns:
+            CSV string.
+        """
+        output = io.StringIO()
+        writer = csv.writer(output)
+        writer.writerow([
+            "Wave",
+            "Wave Status",
+            "Workload",
+            "Type",
+            "Criticality",
+            "Strategy",
+            "Dependencies",
+        ])
+        for wave in waves_data:
+            for wl in wave.get("workloads", []):
+                writer.writerow([
+                    wave.get("name", ""),
+                    wave.get("status", "planned"),
+                    wl.get("name", ""),
+                    wl.get("type", ""),
+                    wl.get("criticality", ""),
+                    wl.get("migration_strategy", ""),
+                    "; ".join(wl.get("dependencies", [])),
+                ])
+        return output.getvalue()
+
+    def export_markdown(self, waves_data: list[dict]) -> str:
+        """Export wave plan as Markdown.
+
+        Args:
+            waves_data: List of wave dicts with workload details.
+
+        Returns:
+            Markdown string.
+        """
+        lines = ["# Migration Wave Plan", ""]
+        for wave in waves_data:
+            name = wave.get("name", "Wave")
+            status = wave.get("status", "planned")
+            workloads = wave.get("workloads", [])
+            lines.append(f"## {name} ({status})")
+            lines.append("")
+            if workloads:
+                lines.append(
+                    "| Workload | Type | Criticality "
+                    "| Strategy | Dependencies |"
+                )
+                lines.append(
+                    "|----------|------|-------------|"
+                    "----------|--------------|"
+                )
+                for wl in workloads:
+                    deps = ", ".join(wl.get("dependencies", []))
+                    lines.append(
+                        f"| {wl.get('name', '')} "
+                        f"| {wl.get('type', '')} "
+                        f"| {wl.get('criticality', '')} "
+                        f"| {wl.get('migration_strategy', '')} "
+                        f"| {deps} |"
+                    )
+            else:
+                lines.append("*No workloads assigned*")
+            lines.append("")
+        return "\n".join(lines)
+
+
+wave_planner = WavePlanner()

--- a/backend/tests/test_migrations.py
+++ b/backend/tests/test_migrations.py
@@ -23,7 +23,7 @@ async def test_migrations_run_cleanly():
     async with engine.connect() as conn:
         result = await conn.execute(text("SELECT version_num FROM alembic_version"))
         versions = [row[0] for row in result]
-        assert "006" in versions
+        assert "007" in versions
 
     await engine.dispose()
 

--- a/backend/tests/test_routes_migration.py
+++ b/backend/tests/test_routes_migration.py
@@ -1,0 +1,97 @@
+"""Tests for migration wave API routes."""
+
+import pytest
+from fastapi.testclient import TestClient
+
+from app.main import app
+
+client = TestClient(app)
+
+PROJECT_ID = "proj-test-migration"
+
+
+class TestGenerateWavesNoDB:
+    """Test wave generation endpoints when no DB is configured."""
+
+    def test_generate_waves_no_db(self):
+        payload = {
+            "project_id": PROJECT_ID,
+            "strategy": "complexity_first",
+            "plan_name": "Test Plan",
+        }
+        r = client.post("/api/migration/waves/generate", json=payload)
+        assert r.status_code == 200
+        data = r.json()
+        assert data["project_id"] == PROJECT_ID
+        assert data["name"] == "Test Plan"
+        assert data["strategy"] == "complexity_first"
+        assert data["is_active"] is True
+        assert isinstance(data["waves"], list)
+        assert isinstance(data["warnings"], list)
+
+    def test_generate_waves_priority_strategy_no_db(self):
+        payload = {
+            "project_id": PROJECT_ID,
+            "strategy": "priority_first",
+            "plan_name": "Priority Plan",
+            "max_wave_size": 5,
+        }
+        r = client.post("/api/migration/waves/generate", json=payload)
+        assert r.status_code == 200
+        data = r.json()
+        assert data["strategy"] == "priority_first"
+
+
+class TestListWavesNoDB:
+    def test_list_waves_no_db(self):
+        r = client.get(
+            "/api/migration/waves",
+            params={"project_id": PROJECT_ID},
+        )
+        assert r.status_code == 200
+        data = r.json()
+        assert data["project_id"] == PROJECT_ID
+        assert data["waves"] == []
+
+    def test_list_waves_missing_project_id(self):
+        r = client.get("/api/migration/waves")
+        assert r.status_code == 422
+
+
+class TestExportNoDB:
+    def test_export_csv_no_db(self):
+        payload = {"project_id": PROJECT_ID, "format": "csv"}
+        r = client.post("/api/migration/waves/export", json=payload)
+        assert r.status_code == 200
+        assert "Wave" in r.text
+        assert "Workload" in r.text
+
+    def test_export_markdown_no_db(self):
+        payload = {"project_id": PROJECT_ID, "format": "markdown"}
+        r = client.post("/api/migration/waves/export", json=payload)
+        assert r.status_code == 200
+        assert "Migration Wave Plan" in r.text
+
+
+class TestValidateNoDB:
+    def test_validate_no_db(self):
+        payload = {"project_id": PROJECT_ID}
+        r = client.post("/api/migration/waves/validate", json=payload)
+        assert r.status_code == 200
+        data = r.json()
+        assert data["project_id"] == PROJECT_ID
+        assert data["waves"] == []
+        assert data["warnings"] == []
+
+
+class TestMoveWorkloadNoDB:
+    def test_move_workload_no_db(self):
+        payload = {
+            "workload_id": "w1",
+            "target_wave_id": "wave-1",
+            "position": 0,
+        }
+        r = client.post("/api/migration/waves/move", json=payload)
+        assert r.status_code == 200
+        data = r.json()
+        assert "waves" in data

--- a/backend/tests/test_wave_planner.py
+++ b/backend/tests/test_wave_planner.py
@@ -1,0 +1,245 @@
+"""Tests for wave planner service."""
+
+import pytest
+
+from app.schemas.dependency import DependencyEdge, WorkloadSummary
+from app.services.wave_planner import WavePlanner
+
+
+def _ws(
+    wid: str,
+    name: str = "",
+    criticality: str = "standard",
+    strategy: str = "rehost",
+) -> WorkloadSummary:
+    return WorkloadSummary(
+        id=wid,
+        name=name or f"Workload-{wid}",
+        criticality=criticality,
+        migration_strategy=strategy,
+        project_id="proj-1",
+    )
+
+
+class TestGenerateWaves:
+    def setup_method(self):
+        self.planner = WavePlanner()
+
+    def test_generate_waves_empty(self):
+        result = self.planner.generate_waves([])
+        assert result == []
+
+    def test_generate_waves_no_dependencies(self):
+        workloads = [
+            _ws("a", strategy="rebuild"),
+            _ws("b", strategy="rehost"),
+            _ws("c", strategy="refactor"),
+        ]
+        waves = self.planner.generate_waves(workloads)
+        assert len(waves) == 1
+        ids = [w.id for w in waves[0]]
+        # rehost < refactor < rebuild in complexity
+        assert ids == ["b", "c", "a"]
+
+    def test_generate_waves_with_dependencies(self):
+        workloads = [_ws("a"), _ws("b"), _ws("c")]
+        edges = [
+            DependencyEdge(source="a", target="b"),
+            DependencyEdge(source="b", target="c"),
+        ]
+        waves = self.planner.generate_waves(workloads, edges)
+        assert len(waves) == 3
+        assert waves[0][0].id == "a"
+        assert waves[1][0].id == "b"
+        assert waves[2][0].id == "c"
+
+    def test_generate_waves_with_cycles(self):
+        workloads = [_ws("a"), _ws("b"), _ws("c"), _ws("d")]
+        edges = [
+            DependencyEdge(source="a", target="b"),
+            DependencyEdge(source="b", target="a"),  # cycle
+            DependencyEdge(source="c", target="d"),
+        ]
+        waves = self.planner.generate_waves(workloads, edges)
+        # c, d are non-cycle; a, b are cycle nodes placed last
+        assert len(waves) >= 2
+        all_ids = [w.id for wave in waves for w in wave]
+        assert set(all_ids) == {"a", "b", "c", "d"}
+        # Cycle nodes should be in the last wave
+        last_ids = {w.id for w in waves[-1]}
+        assert "a" in last_ids
+        assert "b" in last_ids
+
+    def test_generate_waves_max_size(self):
+        workloads = [_ws(f"w{i}") for i in range(6)]
+        waves = self.planner.generate_waves(
+            workloads, max_wave_size=2
+        )
+        for wave in waves:
+            assert len(wave) <= 2
+        all_ids = {w.id for wave in waves for w in wave}
+        assert len(all_ids) == 6
+
+    def test_generate_waves_priority_strategy(self):
+        workloads = [
+            _ws("a", criticality="dev-test", strategy="rehost"),
+            _ws("b", criticality="mission-critical", strategy="rehost"),
+            _ws("c", criticality="standard", strategy="rehost"),
+        ]
+        waves = self.planner.generate_waves(
+            workloads, strategy="priority_first"
+        )
+        assert len(waves) == 1
+        ids = [w.id for w in waves[0]]
+        # priority_first: mission-critical=0, standard=2, dev-test=3
+        assert ids[0] == "b"
+        assert ids[-1] == "a"
+
+    def test_generate_waves_complexity_first_strategy(self):
+        workloads = [
+            _ws("a", criticality="dev-test", strategy="rehost"),
+            _ws("b", criticality="mission-critical", strategy="rehost"),
+            _ws("c", criticality="standard", strategy="rehost"),
+        ]
+        waves = self.planner.generate_waves(
+            workloads, strategy="complexity_first"
+        )
+        assert len(waves) == 1
+        ids = [w.id for w in waves[0]]
+        # complexity_first: dev-test=0, standard=1, mission-critical=3
+        assert ids[0] == "a"
+        assert ids[-1] == "b"
+
+
+class TestValidateWaves:
+    def setup_method(self):
+        self.planner = WavePlanner()
+
+    def test_validate_dependency_violation(self):
+        workload_map = {
+            "a": _ws("a", name="Alpha"),
+            "b": _ws("b", name="Beta"),
+        }
+        edges = [DependencyEdge(source="a", target="b")]
+        waves = [
+            {"id": "w1", "name": "Wave 1", "order": 0, "workload_ids": ["b"]},
+            {"id": "w2", "name": "Wave 2", "order": 1, "workload_ids": ["a"]},
+        ]
+        warnings = self.planner.validate_waves(
+            waves, workload_map, edges
+        )
+        assert len(warnings) == 1
+        assert warnings[0]["type"] == "dependency_violation"
+        assert "Beta" in warnings[0]["message"]
+        assert "Alpha" in warnings[0]["message"]
+
+    def test_validate_oversize_wave(self):
+        workload_map = {
+            "a": _ws("a"),
+            "b": _ws("b"),
+            "c": _ws("c"),
+        }
+        waves = [
+            {
+                "id": "w1",
+                "name": "Wave 1",
+                "order": 0,
+                "workload_ids": ["a", "b", "c"],
+            },
+        ]
+        warnings = self.planner.validate_waves(
+            waves, workload_map, [], max_wave_size=2
+        )
+        assert len(warnings) == 1
+        assert warnings[0]["type"] == "oversize_wave"
+
+    def test_validate_missing_workloads(self):
+        workload_map = {
+            "a": _ws("a", name="Alpha"),
+            "b": _ws("b", name="Beta"),
+        }
+        waves = [
+            {"id": "w1", "name": "Wave 1", "order": 0, "workload_ids": ["a"]},
+        ]
+        warnings = self.planner.validate_waves(
+            waves, workload_map, []
+        )
+        assert len(warnings) == 1
+        assert warnings[0]["type"] == "missing_workload"
+        assert "Beta" in warnings[0]["message"]
+
+    def test_validate_no_warnings(self):
+        workload_map = {
+            "a": _ws("a"),
+            "b": _ws("b"),
+        }
+        edges = [DependencyEdge(source="a", target="b")]
+        waves = [
+            {"id": "w1", "name": "Wave 1", "order": 0, "workload_ids": ["a"]},
+            {"id": "w2", "name": "Wave 2", "order": 1, "workload_ids": ["b"]},
+        ]
+        warnings = self.planner.validate_waves(
+            waves, workload_map, edges
+        )
+        assert warnings == []
+
+
+class TestExport:
+    def setup_method(self):
+        self.planner = WavePlanner()
+        self.waves_data = [
+            {
+                "name": "Wave 1",
+                "status": "planned",
+                "workloads": [
+                    {
+                        "name": "VM-1",
+                        "type": "vm",
+                        "criticality": "standard",
+                        "migration_strategy": "rehost",
+                        "dependencies": ["DB-1"],
+                    },
+                ],
+            },
+            {
+                "name": "Wave 2",
+                "status": "planned",
+                "workloads": [
+                    {
+                        "name": "DB-1",
+                        "type": "database",
+                        "criticality": "business-critical",
+                        "migration_strategy": "refactor",
+                        "dependencies": [],
+                    },
+                ],
+            },
+        ]
+
+    def test_export_csv(self):
+        result = self.planner.export_csv(self.waves_data)
+        assert "Wave,Wave Status,Workload" in result
+        assert "VM-1" in result
+        assert "DB-1" in result
+        lines = result.strip().split("\n")
+        assert len(lines) == 3  # header + 2 data rows
+
+    def test_export_markdown(self):
+        result = self.planner.export_markdown(self.waves_data)
+        assert "# Migration Wave Plan" in result
+        assert "## Wave 1 (planned)" in result
+        assert "## Wave 2 (planned)" in result
+        assert "VM-1" in result
+        assert "DB-1" in result
+        assert "| Workload |" in result
+
+    def test_export_csv_empty(self):
+        result = self.planner.export_csv([])
+        lines = result.strip().split("\n")
+        assert len(lines) == 1  # header only
+
+    def test_export_markdown_empty_wave(self):
+        result = self.planner.export_markdown([
+            {"name": "Wave 1", "status": "planned", "workloads": []}
+        ])
+        assert "*No workloads assigned*" in result

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -16,6 +16,7 @@ const DeployPage = lazy(() => import("./pages/DeployPage"));
 const ProjectDetailPage = lazy(() => import("./pages/ProjectDetailPage"));
 const GapAnalysisPage = lazy(() => import("./pages/GapAnalysisPage"));
 const WorkloadsPage = lazy(() => import("./pages/WorkloadsPage"));
+const MigrationPage = lazy(() => import("./pages/MigrationPage"));
 
 function App() {
   return (
@@ -62,6 +63,9 @@ function App() {
                   <Route path="/workloads" element={<Navigate to="/projects" replace />} />
                   <Route path="/projects/:projectId/workloads" element={
                     <ProjectProvider><WorkloadsPage /></ProjectProvider>
+                  } />
+                  <Route path="/projects/:projectId/migration" element={
+                    <ProjectProvider><MigrationPage /></ProjectProvider>
                   } />
                 </Routes>
               </Suspense>

--- a/frontend/src/components/migration/WaveTimeline.test.tsx
+++ b/frontend/src/components/migration/WaveTimeline.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from "vitest";
-import { render, screen } from "@testing-library/react";
+import { render, screen, fireEvent } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { FluentProvider, teamsLightTheme } from "@fluentui/react-components";
 import { MemoryRouter } from "react-router-dom";
@@ -174,5 +174,77 @@ describe("WaveTimeline", () => {
     renderTimeline();
     const card = screen.getByTestId("workload-card-wl-1");
     expect(card).toHaveAttribute("draggable", "true");
+  });
+
+  it("calls onReorder with up direction", async () => {
+    const user = userEvent.setup();
+    const onReorder = vi.fn();
+    renderTimeline({ onReorder });
+
+    const moveUpBtn = screen.getByLabelText("Move Cache Server up");
+    await user.click(moveUpBtn);
+    expect(onReorder).toHaveBeenCalledWith("wave-1", "wl-2", "up");
+  });
+
+  it("supports drag and drop to move workloads between waves", () => {
+    const onMoveWorkload = vi.fn();
+    renderTimeline({ onMoveWorkload });
+
+    const card = screen.getByTestId("workload-card-wl-1");
+    const targetWave = screen.getByTestId("wave-column-wave-2");
+
+    const mockDataTransfer = {
+      setData: vi.fn(),
+      getData: vi.fn(() => "wl-1"),
+      effectAllowed: "none",
+      dropEffect: "none",
+    };
+
+    const startEvt = new Event("dragstart", { bubbles: true });
+    Object.defineProperty(startEvt, "dataTransfer", { value: mockDataTransfer });
+    fireEvent(card, startEvt);
+
+    const overEvt = new Event("dragover", { bubbles: true, cancelable: true });
+    Object.defineProperty(overEvt, "dataTransfer", { value: mockDataTransfer });
+    fireEvent(targetWave, overEvt);
+
+    const dropEvt = new Event("drop", { bubbles: true, cancelable: true });
+    Object.defineProperty(dropEvt, "dataTransfer", { value: mockDataTransfer });
+    fireEvent(targetWave, dropEvt);
+
+    expect(onMoveWorkload).toHaveBeenCalledWith("wl-1", "wave-2", 0);
+  });
+
+  it("resets drag state on drag end", () => {
+    renderTimeline();
+    const card = screen.getByTestId("workload-card-wl-1");
+    fireEvent.dragEnd(card);
+  });
+
+  it("resets drag over state on drag leave", () => {
+    renderTimeline();
+    const waveColumn = screen.getByTestId("wave-column-wave-1");
+    fireEvent.dragLeave(waveColumn);
+  });
+
+  it("renders completed status badge", () => {
+    const completedWaves: WaveResponse[] = [
+      { ...MOCK_WAVES[0], status: "completed" },
+    ];
+    renderTimeline({ waves: completedWaves });
+    expect(screen.getByText("completed")).toBeInTheDocument();
+  });
+
+  it("renders business-critical criticality badge", () => {
+    const bcWaves: WaveResponse[] = [
+      {
+        ...MOCK_WAVES[0],
+        workloads: [
+          { ...MOCK_WAVES[0].workloads[0], criticality: "business-critical" },
+        ],
+      },
+    ];
+    renderTimeline({ waves: bcWaves });
+    expect(screen.getByText("business-critical")).toBeInTheDocument();
   });
 });

--- a/frontend/src/components/migration/WaveTimeline.test.tsx
+++ b/frontend/src/components/migration/WaveTimeline.test.tsx
@@ -1,0 +1,178 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { FluentProvider, teamsLightTheme } from "@fluentui/react-components";
+import { MemoryRouter } from "react-router-dom";
+import WaveTimeline from "./WaveTimeline";
+import type { WaveResponse, ValidationWarning } from "../../services/api";
+
+const MOCK_WAVES: WaveResponse[] = [
+  {
+    id: "wave-1",
+    name: "Wave 1",
+    order: 0,
+    status: "planned",
+    notes: null,
+    workloads: [
+      {
+        id: "ww-1",
+        workload_id: "wl-1",
+        name: "Frontend App",
+        type: "web-app",
+        criticality: "standard",
+        migration_strategy: "rehost",
+        position: 0,
+        dependencies: [],
+      },
+      {
+        id: "ww-2",
+        workload_id: "wl-2",
+        name: "Cache Server",
+        type: "container",
+        criticality: "dev-test",
+        migration_strategy: "rehost",
+        position: 1,
+        dependencies: [],
+      },
+    ],
+    created_at: "2026-01-01T00:00:00Z",
+    updated_at: "2026-01-01T00:00:00Z",
+  },
+  {
+    id: "wave-2",
+    name: "Wave 2",
+    order: 1,
+    status: "in_progress",
+    notes: null,
+    workloads: [
+      {
+        id: "ww-3",
+        workload_id: "wl-3",
+        name: "Database",
+        type: "database",
+        criticality: "mission-critical",
+        migration_strategy: "refactor",
+        position: 0,
+        dependencies: ["wl-1"],
+      },
+    ],
+    created_at: "2026-01-01T00:00:00Z",
+    updated_at: "2026-01-01T00:00:00Z",
+  },
+];
+
+const MOCK_WARNINGS: ValidationWarning[] = [
+  {
+    type: "dependency_violation",
+    message: "'Database' depends on 'Frontend App' in a later wave",
+    wave_id: "wave-2",
+    workload_id: "wl-3",
+  },
+];
+
+function renderTimeline(
+  props: Partial<React.ComponentProps<typeof WaveTimeline>> = {},
+) {
+  return render(
+    <FluentProvider theme={teamsLightTheme}>
+      <MemoryRouter>
+        <WaveTimeline
+          waves={MOCK_WAVES}
+          warnings={[]}
+          {...props}
+        />
+      </MemoryRouter>
+    </FluentProvider>,
+  );
+}
+
+describe("WaveTimeline", () => {
+  it("renders waves with workloads", () => {
+    renderTimeline();
+    expect(screen.getByText("Wave 1")).toBeInTheDocument();
+    expect(screen.getByText("Wave 2")).toBeInTheDocument();
+    expect(screen.getByText("Frontend App")).toBeInTheDocument();
+    expect(screen.getByText("Cache Server")).toBeInTheDocument();
+    expect(screen.getByText("Database")).toBeInTheDocument();
+  });
+
+  it("shows workload count per wave", () => {
+    renderTimeline();
+    expect(screen.getByText("2 workloads")).toBeInTheDocument();
+    expect(screen.getByText("1 workloads")).toBeInTheDocument();
+  });
+
+  it("shows status badges", () => {
+    renderTimeline();
+    expect(screen.getByText("planned")).toBeInTheDocument();
+    expect(screen.getByText("in_progress")).toBeInTheDocument();
+  });
+
+  it("shows criticality badges", () => {
+    renderTimeline();
+    expect(screen.getByText("standard")).toBeInTheDocument();
+    expect(screen.getByText("dev-test")).toBeInTheDocument();
+    expect(screen.getByText("mission-critical")).toBeInTheDocument();
+  });
+
+  it("shows strategy badges", () => {
+    renderTimeline();
+    expect(screen.getAllByText("rehost")).toHaveLength(2);
+    expect(screen.getByText("refactor")).toBeInTheDocument();
+  });
+
+  it("renders empty state when no waves", () => {
+    renderTimeline({ waves: [] });
+    expect(screen.getByTestId("wave-empty")).toBeInTheDocument();
+    expect(screen.getByText(/No waves generated/)).toBeInTheDocument();
+  });
+
+  it("renders move up/down buttons", () => {
+    renderTimeline();
+    expect(screen.getByLabelText("Move Frontend App up")).toBeInTheDocument();
+    expect(screen.getByLabelText("Move Frontend App down")).toBeInTheDocument();
+    expect(screen.getByLabelText("Move Cache Server up")).toBeInTheDocument();
+    expect(screen.getByLabelText("Move Cache Server down")).toBeInTheDocument();
+  });
+
+  it("disables move up for first item", () => {
+    renderTimeline();
+    const moveUpBtn = screen.getByLabelText("Move Frontend App up");
+    expect(moveUpBtn).toBeDisabled();
+  });
+
+  it("disables move down for last item", () => {
+    renderTimeline();
+    const moveDownBtn = screen.getByLabelText("Move Cache Server down");
+    expect(moveDownBtn).toBeDisabled();
+  });
+
+  it("calls onReorder when move buttons clicked", async () => {
+    const user = userEvent.setup();
+    const onReorder = vi.fn();
+    renderTimeline({ onReorder });
+
+    const moveDownBtn = screen.getByLabelText("Move Frontend App down");
+    await user.click(moveDownBtn);
+    expect(onReorder).toHaveBeenCalledWith("wave-1", "wl-1", "down");
+  });
+
+  it("displays dependency warnings", () => {
+    renderTimeline({ warnings: MOCK_WARNINGS });
+    expect(screen.getByTestId("wave-warnings")).toBeInTheDocument();
+    expect(
+      screen.getAllByText(/Database.*depends on.*Frontend App/).length,
+    ).toBeGreaterThanOrEqual(1);
+  });
+
+  it("shows no warnings section when empty", () => {
+    renderTimeline({ warnings: [] });
+    expect(screen.queryByTestId("wave-warnings")).not.toBeInTheDocument();
+  });
+
+  it("workload cards are draggable", () => {
+    renderTimeline();
+    const card = screen.getByTestId("workload-card-wl-1");
+    expect(card).toHaveAttribute("draggable", "true");
+  });
+});

--- a/frontend/src/components/migration/WaveTimeline.tsx
+++ b/frontend/src/components/migration/WaveTimeline.tsx
@@ -1,0 +1,373 @@
+import { useState, useCallback } from "react";
+import {
+  makeStyles,
+  tokens,
+  Card,
+  CardHeader,
+  Badge,
+  Button,
+  Text,
+  Body1,
+  Caption1,
+  MessageBar,
+  MessageBarBody,
+  Tooltip,
+} from "@fluentui/react-components";
+import {
+  ArrowUpRegular,
+  ArrowDownRegular,
+  WarningRegular,
+} from "@fluentui/react-icons";
+import type { WaveResponse, WaveWorkloadItem, ValidationWarning } from "../../services/api";
+
+type BadgeColor = "informative" | "warning" | "severe" | "success" | "danger";
+
+function criticalityColor(criticality: string): BadgeColor {
+  switch (criticality) {
+    case "mission-critical":
+      return "danger";
+    case "business-critical":
+      return "severe";
+    case "dev-test":
+      return "informative";
+    default:
+      return "warning";
+  }
+}
+
+function statusColor(status: string): BadgeColor {
+  switch (status) {
+    case "completed":
+      return "success";
+    case "in_progress":
+      return "severe";
+    default:
+      return "informative";
+  }
+}
+
+const useStyles = makeStyles({
+  container: {
+    display: "flex",
+    gap: tokens.spacingHorizontalL,
+    overflowX: "auto",
+    paddingBottom: tokens.spacingVerticalM,
+    minHeight: "300px",
+  },
+  waveColumn: {
+    minWidth: "280px",
+    maxWidth: "350px",
+    display: "flex",
+    flexDirection: "column",
+    gap: tokens.spacingVerticalS,
+    backgroundColor: tokens.colorNeutralBackground2,
+    borderRadius: tokens.borderRadiusMedium,
+    padding: tokens.spacingVerticalM,
+  },
+  waveHeader: {
+    display: "flex",
+    justifyContent: "space-between",
+    alignItems: "center",
+    paddingBottom: tokens.spacingVerticalS,
+    borderBottom: `1px solid ${tokens.colorNeutralStroke2}`,
+    marginBottom: tokens.spacingVerticalXS,
+  },
+  waveTitle: {
+    display: "flex",
+    alignItems: "center",
+    gap: tokens.spacingHorizontalS,
+  },
+  workloadCard: {
+    cursor: "grab",
+    padding: tokens.spacingVerticalS,
+    marginBottom: tokens.spacingVerticalXS,
+  },
+  workloadCardDragging: {
+    opacity: "0.5",
+    cursor: "grabbing",
+    padding: tokens.spacingVerticalS,
+    marginBottom: tokens.spacingVerticalXS,
+  },
+  workloadRow: {
+    display: "flex",
+    justifyContent: "space-between",
+    alignItems: "center",
+  },
+  workloadMeta: {
+    display: "flex",
+    gap: tokens.spacingHorizontalXS,
+    flexWrap: "wrap",
+    marginTop: tokens.spacingVerticalXXS,
+  },
+  moveButtons: {
+    display: "flex",
+    flexDirection: "column",
+    gap: "2px",
+  },
+  dropZone: {
+    border: `2px dashed ${tokens.colorNeutralStroke1}`,
+    borderRadius: tokens.borderRadiusMedium,
+    padding: tokens.spacingVerticalM,
+    textAlign: "center",
+    minHeight: "60px",
+    display: "flex",
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  dropZoneActive: {
+    border: `2px dashed ${tokens.colorBrandStroke1}`,
+    borderRadius: tokens.borderRadiusMedium,
+    padding: tokens.spacingVerticalM,
+    textAlign: "center",
+    minHeight: "60px",
+    display: "flex",
+    alignItems: "center",
+    justifyContent: "center",
+    backgroundColor: tokens.colorBrandBackground2,
+  },
+  warningBar: {
+    marginBottom: tokens.spacingVerticalS,
+  },
+  emptyState: {
+    display: "flex",
+    alignItems: "center",
+    justifyContent: "center",
+    minHeight: "200px",
+    padding: tokens.spacingVerticalXXL,
+  },
+});
+
+interface WaveTimelineProps {
+  waves: WaveResponse[];
+  warnings?: ValidationWarning[];
+  onMoveWorkload?: (workloadId: string, targetWaveId: string, position: number) => void;
+  onReorder?: (waveId: string, workloadId: string, direction: "up" | "down") => void;
+}
+
+export default function WaveTimeline({
+  waves,
+  warnings = [],
+  onMoveWorkload,
+  onReorder,
+}: WaveTimelineProps) {
+  const styles = useStyles();
+  const [draggingId, setDraggingId] = useState<string | null>(null);
+  const [dragOverWaveId, setDragOverWaveId] = useState<string | null>(null);
+
+  const handleDragStart = useCallback(
+    (e: React.DragEvent, workloadId: string) => {
+      e.dataTransfer.setData("text/plain", workloadId);
+      e.dataTransfer.effectAllowed = "move";
+      setDraggingId(workloadId);
+    },
+    [],
+  );
+
+  const handleDragEnd = useCallback(() => {
+    setDraggingId(null);
+    setDragOverWaveId(null);
+  }, []);
+
+  const handleDragOver = useCallback(
+    (e: React.DragEvent, waveId: string) => {
+      e.preventDefault();
+      e.dataTransfer.dropEffect = "move";
+      setDragOverWaveId(waveId);
+    },
+    [],
+  );
+
+  const handleDragLeave = useCallback(() => {
+    setDragOverWaveId(null);
+  }, []);
+
+  const handleDrop = useCallback(
+    (e: React.DragEvent, targetWaveId: string) => {
+      e.preventDefault();
+      const workloadId = e.dataTransfer.getData("text/plain");
+      setDraggingId(null);
+      setDragOverWaveId(null);
+      if (workloadId && onMoveWorkload) {
+        onMoveWorkload(workloadId, targetWaveId, 0);
+      }
+    },
+    [onMoveWorkload],
+  );
+
+  const handleMoveUp = useCallback(
+    (waveId: string, workloadId: string) => {
+      if (onReorder) {
+        onReorder(waveId, workloadId, "up");
+      }
+    },
+    [onReorder],
+  );
+
+  const handleMoveDown = useCallback(
+    (waveId: string, workloadId: string) => {
+      if (onReorder) {
+        onReorder(waveId, workloadId, "down");
+      }
+    },
+    [onReorder],
+  );
+
+  // Collect warnings per workload
+  const workloadWarnings = new Map<string, ValidationWarning[]>();
+  for (const w of warnings) {
+    if (w.workload_id) {
+      const existing = workloadWarnings.get(w.workload_id) ?? [];
+      existing.push(w);
+      workloadWarnings.set(w.workload_id, existing);
+    }
+  }
+
+  if (waves.length === 0) {
+    return (
+      <div className={styles.emptyState} data-testid="wave-empty">
+        <Body1>
+          No waves generated yet. Click &quot;Generate Waves&quot; to create a
+          migration plan.
+        </Body1>
+      </div>
+    );
+  }
+
+  return (
+    <div>
+      {warnings.length > 0 && (
+        <div data-testid="wave-warnings">
+          {warnings.map((w, idx) => (
+            <MessageBar
+              key={`warn-${idx}`}
+              intent="warning"
+              className={styles.warningBar}
+            >
+              <MessageBarBody>
+                <WarningRegular /> {w.message}
+              </MessageBarBody>
+            </MessageBar>
+          ))}
+        </div>
+      )}
+
+      <div className={styles.container} data-testid="wave-timeline">
+        {waves.map((wave) => (
+          <div
+            key={wave.id}
+            className={styles.waveColumn}
+            onDragOver={(e) => handleDragOver(e, wave.id)}
+            onDragLeave={handleDragLeave}
+            onDrop={(e) => handleDrop(e, wave.id)}
+            data-testid={`wave-column-${wave.id}`}
+          >
+            <div className={styles.waveHeader}>
+              <div className={styles.waveTitle}>
+                <Text weight="semibold">{wave.name}</Text>
+                <Badge
+                  appearance="filled"
+                  color={statusColor(wave.status)}
+                  size="small"
+                >
+                  {wave.status}
+                </Badge>
+              </div>
+              <Caption1>{wave.workloads.length} workloads</Caption1>
+            </div>
+
+            {wave.workloads.map((wl: WaveWorkloadItem, idx: number) => {
+              const wlWarnings = workloadWarnings.get(wl.workload_id) ?? [];
+              return (
+                <Card
+                  key={wl.id}
+                  className={
+                    draggingId === wl.workload_id
+                      ? styles.workloadCardDragging
+                      : styles.workloadCard
+                  }
+                  draggable
+                  onDragStart={(e) => handleDragStart(e, wl.workload_id)}
+                  onDragEnd={handleDragEnd}
+                  data-testid={`workload-card-${wl.workload_id}`}
+                >
+                  <CardHeader
+                    header={
+                      <div className={styles.workloadRow}>
+                        <div>
+                          <Text weight="semibold">{wl.name}</Text>
+                          <div className={styles.workloadMeta}>
+                            <Badge
+                              appearance="tint"
+                              color={criticalityColor(wl.criticality)}
+                              size="small"
+                            >
+                              {wl.criticality}
+                            </Badge>
+                            <Badge appearance="outline" size="small">
+                              {wl.migration_strategy}
+                            </Badge>
+                            <Badge appearance="outline" size="small">
+                              {wl.type}
+                            </Badge>
+                          </div>
+                          {wlWarnings.length > 0 &&
+                            wlWarnings.map((warn, wIdx) => (
+                              <MessageBar
+                                key={`wl-warn-${wIdx}`}
+                                intent="warning"
+                                className={styles.warningBar}
+                              >
+                                <MessageBarBody>{warn.message}</MessageBarBody>
+                              </MessageBar>
+                            ))}
+                        </div>
+                        <div className={styles.moveButtons}>
+                          <Tooltip content="Move up" relationship="label">
+                            <Button
+                              size="small"
+                              icon={<ArrowUpRegular />}
+                              appearance="subtle"
+                              disabled={idx === 0}
+                              onClick={() =>
+                                handleMoveUp(wave.id, wl.workload_id)
+                              }
+                              aria-label={`Move ${wl.name} up`}
+                            />
+                          </Tooltip>
+                          <Tooltip content="Move down" relationship="label">
+                            <Button
+                              size="small"
+                              icon={<ArrowDownRegular />}
+                              appearance="subtle"
+                              disabled={idx === wave.workloads.length - 1}
+                              onClick={() =>
+                                handleMoveDown(wave.id, wl.workload_id)
+                              }
+                              aria-label={`Move ${wl.name} down`}
+                            />
+                          </Tooltip>
+                        </div>
+                      </div>
+                    }
+                  />
+                </Card>
+              );
+            })}
+
+            {wave.workloads.length === 0 && (
+              <div
+                className={
+                  dragOverWaveId === wave.id
+                    ? styles.dropZoneActive
+                    : styles.dropZone
+                }
+              >
+                <Caption1>Drop workloads here</Caption1>
+              </div>
+            )}
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/MigrationPage.test.tsx
+++ b/frontend/src/pages/MigrationPage.test.tsx
@@ -1,0 +1,189 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { FluentProvider, teamsLightTheme } from "@fluentui/react-components";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
+import MigrationPage from "./MigrationPage";
+import type { WavePlanResponse } from "../services/api";
+
+const MOCK_EMPTY_PLAN: WavePlanResponse = {
+  id: "plan-1",
+  project_id: "proj-1",
+  name: "Migration Plan",
+  strategy: "complexity_first",
+  is_active: true,
+  waves: [],
+  warnings: [],
+  created_at: "2026-01-01T00:00:00Z",
+  updated_at: "2026-01-01T00:00:00Z",
+};
+
+const MOCK_PLAN_WITH_WAVES: WavePlanResponse = {
+  id: "plan-1",
+  project_id: "proj-1",
+  name: "Migration Plan",
+  strategy: "complexity_first",
+  is_active: true,
+  waves: [
+    {
+      id: "wave-1",
+      name: "Wave 1",
+      order: 0,
+      status: "planned",
+      notes: null,
+      workloads: [
+        {
+          id: "ww-1",
+          workload_id: "wl-1",
+          name: "App Server",
+          type: "vm",
+          criticality: "standard",
+          migration_strategy: "rehost",
+          position: 0,
+          dependencies: [],
+        },
+      ],
+      created_at: "2026-01-01T00:00:00Z",
+      updated_at: "2026-01-01T00:00:00Z",
+    },
+  ],
+  warnings: [],
+  created_at: "2026-01-01T00:00:00Z",
+  updated_at: "2026-01-01T00:00:00Z",
+};
+
+vi.mock("../services/api", () => ({
+  api: {
+    migration: {
+      getWaves: vi.fn(),
+      generateWaves: vi.fn(),
+      moveWorkload: vi.fn(),
+      validatePlan: vi.fn(),
+      exportPlan: vi.fn(),
+      deleteWave: vi.fn(),
+    },
+  },
+}));
+
+const { api } = await import("../services/api");
+const mockedApi = vi.mocked(api.migration);
+
+function renderPage() {
+  return render(
+    <FluentProvider theme={teamsLightTheme}>
+      <MemoryRouter initialEntries={["/projects/proj-1/migration"]}>
+        <Routes>
+          <Route
+            path="/projects/:projectId/migration"
+            element={<MigrationPage />}
+          />
+        </Routes>
+      </MemoryRouter>
+    </FluentProvider>,
+  );
+}
+
+describe("MigrationPage", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockedApi.getWaves.mockResolvedValue(MOCK_EMPTY_PLAN);
+    mockedApi.generateWaves.mockResolvedValue(MOCK_PLAN_WITH_WAVES);
+    mockedApi.validatePlan.mockResolvedValue({
+      ...MOCK_PLAN_WITH_WAVES,
+      warnings: [
+        {
+          type: "dependency_violation",
+          message: "Test warning message",
+          wave_id: null,
+          workload_id: null,
+        },
+      ],
+    });
+    mockedApi.exportPlan.mockResolvedValue(new Blob(["test"]));
+  });
+
+  it("renders page with generate button", async () => {
+    renderPage();
+    await waitFor(() => {
+      expect(screen.getByText("Migration Wave Planner")).toBeInTheDocument();
+    });
+    expect(screen.getByTestId("generate-btn")).toBeInTheDocument();
+    expect(screen.getByText("Generate Waves")).toBeInTheDocument();
+  });
+
+  it("loads existing plan on mount", async () => {
+    renderPage();
+    await waitFor(() => {
+      expect(mockedApi.getWaves).toHaveBeenCalledWith("proj-1");
+    });
+  });
+
+  it("generates waves when button clicked", async () => {
+    const user = userEvent.setup();
+    renderPage();
+
+    await waitFor(() => {
+      expect(screen.getByTestId("generate-btn")).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByTestId("generate-btn"));
+
+    await waitFor(() => {
+      expect(mockedApi.generateWaves).toHaveBeenCalledWith(
+        expect.objectContaining({
+          project_id: "proj-1",
+          strategy: "complexity_first",
+        }),
+      );
+    });
+  });
+
+  it("shows waves after generation", async () => {
+    const user = userEvent.setup();
+    renderPage();
+
+    await waitFor(() => {
+      expect(screen.getByTestId("generate-btn")).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByTestId("generate-btn"));
+
+    await waitFor(() => {
+      expect(screen.getByText("Wave 1")).toBeInTheDocument();
+      expect(screen.getByText("App Server")).toBeInTheDocument();
+    });
+  });
+
+  it("shows export buttons after waves are generated", async () => {
+    const user = userEvent.setup();
+    renderPage();
+
+    await waitFor(() => {
+      expect(screen.getByTestId("generate-btn")).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByTestId("generate-btn"));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("export-csv-btn")).toBeInTheDocument();
+      expect(screen.getByTestId("export-md-btn")).toBeInTheDocument();
+    });
+  });
+
+  it("shows empty state when no waves", async () => {
+    renderPage();
+
+    await waitFor(() => {
+      expect(screen.getByTestId("wave-empty")).toBeInTheDocument();
+    });
+  });
+
+  it("handles API error gracefully", async () => {
+    mockedApi.getWaves.mockRejectedValue(new Error("Network error"));
+    renderPage();
+
+    await waitFor(() => {
+      expect(screen.getByText("Network error")).toBeInTheDocument();
+    });
+  });
+});

--- a/frontend/src/pages/MigrationPage.test.tsx
+++ b/frontend/src/pages/MigrationPage.test.tsx
@@ -186,4 +186,155 @@ describe("MigrationPage", () => {
       expect(screen.getByText("Network error")).toBeInTheDocument();
     });
   });
+
+  it("validates plan and shows warnings", async () => {
+    const user = userEvent.setup();
+    renderPage();
+
+    await waitFor(() => {
+      expect(screen.getByTestId("generate-btn")).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByTestId("generate-btn"));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("validate-btn")).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByTestId("validate-btn"));
+
+    await waitFor(() => {
+      expect(mockedApi.validatePlan).toHaveBeenCalledWith("proj-1");
+    });
+
+    await waitFor(() => {
+      expect(screen.getAllByText("Test warning message").length).toBeGreaterThanOrEqual(1);
+    });
+  });
+
+  it("exports plan as CSV", async () => {
+    const user = userEvent.setup();
+    global.URL.createObjectURL = vi.fn(() => "blob:test");
+    global.URL.revokeObjectURL = vi.fn();
+
+    renderPage();
+
+    await waitFor(() => {
+      expect(screen.getByTestId("generate-btn")).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByTestId("generate-btn"));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("export-csv-btn")).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByTestId("export-csv-btn"));
+
+    await waitFor(() => {
+      expect(mockedApi.exportPlan).toHaveBeenCalledWith("proj-1", "csv");
+    });
+  });
+
+  it("exports plan as markdown", async () => {
+    const user = userEvent.setup();
+    global.URL.createObjectURL = vi.fn(() => "blob:test");
+    global.URL.revokeObjectURL = vi.fn();
+
+    renderPage();
+
+    await waitFor(() => {
+      expect(screen.getByTestId("generate-btn")).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByTestId("generate-btn"));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("export-md-btn")).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByTestId("export-md-btn"));
+
+    await waitFor(() => {
+      expect(mockedApi.exportPlan).toHaveBeenCalledWith("proj-1", "markdown");
+    });
+  });
+
+  it("reorders workloads when move button clicked", async () => {
+    const user = userEvent.setup();
+    const multiWorkloadPlan: WavePlanResponse = {
+      ...MOCK_PLAN_WITH_WAVES,
+      waves: [
+        {
+          id: "wave-1",
+          name: "Wave 1",
+          order: 0,
+          status: "planned",
+          notes: null,
+          workloads: [
+            {
+              id: "ww-1",
+              workload_id: "wl-1",
+              name: "App Server",
+              type: "vm",
+              criticality: "standard",
+              migration_strategy: "rehost",
+              position: 0,
+              dependencies: [],
+            },
+            {
+              id: "ww-2",
+              workload_id: "wl-2",
+              name: "Cache Server",
+              type: "container",
+              criticality: "dev-test",
+              migration_strategy: "rehost",
+              position: 1,
+              dependencies: [],
+            },
+          ],
+          created_at: "2026-01-01T00:00:00Z",
+          updated_at: "2026-01-01T00:00:00Z",
+        },
+      ],
+    };
+    mockedApi.generateWaves.mockResolvedValue(multiWorkloadPlan);
+    mockedApi.moveWorkload.mockResolvedValue(multiWorkloadPlan);
+
+    renderPage();
+
+    await waitFor(() => {
+      expect(screen.getByTestId("generate-btn")).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByTestId("generate-btn"));
+
+    await waitFor(() => {
+      expect(screen.getByText("App Server")).toBeInTheDocument();
+      expect(screen.getByText("Cache Server")).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByLabelText("Move App Server down"));
+
+    await waitFor(() => {
+      expect(mockedApi.moveWorkload).toHaveBeenCalled();
+    });
+  });
+
+  it("shows error when generation fails", async () => {
+    const user = userEvent.setup();
+    mockedApi.generateWaves.mockRejectedValue(new Error("Generation failed"));
+
+    renderPage();
+
+    await waitFor(() => {
+      expect(screen.getByTestId("generate-btn")).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByTestId("generate-btn"));
+
+    await waitFor(() => {
+      expect(screen.getByText("Generation failed")).toBeInTheDocument();
+    });
+  });
 });

--- a/frontend/src/pages/MigrationPage.tsx
+++ b/frontend/src/pages/MigrationPage.tsx
@@ -1,0 +1,309 @@
+import { useState, useEffect, useCallback } from "react";
+import { useParams } from "react-router-dom";
+import {
+  makeStyles,
+  tokens,
+  Button,
+  Title1,
+  Subtitle1,
+  Body1,
+  Dropdown,
+  Option,
+  Input,
+  Spinner,
+  MessageBar,
+  MessageBarBody,
+  Card,
+} from "@fluentui/react-components";
+import {
+  PlayRegular,
+  ArrowDownloadRegular,
+  CheckmarkCircleRegular,
+} from "@fluentui/react-icons";
+import { api } from "../services/api";
+import type {
+  WavePlanResponse,
+  WaveResponse,
+  ValidationWarning,
+} from "../services/api";
+import WaveTimeline from "../components/migration/WaveTimeline";
+
+const useStyles = makeStyles({
+  container: {
+    maxWidth: "1200px",
+    marginLeft: "auto",
+    marginRight: "auto",
+    padding: tokens.spacingHorizontalXXL,
+    display: "flex",
+    flexDirection: "column",
+    gap: tokens.spacingVerticalL,
+  },
+  header: {
+    display: "flex",
+    justifyContent: "space-between",
+    alignItems: "center",
+  },
+  controls: {
+    display: "flex",
+    gap: tokens.spacingHorizontalM,
+    alignItems: "flex-end",
+    flexWrap: "wrap",
+  },
+  field: {
+    display: "flex",
+    flexDirection: "column",
+    gap: tokens.spacingVerticalXS,
+  },
+  actions: {
+    display: "flex",
+    gap: tokens.spacingHorizontalS,
+  },
+  validationPanel: {
+    padding: tokens.spacingVerticalM,
+  },
+});
+
+const STRATEGY_OPTIONS = [
+  { value: "complexity_first", label: "Simplest First" },
+  { value: "priority_first", label: "Critical First" },
+];
+
+export default function MigrationPage() {
+  const styles = useStyles();
+  const { projectId } = useParams<{ projectId: string }>();
+  const [, setPlan] = useState<WavePlanResponse | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [generating, setGenerating] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [strategy, setStrategy] = useState("complexity_first");
+  const [maxWaveSize, setMaxWaveSize] = useState<string>("");
+  const [waves, setWaves] = useState<WaveResponse[]>([]);
+  const [warnings, setWarnings] = useState<ValidationWarning[]>([]);
+
+  const loadPlan = useCallback(async () => {
+    if (!projectId) return;
+    setLoading(true);
+    setError(null);
+    try {
+      const data = await api.migration.getWaves(projectId);
+      setPlan(data);
+      setWaves(data.waves);
+      setWarnings(data.warnings);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to load plan");
+    } finally {
+      setLoading(false);
+    }
+  }, [projectId]);
+
+  useEffect(() => {
+    loadPlan();
+  }, [loadPlan]);
+
+  const handleGenerate = useCallback(async () => {
+    if (!projectId) return;
+    setGenerating(true);
+    setError(null);
+    try {
+      const size = maxWaveSize ? parseInt(maxWaveSize, 10) : undefined;
+      const data = await api.migration.generateWaves({
+        project_id: projectId,
+        strategy,
+        max_wave_size: size && !isNaN(size) ? size : null,
+        plan_name: "Migration Plan",
+      });
+      setPlan(data);
+      setWaves(data.waves);
+      setWarnings(data.warnings);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to generate waves");
+    } finally {
+      setGenerating(false);
+    }
+  }, [projectId, strategy, maxWaveSize]);
+
+  const handleMoveWorkload = useCallback(
+    async (workloadId: string, targetWaveId: string, position: number) => {
+      try {
+        const data = await api.migration.moveWorkload({
+          workload_id: workloadId,
+          target_wave_id: targetWaveId,
+          position,
+        });
+        setPlan(data);
+        setWaves(data.waves);
+        setWarnings(data.warnings);
+      } catch (err) {
+        setError(
+          err instanceof Error ? err.message : "Failed to move workload",
+        );
+      }
+    },
+    [],
+  );
+
+  const handleReorder = useCallback(
+    (waveId: string, workloadId: string, direction: "up" | "down") => {
+      setWaves((prev) => {
+        return prev.map((wave) => {
+          if (wave.id !== waveId) return wave;
+          const wls = [...wave.workloads];
+          const idx = wls.findIndex((wl) => wl.workload_id === workloadId);
+          if (idx < 0) return wave;
+          const newIdx = direction === "up" ? idx - 1 : idx + 1;
+          if (newIdx < 0 || newIdx >= wls.length) return wave;
+          [wls[idx], wls[newIdx]] = [wls[newIdx], wls[idx]];
+          return { ...wave, workloads: wls };
+        });
+      });
+    },
+    [],
+  );
+
+  const handleValidate = useCallback(async () => {
+    if (!projectId) return;
+    setError(null);
+    try {
+      const data = await api.migration.validatePlan(projectId);
+      setWarnings(data.warnings);
+    } catch (err) {
+      setError(
+        err instanceof Error ? err.message : "Failed to validate plan",
+      );
+    }
+  }, [projectId]);
+
+  const handleExport = useCallback(
+    async (format: "csv" | "markdown") => {
+      if (!projectId) return;
+      try {
+        const blob = await api.migration.exportPlan(projectId, format);
+        const url = URL.createObjectURL(blob);
+        const a = document.createElement("a");
+        a.href = url;
+        a.download = `migration-plan.${format === "csv" ? "csv" : "md"}`;
+        document.body.appendChild(a);
+        a.click();
+        document.body.removeChild(a);
+        URL.revokeObjectURL(url);
+      } catch (err) {
+        setError(
+          err instanceof Error ? err.message : "Failed to export plan",
+        );
+      }
+    },
+    [projectId],
+  );
+
+  if (loading) {
+    return (
+      <div className={styles.container}>
+        <Spinner size="large" label="Loading migration plan..." />
+      </div>
+    );
+  }
+
+  return (
+    <div className={styles.container}>
+      <div className={styles.header}>
+        <Title1>Migration Wave Planner</Title1>
+      </div>
+
+      <div className={styles.controls}>
+        <div className={styles.field}>
+          <Body1>Strategy</Body1>
+          <Dropdown
+            value={
+              STRATEGY_OPTIONS.find((o) => o.value === strategy)?.label ??
+              "Simplest First"
+            }
+            selectedOptions={[strategy]}
+            onOptionSelect={(_e, data) => {
+              if (data.optionValue) setStrategy(data.optionValue);
+            }}
+            data-testid="strategy-dropdown"
+          >
+            {STRATEGY_OPTIONS.map((opt) => (
+              <Option key={opt.value} value={opt.value}>
+                {opt.label}
+              </Option>
+            ))}
+          </Dropdown>
+        </div>
+
+        <div className={styles.field}>
+          <Body1>Max wave size</Body1>
+          <Input
+            type="number"
+            placeholder="Unlimited"
+            value={maxWaveSize}
+            onChange={(_e, data) => setMaxWaveSize(data.value)}
+            data-testid="max-wave-size"
+          />
+        </div>
+
+        <Button
+          appearance="primary"
+          icon={<PlayRegular />}
+          onClick={handleGenerate}
+          disabled={generating}
+          data-testid="generate-btn"
+        >
+          {generating ? "Generating..." : "Generate Waves"}
+        </Button>
+      </div>
+
+      {error && (
+        <MessageBar intent="error">
+          <MessageBarBody>{error}</MessageBarBody>
+        </MessageBar>
+      )}
+
+      <Subtitle1>Wave Timeline</Subtitle1>
+
+      <WaveTimeline
+        waves={waves}
+        warnings={warnings}
+        onMoveWorkload={handleMoveWorkload}
+        onReorder={handleReorder}
+      />
+
+      {waves.length > 0 && (
+        <div className={styles.actions}>
+          <Button
+            icon={<CheckmarkCircleRegular />}
+            onClick={handleValidate}
+            data-testid="validate-btn"
+          >
+            Validate Plan
+          </Button>
+          <Button
+            icon={<ArrowDownloadRegular />}
+            onClick={() => handleExport("csv")}
+            data-testid="export-csv-btn"
+          >
+            Export CSV
+          </Button>
+          <Button
+            icon={<ArrowDownloadRegular />}
+            onClick={() => handleExport("markdown")}
+            data-testid="export-md-btn"
+          >
+            Export Markdown
+          </Button>
+        </div>
+      )}
+
+      {warnings.length > 0 && (
+        <Card className={styles.validationPanel}>
+          <Subtitle1>Validation Warnings ({warnings.length})</Subtitle1>
+          {warnings.map((w, idx) => (
+            <MessageBar key={`vw-${idx}`} intent="warning">
+              <MessageBarBody>{w.message}</MessageBarBody>
+            </MessageBar>
+          ))}
+        </Card>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/pages/MigrationPage.tsx
+++ b/frontend/src/pages/MigrationPage.tsx
@@ -22,7 +22,6 @@ import {
 } from "@fluentui/react-icons";
 import { api } from "../services/api";
 import type {
-  WavePlanResponse,
   WaveResponse,
   ValidationWarning,
 } from "../services/api";
@@ -71,7 +70,6 @@ const STRATEGY_OPTIONS = [
 export default function MigrationPage() {
   const styles = useStyles();
   const { projectId } = useParams<{ projectId: string }>();
-  const [, setPlan] = useState<WavePlanResponse | null>(null);
   const [loading, setLoading] = useState(false);
   const [generating, setGenerating] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -86,7 +84,6 @@ export default function MigrationPage() {
     setError(null);
     try {
       const data = await api.migration.getWaves(projectId);
-      setPlan(data);
       setWaves(data.waves);
       setWarnings(data.warnings);
     } catch (err) {
@@ -112,7 +109,6 @@ export default function MigrationPage() {
         max_wave_size: size && !isNaN(size) ? size : null,
         plan_name: "Migration Plan",
       });
-      setPlan(data);
       setWaves(data.waves);
       setWarnings(data.warnings);
     } catch (err) {
@@ -130,7 +126,6 @@ export default function MigrationPage() {
           target_wave_id: targetWaveId,
           position,
         });
-        setPlan(data);
         setWaves(data.waves);
         setWarnings(data.warnings);
       } catch (err) {
@@ -145,7 +140,7 @@ export default function MigrationPage() {
   const handleReorder = useCallback(
     (waveId: string, workloadId: string, direction: "up" | "down") => {
       setWaves((prev) => {
-        return prev.map((wave) => {
+        const updated = prev.map((wave) => {
           if (wave.id !== waveId) return wave;
           const wls = [...wave.workloads];
           const idx = wls.findIndex((wl) => wl.workload_id === workloadId);
@@ -155,6 +150,31 @@ export default function MigrationPage() {
           [wls[idx], wls[newIdx]] = [wls[newIdx], wls[idx]];
           return { ...wave, workloads: wls };
         });
+
+        // Persist the new position via API
+        const wave = updated.find((w) => w.id === waveId);
+        if (wave) {
+          const targetIdx = wave.workloads.findIndex(
+            (w) => w.workload_id === workloadId,
+          );
+          if (targetIdx >= 0) {
+            api.migration
+              .moveWorkload({
+                workload_id: workloadId,
+                target_wave_id: waveId,
+                position: targetIdx,
+              })
+              .catch((err: unknown) => {
+                setError(
+                  err instanceof Error
+                    ? err.message
+                    : "Failed to reorder workload",
+                );
+              });
+          }
+        }
+
+        return updated;
       });
     },
     [],

--- a/frontend/src/pages/ProjectDetailPage.tsx
+++ b/frontend/src/pages/ProjectDetailPage.tsx
@@ -211,6 +211,34 @@ export default function ProjectDetailPage() {
           );
         })}
       </Card>
+      <Subtitle1>Tools</Subtitle1>
+
+      <Card className={styles.stepCard}>
+        <div className={styles.stepRow}>
+          <div className={styles.stepLabel}>
+            <Body1>Workloads</Body1>
+          </div>
+          <Button
+            appearance="subtle"
+            size="small"
+            onClick={() => navigate(`/projects/${project.id}/workloads`)}
+          >
+            Open →
+          </Button>
+        </div>
+        <div className={styles.stepRow}>
+          <div className={styles.stepLabel}>
+            <Body1>Migration Waves</Body1>
+          </div>
+          <Button
+            appearance="subtle"
+            size="small"
+            onClick={() => navigate(`/projects/${project.id}/migration`)}
+          >
+            Open →
+          </Button>
+        </div>
+      </Card>
     </div>
   );
 }

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -312,7 +312,7 @@ export const api = {
         method: "POST",
         body: JSON.stringify({ project_id: projectId }),
       }),
-    exportPlan: (projectId: string, format: string) =>
+    exportPlan: (projectId: string, format: 'csv' | 'markdown') =>
       fetchBlob("/api/migration/waves/export", {
         method: "POST",
         body: JSON.stringify({ project_id: projectId, format }),

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -284,6 +284,42 @@ export const api = {
         method: "DELETE",
       }),
   },
+
+  migration: {
+    generateWaves: (body: WaveGenerateRequest) =>
+      fetchApi<WavePlanResponse>("/api/migration/waves/generate", {
+        method: "POST",
+        body: JSON.stringify(body),
+      }),
+    getWaves: (projectId: string) =>
+      fetchApi<WavePlanResponse>(
+        `/api/migration/waves?project_id=${encodeURIComponent(projectId)}`,
+      ),
+    getWave: (waveId: string) =>
+      fetchApi<WaveResponse>(`/api/migration/waves/${waveId}`),
+    updateWave: (waveId: string, body: WaveUpdateRequest) =>
+      fetchApi<WaveResponse>(`/api/migration/waves/${waveId}`, {
+        method: "PATCH",
+        body: JSON.stringify(body),
+      }),
+    moveWorkload: (body: MoveWorkloadRequest) =>
+      fetchApi<WavePlanResponse>("/api/migration/waves/move", {
+        method: "POST",
+        body: JSON.stringify(body),
+      }),
+    validatePlan: (projectId: string) =>
+      fetchApi<WavePlanResponse>("/api/migration/waves/validate", {
+        method: "POST",
+        body: JSON.stringify({ project_id: projectId }),
+      }),
+    exportPlan: (projectId: string, format: string) =>
+      fetchBlob("/api/migration/waves/export", {
+        method: "POST",
+        body: JSON.stringify({ project_id: projectId, format }),
+      }),
+    deleteWave: (waveId: string) =>
+      fetchApi<void>(`/api/migration/waves/${waveId}`, { method: "DELETE" }),
+  },
 };
 
 export interface Category {
@@ -551,4 +587,67 @@ export interface MigrationOrderResponse {
   circular_dependencies: string[][];
   has_circular: boolean;
   workload_names: Record<string, string>;
+}
+
+// --- Migration Wave Planning ---
+
+export interface WaveGenerateRequest {
+  project_id: string;
+  strategy?: string;
+  max_wave_size?: number | null;
+  plan_name?: string;
+}
+
+export interface WaveWorkloadItem {
+  id: string;
+  workload_id: string;
+  name: string;
+  type: string;
+  criticality: string;
+  migration_strategy: string;
+  position: number;
+  dependencies: string[];
+}
+
+export interface WaveResponse {
+  id: string;
+  name: string;
+  order: number;
+  status: string;
+  notes: string | null;
+  workloads: WaveWorkloadItem[];
+  created_at: string;
+  updated_at: string;
+}
+
+export interface ValidationWarning {
+  type: string;
+  message: string;
+  wave_id: string | null;
+  workload_id: string | null;
+}
+
+export interface WavePlanResponse {
+  id: string;
+  project_id: string;
+  name: string;
+  strategy: string;
+  is_active: boolean;
+  waves: WaveResponse[];
+  warnings: ValidationWarning[];
+  created_at: string;
+  updated_at: string;
+}
+
+export interface WaveUpdateRequest {
+  name?: string;
+  status?: string;
+  notes?: string;
+  workload_ids?: string[];
+}
+
+export interface MoveWorkloadRequest {
+  workload_id: string;
+  target_wave_id: string;
+  position?: number;
 }


### PR DESCRIPTION
Closes #46

## Summary

Implements full migration wave planning for workloads, including:

### Backend
- **WavePlanner service** (\ackend/app/services/wave_planner.py\): Core algorithm using Kahn's topological layering
  - \generate_waves()\ — groups workloads into waves respecting dependency order, complexity scoring, and criticality
  - \alidate_waves()\ — detects dependency violations, oversize waves, unassigned workloads
  - \xport_csv()\ / \xport_markdown()\ — export wave plans
  - Cycle detection via DFS — cyclic workloads placed in final wave with warnings
- **3 ORM models** (\ackend/app/models/migration_wave.py\): MigrationPlan, MigrationWave, WaveWorkload with proper FK constraints and unique constraints
- **Schemas** (\ackend/app/schemas/migration_wave.py\): WaveGenerateRequest, WaveResponse, WavePlanResponse, MoveWorkloadRequest, ValidationWarning, WaveExportRequest
- **8 API endpoints** at \/api/migration/waves\:
  - \POST /generate\ — auto-generate waves from workload inventory
  - \GET /\ — list waves for a project
  - \GET /{wave_id}\ — get single wave details
  - \PATCH /{wave_id}\ — update wave (name, status, notes)
  - \POST /move\ — move workload between waves
  - \POST /validate\ — validate current plan
  - \POST /export\ — export plan as CSV or Markdown
  - \DELETE /{wave_id}\ — delete a wave
- **Alembic migration** for 3 new tables

### Frontend
- **WaveTimeline component** (\rontend/src/components/migration/WaveTimeline.tsx\): Kanban-style visualization
  - Wave columns with workload cards showing criticality badges and migration strategy
  - HTML5 drag-and-drop to move workloads between waves
  - Up/down buttons as accessibility alternative to drag
  - Dependency violation warnings inline
  - Fluent UI v9 components with makeStyles + tokens
- **MigrationPage** (\rontend/src/pages/MigrationPage.tsx\):
  - Strategy selector (Simplest First / Critical First)
  - Optional max wave size configuration
  - Generate, validate, export controls
  - Validation warnings panel
- **API methods** in \rontend/src/services/api.ts\: 8 methods in \migration\ namespace
- **Navigation** link added to ProjectDetailPage

### Tests
- **Backend**: 23 tests (15 service + 8 route) — all passing
- **Frontend**: 20 tests (13 component + 7 page) — all passing
- Backend lint: clean
- Frontend lint: clean
- Frontend build: succeeds

### Quality
- Backend coverage: maintained above 75%
- Frontend coverage: maintained above 75%
