### PR TITLE
feat: Add interactive tutorial walkthrough (#1)

### DIFF
--- a/frontend/src/components/shared/Layout.test.tsx
+++ b/frontend/src/components/shared/Layout.test.tsx
@@ -4,6 +4,7 @@ import userEvent from "@testing-library/user-event";
 import { MemoryRouter } from "react-router-dom";
 import { FluentProvider, teamsLightTheme } from "@fluentui/react-components";
 import Layout from "./Layout";
+import { TUTORIAL_STORAGE_KEY } from "../../hooks/useTutorial";
 
 // Mock useAuth used by AuthButton
 vi.mock("../../auth", () => ({
@@ -63,7 +64,7 @@ describe("Layout", () => {
     mockProjectsList.mockResolvedValue({ projects: [] });
     // Provide a functional localStorage mock and mark tutorial as completed
     storageMock = createStorageMock();
-    storageMock.setItem("onramp-tutorial-completed", "true");
+    storageMock.setItem(TUTORIAL_STORAGE_KEY, "true");
     vi.stubGlobal("localStorage", storageMock);
   });
 

--- a/frontend/src/components/shared/Layout.test.tsx
+++ b/frontend/src/components/shared/Layout.test.tsx
@@ -1,5 +1,6 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { MemoryRouter } from "react-router-dom";
 import { FluentProvider, teamsLightTheme } from "@fluentui/react-components";
 import Layout from "./Layout";
@@ -24,6 +25,26 @@ vi.mock("../../services/api", () => ({
   },
 }));
 
+function createStorageMock(): Storage {
+  let store: Record<string, string> = {};
+  return {
+    getItem: (key: string) => store[key] ?? null,
+    setItem: (key: string, value: string) => {
+      store[key] = value;
+    },
+    removeItem: (key: string) => {
+      delete store[key];
+    },
+    clear: () => {
+      store = {};
+    },
+    get length() {
+      return Object.keys(store).length;
+    },
+    key: (index: number) => Object.keys(store)[index] ?? null,
+  };
+}
+
 function renderLayout(children = <div>Test Content</div>, initialRoute = "/") {
   return render(
     <FluentProvider theme={teamsLightTheme}>
@@ -35,9 +56,19 @@ function renderLayout(children = <div>Test Content</div>, initialRoute = "/") {
 }
 
 describe("Layout", () => {
+  let storageMock: Storage;
+
   beforeEach(() => {
     vi.clearAllMocks();
     mockProjectsList.mockResolvedValue({ projects: [] });
+    // Provide a functional localStorage mock and mark tutorial as completed
+    storageMock = createStorageMock();
+    storageMock.setItem("onramp-tutorial-completed", "true");
+    vi.stubGlobal("localStorage", storageMock);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
   });
 
   it("renders OnRamp title", () => {
@@ -81,5 +112,29 @@ describe("Layout", () => {
       expect(mockProjectsList).toHaveBeenCalled();
     });
     expect(screen.queryByLabelText("Switch project")).not.toBeInTheDocument();
+  });
+
+  it("renders tutorial help button", () => {
+    renderLayout();
+    expect(
+      screen.getByRole("button", { name: /start tutorial/i })
+    ).toBeInTheDocument();
+  });
+
+  it("shows tutorial overlay when help button is clicked", async () => {
+    // Tutorial is already marked as completed in beforeEach
+    const user = userEvent.setup();
+    renderLayout();
+
+    // Tutorial should not be visible initially (already completed)
+    expect(screen.queryByTestId("tutorial-overlay")).not.toBeInTheDocument();
+
+    // Click the help button
+    await user.click(
+      screen.getByRole("button", { name: /start tutorial/i })
+    );
+
+    // Tutorial overlay should now be visible
+    expect(screen.getByTestId("tutorial-overlay")).toBeInTheDocument();
   });
 });

--- a/frontend/src/components/shared/Layout.tsx
+++ b/frontend/src/components/shared/Layout.tsx
@@ -97,7 +97,7 @@ export default function Layout({ children }: LayoutProps) {
   const location = useLocation();
   const navigate = useNavigate();
   const [projects, setProjects] = useState<Project[]>([]);
-  const tutorial = useTutorial();
+  const tutorial = useTutorial(location.pathname);
 
   useEffect(() => {
     api.projects.list().then((res) => setProjects(res.projects)).catch(() => {});

--- a/frontend/src/components/shared/Layout.tsx
+++ b/frontend/src/components/shared/Layout.tsx
@@ -8,6 +8,8 @@ import {
   TabList,
   Dropdown,
   Option,
+  Button,
+  Tooltip,
 } from "@fluentui/react-components";
 import {
   HomeRegular,
@@ -17,8 +19,11 @@ import {
   CodeRegular,
   RocketRegular,
   FolderRegular,
+  QuestionCircleRegular,
 } from "@fluentui/react-icons";
 import AuthButton from "./AuthButton";
+import TutorialOverlay from "./TutorialOverlay";
+import { useTutorial } from "../../hooks/useTutorial";
 import { api } from "../../services/api";
 import type { Project } from "../../types/project";
 
@@ -92,6 +97,7 @@ export default function Layout({ children }: LayoutProps) {
   const location = useLocation();
   const navigate = useNavigate();
   const [projects, setProjects] = useState<Project[]>([]);
+  const tutorial = useTutorial();
 
   useEffect(() => {
     api.projects.list().then((res) => setProjects(res.projects)).catch(() => {});
@@ -145,10 +151,28 @@ export default function Layout({ children }: LayoutProps) {
               ))}
             </Dropdown>
           )}
+          <Tooltip content="Start tutorial" relationship="label">
+            <Button
+              appearance="subtle"
+              icon={<QuestionCircleRegular />}
+              onClick={tutorial.startTutorial}
+              aria-label="Start tutorial"
+              size="small"
+            />
+          </Tooltip>
           <AuthButton />
         </div>
       </header>
       <main className={styles.content}>{children}</main>
+      <TutorialOverlay
+        isActive={tutorial.isActive}
+        currentStep={tutorial.currentStep}
+        currentStepIndex={tutorial.currentStepIndex}
+        totalSteps={tutorial.totalSteps}
+        onNext={tutorial.nextStep}
+        onPrev={tutorial.prevStep}
+        onSkip={tutorial.skipTutorial}
+      />
     </div>
   );
 }

--- a/frontend/src/components/shared/TutorialOverlay.test.tsx
+++ b/frontend/src/components/shared/TutorialOverlay.test.tsx
@@ -10,7 +10,6 @@ const sampleStep: TutorialStep = {
   id: "welcome",
   title: "Welcome to OnRamp!",
   content: "Start by creating a project for your Azure landing zone.",
-  targetSelector: "[data-tutorial='home']",
   page: "/",
 };
 

--- a/frontend/src/components/shared/TutorialOverlay.test.tsx
+++ b/frontend/src/components/shared/TutorialOverlay.test.tsx
@@ -1,0 +1,112 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { FluentProvider, teamsLightTheme } from "@fluentui/react-components";
+import TutorialOverlay from "./TutorialOverlay";
+import type { TutorialOverlayProps } from "./TutorialOverlay";
+import type { TutorialStep } from "../../hooks/useTutorial";
+
+const sampleStep: TutorialStep = {
+  id: "welcome",
+  title: "Welcome to OnRamp!",
+  content: "Start by creating a project for your Azure landing zone.",
+  targetSelector: "[data-tutorial='home']",
+  page: "/",
+};
+
+const defaultProps: TutorialOverlayProps = {
+  isActive: true,
+  currentStep: sampleStep,
+  currentStepIndex: 0,
+  totalSteps: 7,
+  onNext: vi.fn(),
+  onPrev: vi.fn(),
+  onSkip: vi.fn(),
+};
+
+function renderOverlay(overrides: Partial<TutorialOverlayProps> = {}) {
+  const props = { ...defaultProps, ...overrides };
+  return render(
+    <FluentProvider theme={teamsLightTheme}>
+      <TutorialOverlay {...props} />
+    </FluentProvider>
+  );
+}
+
+describe("TutorialOverlay", () => {
+  it("renders when active with step content", () => {
+    renderOverlay();
+    expect(screen.getByText("Welcome to OnRamp!")).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "Start by creating a project for your Azure landing zone."
+      )
+    ).toBeInTheDocument();
+  });
+
+  it("does not render when inactive", () => {
+    renderOverlay({ isActive: false });
+    expect(screen.queryByTestId("tutorial-overlay")).not.toBeInTheDocument();
+  });
+
+  it("does not render when currentStep is null", () => {
+    renderOverlay({ currentStep: null });
+    expect(screen.queryByTestId("tutorial-overlay")).not.toBeInTheDocument();
+  });
+
+  it("calls onNext when Next button is clicked", async () => {
+    const onNext = vi.fn();
+    const user = userEvent.setup();
+    renderOverlay({ onNext });
+
+    await user.click(screen.getByRole("button", { name: /next step/i }));
+    expect(onNext).toHaveBeenCalledOnce();
+  });
+
+  it("calls onSkip when Skip button is clicked", async () => {
+    const onSkip = vi.fn();
+    const user = userEvent.setup();
+    renderOverlay({ onSkip });
+
+    await user.click(screen.getByRole("button", { name: "Skip" }));
+    expect(onSkip).toHaveBeenCalled();
+  });
+
+  it("disables Back button on first step", () => {
+    renderOverlay({ currentStepIndex: 0 });
+    const backButton = screen.getByRole("button", { name: /previous step/i });
+    expect(backButton).toBeDisabled();
+  });
+
+  it("enables Back button on subsequent steps", () => {
+    renderOverlay({ currentStepIndex: 2 });
+    const backButton = screen.getByRole("button", { name: /previous step/i });
+    expect(backButton).not.toBeDisabled();
+  });
+
+  it("calls onPrev when Back button is clicked", async () => {
+    const onPrev = vi.fn();
+    const user = userEvent.setup();
+    renderOverlay({ onPrev, currentStepIndex: 2 });
+
+    await user.click(screen.getByRole("button", { name: /previous step/i }));
+    expect(onPrev).toHaveBeenCalledOnce();
+  });
+
+  it("shows correct progress indicator", () => {
+    renderOverlay({ currentStepIndex: 2, totalSteps: 7 });
+    expect(screen.getByText("Step 3 of 7")).toBeInTheDocument();
+  });
+
+  it("shows Finish button on last step", () => {
+    renderOverlay({ currentStepIndex: 6, totalSteps: 7 });
+    expect(
+      screen.getByRole("button", { name: /finish tutorial/i })
+    ).toBeInTheDocument();
+  });
+
+  it("has a dialog role for accessibility", () => {
+    renderOverlay();
+    expect(screen.getByRole("dialog", { name: /tutorial/i })).toBeInTheDocument();
+  });
+});

--- a/frontend/src/components/shared/TutorialOverlay.tsx
+++ b/frontend/src/components/shared/TutorialOverlay.tsx
@@ -1,0 +1,159 @@
+import {
+  makeStyles,
+  tokens,
+  Text,
+  Button,
+  Card,
+  CardHeader,
+  CardFooter,
+  ProgressBar,
+} from "@fluentui/react-components";
+import {
+  DismissRegular,
+  ChevronLeftRegular,
+  ChevronRightRegular,
+} from "@fluentui/react-icons";
+import type { TutorialStep } from "../../hooks/useTutorial";
+
+export interface TutorialOverlayProps {
+  isActive: boolean;
+  currentStep: TutorialStep | null;
+  currentStepIndex: number;
+  totalSteps: number;
+  onNext: () => void;
+  onPrev: () => void;
+  onSkip: () => void;
+}
+
+const useStyles = makeStyles({
+  backdrop: {
+    position: "fixed",
+    top: "0",
+    left: "0",
+    width: "100vw",
+    height: "100vh",
+    backgroundColor: "rgba(0, 0, 0, 0.4)",
+    zIndex: 1000,
+    display: "flex",
+    justifyContent: "center",
+    alignItems: "flex-start",
+    paddingTop: "80px",
+  },
+  card: {
+    maxWidth: "440px",
+    width: "100%",
+    zIndex: 1001,
+    boxShadow: tokens.shadow16,
+  },
+  header: {
+    display: "flex",
+    alignItems: "center",
+    justifyContent: "space-between",
+  },
+  title: {
+    fontWeight: tokens.fontWeightSemibold,
+    fontSize: tokens.fontSizeBase400,
+  },
+  content: {
+    padding: `0 ${tokens.spacingHorizontalL} ${tokens.spacingVerticalM}`,
+    color: tokens.colorNeutralForeground2,
+    fontSize: tokens.fontSizeBase300,
+    lineHeight: tokens.lineHeightBase300,
+  },
+  progress: {
+    padding: `0 ${tokens.spacingHorizontalL} ${tokens.spacingVerticalS}`,
+  },
+  progressLabel: {
+    fontSize: tokens.fontSizeBase200,
+    color: tokens.colorNeutralForeground3,
+    display: "block",
+    marginBottom: tokens.spacingVerticalXS,
+  },
+  footer: {
+    display: "flex",
+    justifyContent: "space-between",
+    alignItems: "center",
+    gap: tokens.spacingHorizontalS,
+  },
+  navButtons: {
+    display: "flex",
+    gap: tokens.spacingHorizontalS,
+  },
+});
+
+export default function TutorialOverlay({
+  isActive,
+  currentStep,
+  currentStepIndex,
+  totalSteps,
+  onNext,
+  onPrev,
+  onSkip,
+}: TutorialOverlayProps) {
+  const styles = useStyles();
+
+  if (!isActive || !currentStep) {
+    return null;
+  }
+
+  const isFirstStep = currentStepIndex === 0;
+  const isLastStep = currentStepIndex === totalSteps - 1;
+  const progressValue = (currentStepIndex + 1) / totalSteps;
+
+  return (
+    <div className={styles.backdrop} data-testid="tutorial-overlay">
+      <Card className={styles.card} role="dialog" aria-label="Tutorial">
+        <CardHeader
+          header={
+            <div className={styles.header}>
+              <Text className={styles.title}>{currentStep.title}</Text>
+              <Button
+                appearance="subtle"
+                icon={<DismissRegular />}
+                onClick={onSkip}
+                aria-label="Skip tutorial"
+                size="small"
+              />
+            </div>
+          }
+        />
+        <div className={styles.content}>{currentStep.content}</div>
+        <div className={styles.progress}>
+          <Text className={styles.progressLabel}>
+            Step {currentStepIndex + 1} of {totalSteps}
+          </Text>
+          <ProgressBar value={progressValue} thickness="large" />
+        </div>
+        <CardFooter>
+          <div className={styles.footer}>
+            <Button appearance="subtle" onClick={onSkip} size="small">
+              Skip
+            </Button>
+            <div className={styles.navButtons}>
+              <Button
+                appearance="outline"
+                icon={<ChevronLeftRegular />}
+                onClick={onPrev}
+                disabled={isFirstStep}
+                size="small"
+                aria-label="Previous step"
+              >
+                Back
+              </Button>
+              <Button
+                appearance="primary"
+                icon={<ChevronRightRegular />}
+                iconPosition="after"
+                onClick={onNext}
+                size="small"
+                aria-label={isLastStep ? "Finish tutorial" : "Next step"}
+              >
+                {isLastStep ? "Finish" : "Next"}
+              </Button>
+            </div>
+          </div>
+        </CardFooter>
+      </Card>
+    </div>
+  );
+}

--- a/frontend/src/components/shared/TutorialOverlay.tsx
+++ b/frontend/src/components/shared/TutorialOverlay.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useRef } from "react";
 import {
   makeStyles,
   tokens,
@@ -91,6 +92,23 @@ export default function TutorialOverlay({
   onSkip,
 }: TutorialOverlayProps) {
   const styles = useStyles();
+  const primaryButtonRef = useRef<HTMLButtonElement>(null);
+
+  useEffect(() => {
+    if (!isActive || !currentStep) return;
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        onSkip();
+      }
+    };
+    document.addEventListener("keydown", handleKeyDown);
+    return () => document.removeEventListener("keydown", handleKeyDown);
+  }, [isActive, currentStep, onSkip]);
+
+  useEffect(() => {
+    if (!isActive || !currentStep) return;
+    primaryButtonRef.current?.focus();
+  }, [isActive, currentStep, currentStepIndex]);
 
   if (!isActive || !currentStep) {
     return null;
@@ -102,7 +120,7 @@ export default function TutorialOverlay({
 
   return (
     <div className={styles.backdrop} data-testid="tutorial-overlay">
-      <Card className={styles.card} role="dialog" aria-label="Tutorial">
+      <Card className={styles.card} role="dialog" aria-label="Tutorial" aria-modal="true">
         <CardHeader
           header={
             <div className={styles.header}>
@@ -141,6 +159,7 @@ export default function TutorialOverlay({
                 Back
               </Button>
               <Button
+                ref={primaryButtonRef}
                 appearance="primary"
                 icon={<ChevronRightRegular />}
                 iconPosition="after"

--- a/frontend/src/hooks/useTutorial.test.ts
+++ b/frontend/src/hooks/useTutorial.test.ts
@@ -1,0 +1,172 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import { useTutorial } from "./useTutorial";
+
+const STORAGE_KEY = "onramp-tutorial-completed";
+
+function createStorageMock(): Storage {
+  let store: Record<string, string> = {};
+  return {
+    getItem: (key: string) => store[key] ?? null,
+    setItem: (key: string, value: string) => {
+      store[key] = value;
+    },
+    removeItem: (key: string) => {
+      delete store[key];
+    },
+    clear: () => {
+      store = {};
+    },
+    get length() {
+      return Object.keys(store).length;
+    },
+    key: (index: number) => Object.keys(store)[index] ?? null,
+  };
+}
+
+describe("useTutorial", () => {
+  beforeEach(() => {
+    vi.stubGlobal("localStorage", createStorageMock());
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("auto-starts when tutorial has not been completed", () => {
+    const { result } = renderHook(() => useTutorial());
+    expect(result.current.isActive).toBe(true);
+    expect(result.current.isTutorialCompleted).toBe(false);
+    expect(result.current.currentStepIndex).toBe(0);
+  });
+
+  it("does not auto-start when tutorial has been completed", () => {
+    window.localStorage.setItem(STORAGE_KEY, "true");
+    const { result } = renderHook(() => useTutorial());
+    expect(result.current.isActive).toBe(false);
+    expect(result.current.isTutorialCompleted).toBe(true);
+  });
+
+  it("navigates to the next step", () => {
+    const { result } = renderHook(() => useTutorial());
+    expect(result.current.currentStepIndex).toBe(0);
+
+    act(() => {
+      result.current.nextStep();
+    });
+
+    expect(result.current.currentStepIndex).toBe(1);
+    expect(result.current.isActive).toBe(true);
+  });
+
+  it("navigates to the previous step", () => {
+    const { result } = renderHook(() => useTutorial());
+
+    act(() => {
+      result.current.nextStep();
+      result.current.nextStep();
+    });
+    expect(result.current.currentStepIndex).toBe(2);
+
+    act(() => {
+      result.current.prevStep();
+    });
+    expect(result.current.currentStepIndex).toBe(1);
+  });
+
+  it("does not go below step 0 on prevStep", () => {
+    const { result } = renderHook(() => useTutorial());
+    expect(result.current.currentStepIndex).toBe(0);
+
+    act(() => {
+      result.current.prevStep();
+    });
+    expect(result.current.currentStepIndex).toBe(0);
+  });
+
+  it("marks tutorial as completed when skipped", () => {
+    const { result } = renderHook(() => useTutorial());
+    expect(result.current.isActive).toBe(true);
+
+    act(() => {
+      result.current.skipTutorial();
+    });
+
+    expect(result.current.isActive).toBe(false);
+    expect(result.current.isTutorialCompleted).toBe(true);
+    expect(window.localStorage.getItem(STORAGE_KEY)).toBe("true");
+  });
+
+  it("completes tutorial when advancing past last step", () => {
+    const { result } = renderHook(() => useTutorial());
+    const totalSteps = result.current.totalSteps;
+
+    // Navigate to the last step
+    for (let i = 0; i < totalSteps - 1; i++) {
+      act(() => {
+        result.current.nextStep();
+      });
+    }
+    expect(result.current.currentStepIndex).toBe(totalSteps - 1);
+    expect(result.current.isActive).toBe(true);
+
+    // Advance past the last step
+    act(() => {
+      result.current.nextStep();
+    });
+
+    expect(result.current.isActive).toBe(false);
+    expect(result.current.isTutorialCompleted).toBe(true);
+  });
+
+  it("restarts tutorial after completion", () => {
+    const { result } = renderHook(() => useTutorial());
+
+    act(() => {
+      result.current.skipTutorial();
+    });
+    expect(result.current.isActive).toBe(false);
+    expect(result.current.isTutorialCompleted).toBe(true);
+
+    act(() => {
+      result.current.startTutorial();
+    });
+    expect(result.current.isActive).toBe(true);
+    expect(result.current.currentStepIndex).toBe(0);
+  });
+
+  it("provides the current step data when active", () => {
+    const { result } = renderHook(() => useTutorial());
+    expect(result.current.currentStep).not.toBeNull();
+    expect(result.current.currentStep?.id).toBe("welcome");
+    expect(result.current.currentStep?.title).toBe("Welcome to OnRamp!");
+  });
+
+  it("returns null currentStep when inactive", () => {
+    const { result } = renderHook(() => useTutorial());
+
+    act(() => {
+      result.current.skipTutorial();
+    });
+
+    expect(result.current.currentStep).toBeNull();
+  });
+
+  it("exposes the total number of steps", () => {
+    const { result } = renderHook(() => useTutorial());
+    expect(result.current.totalSteps).toBe(7);
+  });
+
+  it("persists completion state in localStorage", () => {
+    const { result } = renderHook(() => useTutorial());
+
+    act(() => {
+      result.current.skipTutorial();
+    });
+
+    // Re-render a new hook to simulate page reload
+    const { result: result2 } = renderHook(() => useTutorial());
+    expect(result2.current.isTutorialCompleted).toBe(true);
+    expect(result2.current.isActive).toBe(false);
+  });
+});

--- a/frontend/src/hooks/useTutorial.test.ts
+++ b/frontend/src/hooks/useTutorial.test.ts
@@ -1,8 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { renderHook, act } from "@testing-library/react";
-import { useTutorial } from "./useTutorial";
-
-const STORAGE_KEY = "onramp-tutorial-completed";
+import { useTutorial, TUTORIAL_STORAGE_KEY } from "./useTutorial";
 
 function createStorageMock(): Storage {
   let store: Record<string, string> = {};
@@ -41,7 +39,7 @@ describe("useTutorial", () => {
   });
 
   it("does not auto-start when tutorial has been completed", () => {
-    window.localStorage.setItem(STORAGE_KEY, "true");
+    window.localStorage.setItem(TUTORIAL_STORAGE_KEY, "true");
     const { result } = renderHook(() => useTutorial());
     expect(result.current.isActive).toBe(false);
     expect(result.current.isTutorialCompleted).toBe(true);
@@ -94,7 +92,7 @@ describe("useTutorial", () => {
 
     expect(result.current.isActive).toBe(false);
     expect(result.current.isTutorialCompleted).toBe(true);
-    expect(window.localStorage.getItem(STORAGE_KEY)).toBe("true");
+    expect(window.localStorage.getItem(TUTORIAL_STORAGE_KEY)).toBe("true");
   });
 
   it("completes tutorial when advancing past last step", () => {
@@ -133,6 +131,8 @@ describe("useTutorial", () => {
     });
     expect(result.current.isActive).toBe(true);
     expect(result.current.currentStepIndex).toBe(0);
+    expect(result.current.isTutorialCompleted).toBe(false);
+    expect(window.localStorage.getItem(TUTORIAL_STORAGE_KEY)).toBeNull();
   });
 
   it("provides the current step data when active", () => {

--- a/frontend/src/hooks/useTutorial.ts
+++ b/frontend/src/hooks/useTutorial.ts
@@ -1,0 +1,154 @@
+import { useState, useCallback } from "react";
+
+const TUTORIAL_STORAGE_KEY = "onramp-tutorial-completed";
+
+export interface TutorialStep {
+  id: string;
+  title: string;
+  content: string;
+  targetSelector: string;
+  page: string;
+}
+
+export interface UseTutorialReturn {
+  isActive: boolean;
+  currentStep: TutorialStep | null;
+  currentStepIndex: number;
+  totalSteps: number;
+  startTutorial: () => void;
+  nextStep: () => void;
+  prevStep: () => void;
+  skipTutorial: () => void;
+  isTutorialCompleted: boolean;
+}
+
+const TUTORIAL_STEPS: TutorialStep[] = [
+  {
+    id: "welcome",
+    title: "Welcome to OnRamp!",
+    content:
+      "Start by creating a project for your Azure landing zone.",
+    targetSelector: "[data-tutorial='home']",
+    page: "/",
+  },
+  {
+    id: "projects",
+    title: "Projects",
+    content:
+      "Each project guides you through designing and deploying a landing zone.",
+    targetSelector: "[data-tutorial='projects']",
+    page: "/",
+  },
+  {
+    id: "wizard",
+    title: "Wizard",
+    content:
+      "Answer questions about your organization. Recommended options are highlighted.",
+    targetSelector: "[data-tutorial='wizard']",
+    page: "/wizard",
+  },
+  {
+    id: "architecture",
+    title: "Architecture",
+    content: "Review your AI-generated landing zone architecture.",
+    targetSelector: "[data-tutorial='architecture']",
+    page: "/architecture",
+  },
+  {
+    id: "compliance",
+    title: "Compliance",
+    content:
+      "See how your architecture scores against compliance frameworks.",
+    targetSelector: "[data-tutorial='compliance']",
+    page: "/compliance",
+  },
+  {
+    id: "bicep",
+    title: "Bicep",
+    content:
+      "Download Infrastructure-as-Code templates for your landing zone.",
+    targetSelector: "[data-tutorial='bicep']",
+    page: "/bicep",
+  },
+  {
+    id: "deploy",
+    title: "Deploy",
+    content: "Deploy your landing zone directly to Azure subscriptions.",
+    targetSelector: "[data-tutorial='deploy']",
+    page: "/deploy",
+  },
+];
+
+function getIsCompleted(): boolean {
+  try {
+    return typeof localStorage !== "undefined" &&
+      typeof localStorage.getItem === "function" &&
+      localStorage.getItem(TUTORIAL_STORAGE_KEY) === "true";
+  } catch {
+    return false;
+  }
+}
+
+function setCompleted(value: boolean): void {
+  try {
+    if (typeof localStorage === "undefined" || typeof localStorage.setItem !== "function") {
+      return;
+    }
+    if (value) {
+      localStorage.setItem(TUTORIAL_STORAGE_KEY, "true");
+    } else {
+      localStorage.removeItem(TUTORIAL_STORAGE_KEY);
+    }
+  } catch {
+    // localStorage may be unavailable; silently ignore
+  }
+}
+
+export function useTutorial(): UseTutorialReturn {
+  const [isTutorialCompleted, setIsTutorialCompleted] = useState(getIsCompleted);
+  const [isActive, setIsActive] = useState(() => !getIsCompleted());
+  const [currentStepIndex, setCurrentStepIndex] = useState(0);
+
+  const startTutorial = useCallback(() => {
+    setCurrentStepIndex(0);
+    setIsActive(true);
+  }, []);
+
+  const skipTutorial = useCallback(() => {
+    setIsActive(false);
+    setIsTutorialCompleted(true);
+    setCompleted(true);
+  }, []);
+
+  const nextStep = useCallback(() => {
+    setCurrentStepIndex((prev) => {
+      const next = prev + 1;
+      if (next >= TUTORIAL_STEPS.length) {
+        // Tutorial finished — mark completed
+        setIsActive(false);
+        setIsTutorialCompleted(true);
+        setCompleted(true);
+        return prev;
+      }
+      return next;
+    });
+  }, []);
+
+  const prevStep = useCallback(() => {
+    setCurrentStepIndex((prev) => Math.max(0, prev - 1));
+  }, []);
+
+  const currentStep = isActive ? TUTORIAL_STEPS[currentStepIndex] ?? null : null;
+
+  return {
+    isActive,
+    currentStep,
+    currentStepIndex,
+    totalSteps: TUTORIAL_STEPS.length,
+    startTutorial,
+    nextStep,
+    prevStep,
+    skipTutorial,
+    isTutorialCompleted,
+  };
+}

--- a/frontend/src/hooks/useTutorial.ts
+++ b/frontend/src/hooks/useTutorial.ts
@@ -1,12 +1,12 @@
 import { useState, useCallback } from "react";
 
-const TUTORIAL_STORAGE_KEY = "onramp-tutorial-completed";
+export const TUTORIAL_STORAGE_KEY = "onramp-tutorial-completed";
 
 export interface TutorialStep {
   id: string;
   title: string;
   content: string;
-  targetSelector: string;
+  /** Informational: indicates which page this step describes (not used for routing) */
   page: string;
 }
 
@@ -28,7 +28,6 @@ const TUTORIAL_STEPS: TutorialStep[] = [
     title: "Welcome to OnRamp!",
     content:
       "Start by creating a project for your Azure landing zone.",
-    targetSelector: "[data-tutorial='home']",
     page: "/",
   },
   {
@@ -36,7 +35,6 @@ const TUTORIAL_STEPS: TutorialStep[] = [
     title: "Projects",
     content:
       "Each project guides you through designing and deploying a landing zone.",
-    targetSelector: "[data-tutorial='projects']",
     page: "/",
   },
   {
@@ -44,14 +42,12 @@ const TUTORIAL_STEPS: TutorialStep[] = [
     title: "Wizard",
     content:
       "Answer questions about your organization. Recommended options are highlighted.",
-    targetSelector: "[data-tutorial='wizard']",
     page: "/wizard",
   },
   {
     id: "architecture",
     title: "Architecture",
     content: "Review your AI-generated landing zone architecture.",
-    targetSelector: "[data-tutorial='architecture']",
     page: "/architecture",
   },
   {
@@ -59,7 +55,6 @@ const TUTORIAL_STEPS: TutorialStep[] = [
     title: "Compliance",
     content:
       "See how your architecture scores against compliance frameworks.",
-    targetSelector: "[data-tutorial='compliance']",
     page: "/compliance",
   },
   {
@@ -67,14 +62,12 @@ const TUTORIAL_STEPS: TutorialStep[] = [
     title: "Bicep",
     content:
       "Download Infrastructure-as-Code templates for your landing zone.",
-    targetSelector: "[data-tutorial='bicep']",
     page: "/bicep",
   },
   {
     id: "deploy",
     title: "Deploy",
     content: "Deploy your landing zone directly to Azure subscriptions.",
-    targetSelector: "[data-tutorial='deploy']",
     page: "/deploy",
   },
 ];
@@ -104,13 +97,20 @@ function setCompleted(value: boolean): void {
   }
 }
 
-export function useTutorial(): UseTutorialReturn {
+export function useTutorial(currentPath?: string): UseTutorialReturn {
   const [isTutorialCompleted, setIsTutorialCompleted] = useState(getIsCompleted);
-  const [isActive, setIsActive] = useState(() => !getIsCompleted());
+  const [isActive, setIsActive] = useState(() => {
+    if (getIsCompleted()) return false;
+    // Only auto-start on the home page
+    const path = currentPath ?? "/";
+    return path === "/" || path === "";
+  });
   const [currentStepIndex, setCurrentStepIndex] = useState(0);
 
   const startTutorial = useCallback(() => {
     setCurrentStepIndex(0);
+    setIsTutorialCompleted(false);
+    setCompleted(false);
     setIsActive(true);
   }, []);
 


### PR DESCRIPTION
Closes #1

## Summary

Implements a tooltip-based guided walkthrough for first-time users using Fluent UI v9 components.

### New Files
- **useTutorial hook** — 7-step tutorial with localStorage persistence, auto-start on first visit
- **TutorialOverlay** — Floating card with backdrop, progress bar, Back/Next/Skip navigation
- **Tests** — 12 hook tests + 11 overlay tests + 2 Layout tests (all passing)

### Modified Files
- **Layout.tsx** — Added help button (question circle icon) and TutorialOverlay
- **Layout.test.tsx** — Added tutorial integration tests

### Quality
- 281 total frontend tests passing
- ESLint clean
- All Fluent UI v9 components with makeStyles + tokens