### PR TITLE
feat: Auto-generate Architecture Decision Records (#2)

### DIFF
--- a/backend/app/api/routes/adr.py
+++ b/backend/app/api/routes/adr.py
@@ -1,0 +1,47 @@
+"""ADR generation and export API routes."""
+
+import logging
+
+from fastapi import APIRouter, Depends
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.auth import get_current_user
+from app.db.session import get_db
+from app.schemas.adr import (
+    ADRExportRequest,
+    ADRGenerateRequest,
+    ADRGenerateResponse,
+)
+from app.services.adr_generator import export_adrs, generate_adrs
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/api/architecture", tags=["architecture"])
+
+
+@router.post("/adrs/generate", response_model=ADRGenerateResponse)
+async def generate_adrs_endpoint(
+    request: ADRGenerateRequest,
+    user: dict = Depends(get_current_user),
+    db: AsyncSession | None = Depends(get_db),
+):
+    """Generate Architecture Decision Records from architecture data."""
+    logger.info("Generating ADRs for user %s", user.get("name", "unknown"))
+    adrs = generate_adrs(
+        architecture=request.architecture,
+        answers=request.answers,
+        use_ai=request.use_ai,
+    )
+    return ADRGenerateResponse(adrs=adrs, project_id=request.project_id)
+
+
+@router.post("/adrs/export")
+async def export_adrs_endpoint(
+    request: ADRExportRequest,
+    user: dict = Depends(get_current_user),
+    db: AsyncSession | None = Depends(get_db),
+):
+    """Export ADRs as Markdown content."""
+    logger.info("Exporting %d ADRs in %s format", len(request.adrs), request.format)
+    content = export_adrs(adrs=request.adrs, format=request.format)
+    return {"content": content}

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -3,6 +3,7 @@ from contextlib import asynccontextmanager
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
+from app.api.routes.adr import router as adr_router
 from app.api.routes.architecture import router as architecture_router
 from app.api.routes.bicep import router as bicep_router
 from app.api.routes.compliance import router as compliance_router
@@ -71,6 +72,7 @@ app.include_router(questionnaire_router)
 app.include_router(compliance_router)
 app.include_router(projects_router)
 app.include_router(architecture_router)
+app.include_router(adr_router)
 app.include_router(deployment_router)
 app.include_router(bicep_router)
 app.include_router(scoring_router)

--- a/backend/app/schemas/adr.py
+++ b/backend/app/schemas/adr.py
@@ -1,0 +1,41 @@
+"""Pydantic schemas for ADR generation and export."""
+
+from typing import Literal
+
+from pydantic import BaseModel, Field
+
+
+class ADRRecord(BaseModel):
+    """A single Architecture Decision Record."""
+
+    id: str
+    title: str
+    status: str = "Accepted"
+    context: str
+    decision: str
+    consequences: str
+    category: str  # e.g., "networking", "identity", "compliance"
+    created_at: str
+
+
+class ADRGenerateRequest(BaseModel):
+    """Request to generate ADRs from architecture data."""
+
+    architecture: dict
+    answers: dict[str, str | list[str]] = Field(default_factory=dict)
+    use_ai: bool = False
+    project_id: str | None = None
+
+
+class ADRGenerateResponse(BaseModel):
+    """Response containing generated ADRs."""
+
+    adrs: list[ADRRecord]
+    project_id: str | None = None
+
+
+class ADRExportRequest(BaseModel):
+    """Request to export ADRs as Markdown."""
+
+    adrs: list[ADRRecord]
+    format: Literal["individual", "combined"] = "combined"

--- a/backend/app/services/adr_generator.py
+++ b/backend/app/services/adr_generator.py
@@ -1,0 +1,334 @@
+"""ADR generation service.
+
+Generates Architecture Decision Records from architecture data
+and questionnaire answers using either static templates or AI.
+"""
+
+import logging
+from datetime import datetime, timezone
+
+from app.schemas.adr import ADRRecord
+
+logger = logging.getLogger(__name__)
+
+
+def _today() -> str:
+    """Return today's date as ISO string."""
+    return datetime.now(tz=timezone.utc).strftime("%Y-%m-%d")
+
+
+def _extract_mg_info(architecture: dict) -> dict:
+    """Extract management group details from architecture data."""
+    mg = architecture.get("management_groups", {})
+    if isinstance(mg, list):
+        names = [g.get("name", "unknown") for g in mg]
+    elif isinstance(mg, dict):
+        names = list(mg.keys()) if mg else ["root"]
+    else:
+        names = ["root"]
+    return {"names": names, "count": len(names)}
+
+
+def _extract_network_info(architecture: dict) -> dict:
+    """Extract network topology details from architecture data."""
+    net = architecture.get("network_topology", {})
+    if isinstance(net, dict):
+        return {
+            "type": net.get("type", "hub-spoke"),
+            "primary_region": net.get("primary_region", "eastus2"),
+            "secondary_region": net.get("secondary_region"),
+        }
+    return {"type": "hub-spoke", "primary_region": "eastus2", "secondary_region": None}
+
+
+def _extract_subscription_info(architecture: dict) -> dict:
+    """Extract subscription topology details."""
+    subs = architecture.get("subscriptions", [])
+    if isinstance(subs, list):
+        names = [s.get("name", "unknown") if isinstance(s, dict) else str(s) for s in subs]
+    else:
+        names = []
+    return {"names": names, "count": len(names)}
+
+
+def _generate_mg_adr(architecture: dict, adr_number: int) -> ADRRecord:
+    """Generate ADR for management group hierarchy decision."""
+    mg_info = _extract_mg_info(architecture)
+    group_list = ", ".join(mg_info["names"][:5])
+    return ADRRecord(
+        id=f"ADR-{adr_number:03d}",
+        title="Management Group Hierarchy",
+        status="Accepted",
+        context=(
+            "The organization requires a management group hierarchy to organize "
+            "Azure subscriptions, apply policies consistently, and enforce governance "
+            "at scale. The hierarchy must balance granularity with operational simplicity."
+        ),
+        decision=(
+            f"Adopt a management group hierarchy with {mg_info['count']} groups: "
+            f"{group_list}. This structure aligns with the Cloud Adoption Framework "
+            "recommended patterns and supports the organization's governance model."
+        ),
+        consequences=(
+            "Policies applied at upper management groups cascade to child scopes, "
+            "reducing per-subscription configuration. Teams must follow the established "
+            "hierarchy when creating new subscriptions. Changes to the hierarchy "
+            "require coordination across platform and workload teams."
+        ),
+        category="governance",
+        created_at=_today(),
+    )
+
+
+def _generate_network_adr(architecture: dict, adr_number: int) -> ADRRecord:
+    """Generate ADR for network topology decision."""
+    net_info = _extract_network_info(architecture)
+    topo_type = net_info["type"]
+    region = net_info["primary_region"]
+    return ADRRecord(
+        id=f"ADR-{adr_number:03d}",
+        title="Network Topology",
+        status="Accepted",
+        context=(
+            "The landing zone requires a network topology that provides secure "
+            "connectivity between workloads, on-premises resources, and the internet "
+            "while supporting the organization's latency and compliance requirements."
+        ),
+        decision=(
+            f"Use a {topo_type} network topology with the hub deployed in {region}. "
+            "Central network virtual appliances and shared services reside in the hub, "
+            "while workload VNets peer as spokes. This topology provides centralized "
+            "traffic inspection and simplified network management."
+        ),
+        consequences=(
+            "All inter-spoke traffic routes through the hub, enabling centralized "
+            "firewall inspection but adding a potential bottleneck. Spoke teams depend "
+            "on the platform team for peering and DNS configuration. Network latency "
+            "between spokes is slightly higher than direct peering."
+        ),
+        category="networking",
+        created_at=_today(),
+    )
+
+
+def _generate_identity_adr(
+    architecture: dict, answers: dict, adr_number: int,
+) -> ADRRecord:
+    """Generate ADR for identity model decision."""
+    identity = architecture.get("identity", {})
+    provider = "Entra ID"
+    if isinstance(identity, dict):
+        provider = identity.get("provider", "Entra ID")
+    model = answers.get("identity_model", "centralized")
+    if isinstance(model, list):
+        model = model[0] if model else "centralized"
+    return ADRRecord(
+        id=f"ADR-{adr_number:03d}",
+        title="Identity Model",
+        status="Accepted",
+        context=(
+            "The organization needs a consistent identity and access management "
+            "strategy across all Azure landing zone subscriptions. The identity "
+            "model must support least-privilege access, conditional access policies, "
+            "and integration with existing directory services."
+        ),
+        decision=(
+            f"Adopt a {model} identity model using {provider} as the primary "
+            "identity provider. Privileged Identity Management (PIM) is enabled "
+            "for just-in-time access to sensitive roles. Multi-factor authentication "
+            "is enforced for all users via conditional access policies."
+        ),
+        consequences=(
+            "All authentication flows route through the centralized identity provider, "
+            "providing a single audit trail. Teams must request role assignments through "
+            "PIM rather than permanent role grants. Federation with external identity "
+            "providers requires additional configuration and approval."
+        ),
+        category="identity",
+        created_at=_today(),
+    )
+
+
+def _generate_compliance_adr(
+    architecture: dict, answers: dict, adr_number: int,
+) -> ADRRecord:
+    """Generate ADR for compliance framework selection."""
+    frameworks = answers.get("compliance_frameworks", [])
+    if isinstance(frameworks, str):
+        frameworks = [frameworks]
+    if not frameworks:
+        policies = architecture.get("policies", {})
+        if isinstance(policies, dict):
+            frameworks = list(policies.keys())[:3]
+    framework_str = ", ".join(frameworks) if frameworks else "Azure CIS Benchmark"
+    return ADRRecord(
+        id=f"ADR-{adr_number:03d}",
+        title="Compliance Frameworks",
+        status="Accepted",
+        context=(
+            "The organization operates in a regulated environment and must demonstrate "
+            "compliance with industry standards and regulatory requirements. Azure Policy "
+            "and Microsoft Defender for Cloud provide built-in compliance monitoring."
+        ),
+        decision=(
+            f"Adopt the following compliance frameworks: {framework_str}. "
+            "Azure Policy initiative assignments enforce these frameworks at the "
+            "management group level. Continuous compliance monitoring is enabled "
+            "through Microsoft Defender for Cloud regulatory compliance dashboard."
+        ),
+        consequences=(
+            "Non-compliant resources are flagged automatically and may be denied "
+            "deployment depending on policy effect (Deny vs Audit). Teams must remediate "
+            "compliance findings within defined SLAs. Adding new frameworks requires "
+            "policy initiative updates and potential resource reconfiguration."
+        ),
+        category="compliance",
+        created_at=_today(),
+    )
+
+
+def _generate_region_adr(architecture: dict, adr_number: int) -> ADRRecord:
+    """Generate ADR for region selection decision."""
+    net_info = _extract_network_info(architecture)
+    primary = net_info["primary_region"]
+    secondary = net_info.get("secondary_region") or "westus2"
+    return ADRRecord(
+        id=f"ADR-{adr_number:03d}",
+        title="Region Selection",
+        status="Accepted",
+        context=(
+            "Choosing Azure regions impacts latency, data residency compliance, "
+            "service availability, and disaster recovery capabilities. The landing "
+            "zone must support business continuity requirements while meeting "
+            "data sovereignty regulations."
+        ),
+        decision=(
+            f"Deploy the primary landing zone in {primary} with {secondary} as the "
+            "paired disaster recovery region. This pairing leverages Azure's built-in "
+            "regional redundancy and ensures data residency compliance. Critical "
+            "workloads use zone-redundant deployments within the primary region."
+        ),
+        consequences=(
+            "Cross-region replication increases storage and egress costs. Failover "
+            "to the secondary region requires tested runbooks and may involve brief "
+            "service interruption. Some Azure services may have feature availability "
+            "differences between regions."
+        ),
+        category="networking",
+        created_at=_today(),
+    )
+
+
+def _generate_subscription_adr(architecture: dict, adr_number: int) -> ADRRecord:
+    """Generate ADR for subscription topology decision."""
+    sub_info = _extract_subscription_info(architecture)
+    sub_list = ", ".join(sub_info["names"][:5]) if sub_info["names"] else "production, development"
+    return ADRRecord(
+        id=f"ADR-{adr_number:03d}",
+        title="Subscription Topology",
+        status="Accepted",
+        context=(
+            "Azure subscriptions serve as units of management, billing, and scale. "
+            "The subscription topology must balance workload isolation, cost tracking, "
+            "and administrative overhead while supporting the organization's growth."
+        ),
+        decision=(
+            f"Organize subscriptions into {sub_info['count'] or 2} dedicated "
+            f"subscriptions: {sub_list}. Each subscription maps to a specific "
+            "environment or workload tier, enabling fine-grained RBAC, cost "
+            "management, and policy enforcement per subscription."
+        ),
+        consequences=(
+            "Each subscription has its own resource quotas and billing scope, "
+            "simplifying cost attribution. Cross-subscription communication requires "
+            "VNet peering or Private Link. Platform teams must manage subscription "
+            "vending and decommissioning processes."
+        ),
+        category="governance",
+        created_at=_today(),
+    )
+
+
+def generate_adrs(
+    architecture: dict,
+    answers: dict,
+    use_ai: bool = False,
+) -> list[ADRRecord]:
+    """Generate ADRs from architecture data and questionnaire answers.
+
+    Args:
+        architecture: The generated landing zone architecture.
+        answers: Questionnaire answers that informed the architecture.
+        use_ai: Whether to enhance ADRs with AI-generated content.
+
+    Returns:
+        A list of ADRRecord instances, one per major decision area.
+    """
+    adrs = [
+        _generate_mg_adr(architecture, 1),
+        _generate_network_adr(architecture, 2),
+        _generate_identity_adr(architecture, answers, 3),
+        _generate_compliance_adr(architecture, answers, 4),
+        _generate_region_adr(architecture, 5),
+        _generate_subscription_adr(architecture, 6),
+    ]
+
+    if use_ai:
+        try:
+            from app.services.ai_foundry import ai_client
+
+            if ai_client.is_configured:
+                logger.info("Enhancing ADRs with AI")
+                # AI enhancement would happen here in production
+                # For now, log and return template ADRs
+            else:
+                logger.info("AI not configured — using template ADRs")
+        except Exception as e:
+            logger.warning("AI enhancement failed, falling back to templates: %s", e)
+
+    return adrs
+
+
+def _format_single_adr(adr: ADRRecord) -> str:
+    """Format a single ADR as Markdown."""
+    return (
+        f"# {adr.id}: {adr.title}\n"
+        f"\n"
+        f"**Status:** {adr.status}\n"
+        f"**Date:** {adr.created_at}\n"
+        f"**Category:** {adr.category}\n"
+        f"\n"
+        f"## Context\n"
+        f"\n"
+        f"{adr.context}\n"
+        f"\n"
+        f"## Decision\n"
+        f"\n"
+        f"{adr.decision}\n"
+        f"\n"
+        f"## Consequences\n"
+        f"\n"
+        f"{adr.consequences}\n"
+    )
+
+
+def export_adrs(adrs: list[ADRRecord], format: str = "combined") -> str:
+    """Export ADRs as Markdown.
+
+    Args:
+        adrs: List of ADR records to export.
+        format: Export format — "combined" for single document,
+                "individual" for first ADR only.
+
+    Returns:
+        Markdown string of the exported ADRs.
+    """
+    if not adrs:
+        return "# Architecture Decision Records\n\nNo ADRs generated yet.\n"
+
+    if format == "individual":
+        return _format_single_adr(adrs[0])
+
+    sections = [_format_single_adr(adr) for adr in adrs]
+    header = "# Architecture Decision Records\n\n"
+    return header + "\n---\n\n".join(sections)

--- a/backend/app/services/adr_generator.py
+++ b/backend/app/services/adr_generator.py
@@ -279,14 +279,69 @@ def generate_adrs(
 
             if ai_client.is_configured:
                 logger.info("Enhancing ADRs with AI")
-                # AI enhancement would happen here in production
-                # For now, log and return template ADRs
+                adrs = _enhance_adrs_with_ai(adrs, ai_client, architecture, answers)
             else:
-                logger.info("AI not configured — using template ADRs")
+                logger.warning("AI not configured — falling back to template ADRs")
         except Exception as e:
             logger.warning("AI enhancement failed, falling back to templates: %s", e)
 
     return adrs
+
+
+def _enhance_adrs_with_ai(
+    adrs: list[ADRRecord],
+    client: object,
+    architecture: dict,
+    answers: dict,
+) -> list[ADRRecord]:
+    """Enhance template-generated ADRs using AI.
+
+    Uses the AI client to rewrite context, decision, and consequences
+    for each ADR with richer, architecture-specific content.
+    Falls back to the original ADR if enhancement fails.
+    """
+    import json as _json
+
+    enhanced: list[ADRRecord] = []
+    for adr in adrs:
+        system_prompt = (
+            "You are an Azure cloud architecture expert. Enhance the following "
+            "Architecture Decision Record with richer detail based on the provided "
+            "architecture and questionnaire answers. Return a JSON object with keys: "
+            "context, decision, consequences. Keep the tone professional and concise."
+        )
+        user_prompt = _json.dumps({
+            "adr_title": adr.title,
+            "adr_category": adr.category,
+            "current_context": adr.context,
+            "current_decision": adr.decision,
+            "current_consequences": adr.consequences,
+            "architecture_summary": {
+                k: v for k, v in architecture.items()
+                if k in ("management_groups", "network_topology", "identity",
+                         "subscriptions", "policies")
+            },
+            "answers_summary": answers,
+        })
+        try:
+            response = client.generate_completion(
+                system_prompt, user_prompt, temperature=0.3, max_tokens=1024,
+            )
+            data = _json.loads(response)
+            enhanced.append(ADRRecord(
+                id=adr.id,
+                title=adr.title,
+                status=adr.status,
+                context=data.get("context", adr.context),
+                decision=data.get("decision", adr.decision),
+                consequences=data.get("consequences", adr.consequences),
+                category=adr.category,
+                created_at=adr.created_at,
+            ))
+        except Exception as exc:
+            logger.warning("AI enhancement failed for %s, keeping template: %s", adr.id, exc)
+            enhanced.append(adr)
+    return enhanced
 
 
 def _format_single_adr(adr: ADRRecord) -> str:
@@ -318,7 +373,7 @@ def export_adrs(adrs: list[ADRRecord], format: str = "combined") -> str:
     Args:
         adrs: List of ADR records to export.
         format: Export format — "combined" for single document,
-                "individual" for first ADR only.
+                "individual" for separate markdown per ADR.
 
     Returns:
         Markdown string of the exported ADRs.
@@ -327,7 +382,8 @@ def export_adrs(adrs: list[ADRRecord], format: str = "combined") -> str:
         return "# Architecture Decision Records\n\nNo ADRs generated yet.\n"
 
     if format == "individual":
-        return _format_single_adr(adrs[0])
+        sections = [_format_single_adr(adr) for adr in adrs]
+        return "\n---\n\n".join(sections)
 
     sections = [_format_single_adr(adr) for adr in adrs]
     header = "# Architecture Decision Records\n\n"

--- a/backend/tests/test_adr.py
+++ b/backend/tests/test_adr.py
@@ -1,0 +1,259 @@
+"""Tests for ADR generation service and API routes."""
+
+import pytest
+from fastapi.testclient import TestClient
+
+from app.main import app
+from app.schemas.adr import ADRRecord
+from app.services.adr_generator import export_adrs, generate_adrs
+
+client = TestClient(app)
+
+# --- Sample architecture data for tests ---
+
+SAMPLE_ARCHITECTURE = {
+    "management_groups": {
+        "root": {"children": ["platform", "workloads"]},
+        "platform": {"children": ["connectivity", "identity"]},
+        "workloads": {"children": ["prod", "dev"]},
+    },
+    "subscriptions": [
+        {"name": "connectivity", "purpose": "Hub networking", "management_group": "platform"},
+        {"name": "identity", "purpose": "Identity services", "management_group": "platform"},
+        {"name": "production", "purpose": "Production workloads", "management_group": "workloads"},
+        {"name": "development", "purpose": "Dev/test", "management_group": "workloads"},
+    ],
+    "network_topology": {
+        "type": "hub-spoke",
+        "primary_region": "eastus2",
+        "secondary_region": "westus2",
+    },
+    "identity": {
+        "provider": "Entra ID",
+        "pim_enabled": True,
+        "mfa_policy": "all_users",
+    },
+    "policies": {
+        "CIS": {"version": "1.4"},
+        "NIST_800_53": {"version": "5"},
+    },
+}
+
+SAMPLE_ANSWERS = {
+    "org_size": "enterprise",
+    "identity_model": "centralized",
+    "compliance_frameworks": ["CIS", "NIST 800-53", "SOC 2"],
+    "network_topology": "hub_spoke",
+}
+
+
+# --- Service-level tests ---
+
+
+class TestGenerateAdrs:
+    """Tests for the generate_adrs service function."""
+
+    def test_generates_six_adrs(self):
+        """Should produce one ADR per major decision area."""
+        adrs = generate_adrs(SAMPLE_ARCHITECTURE, SAMPLE_ANSWERS)
+        assert len(adrs) == 6
+
+    def test_adr_ids_are_sequential(self):
+        """Each ADR should have a sequential ID like ADR-001."""
+        adrs = generate_adrs(SAMPLE_ARCHITECTURE, SAMPLE_ANSWERS)
+        for i, adr in enumerate(adrs, 1):
+            assert adr.id == f"ADR-{i:03d}"
+
+    def test_all_categories_present(self):
+        """ADRs should cover governance, networking, identity, and compliance."""
+        adrs = generate_adrs(SAMPLE_ARCHITECTURE, SAMPLE_ANSWERS)
+        categories = {adr.category for adr in adrs}
+        assert "governance" in categories
+        assert "networking" in categories
+        assert "identity" in categories
+        assert "compliance" in categories
+
+    def test_adr_titles_match_decision_areas(self):
+        """Each ADR should have a descriptive title for its decision area."""
+        adrs = generate_adrs(SAMPLE_ARCHITECTURE, SAMPLE_ANSWERS)
+        titles = [adr.title for adr in adrs]
+        assert "Management Group Hierarchy" in titles
+        assert "Network Topology" in titles
+        assert "Identity Model" in titles
+        assert "Compliance Frameworks" in titles
+        assert "Region Selection" in titles
+        assert "Subscription Topology" in titles
+
+    def test_adr_fields_are_populated(self):
+        """Every ADR field should be non-empty."""
+        adrs = generate_adrs(SAMPLE_ARCHITECTURE, SAMPLE_ANSWERS)
+        for adr in adrs:
+            assert adr.id
+            assert adr.title
+            assert adr.status == "Accepted"
+            assert adr.context
+            assert adr.decision
+            assert adr.consequences
+            assert adr.category
+            assert adr.created_at
+
+    def test_network_adr_uses_architecture_topology(self):
+        """Network ADR should reference the topology type from architecture."""
+        adrs = generate_adrs(SAMPLE_ARCHITECTURE, SAMPLE_ANSWERS)
+        net_adr = next(a for a in adrs if a.title == "Network Topology")
+        assert "hub-spoke" in net_adr.decision
+
+    def test_region_adr_uses_architecture_regions(self):
+        """Region ADR should reference primary and secondary regions."""
+        adrs = generate_adrs(SAMPLE_ARCHITECTURE, SAMPLE_ANSWERS)
+        region_adr = next(a for a in adrs if a.title == "Region Selection")
+        assert "eastus2" in region_adr.decision
+        assert "westus2" in region_adr.decision
+
+    def test_compliance_adr_uses_answers(self):
+        """Compliance ADR should reference selected frameworks from answers."""
+        adrs = generate_adrs(SAMPLE_ARCHITECTURE, SAMPLE_ANSWERS)
+        comp_adr = next(a for a in adrs if a.title == "Compliance Frameworks")
+        assert "CIS" in comp_adr.decision
+        assert "NIST 800-53" in comp_adr.decision
+
+    def test_ai_mode_falls_back_to_templates(self):
+        """use_ai=True should fall back to template mode when AI is not configured."""
+        adrs = generate_adrs(SAMPLE_ARCHITECTURE, SAMPLE_ANSWERS, use_ai=True)
+        assert len(adrs) == 6
+        # Should still produce valid ADRs
+        assert all(isinstance(a, ADRRecord) for a in adrs)
+
+    def test_empty_architecture(self):
+        """Should handle empty architecture gracefully."""
+        adrs = generate_adrs({}, {})
+        assert len(adrs) == 6
+        # Should still produce ADRs with fallback values
+        for adr in adrs:
+            assert adr.context
+            assert adr.decision
+
+    def test_list_management_groups(self):
+        """Should handle management groups provided as a list."""
+        arch = {
+            "management_groups": [
+                {"name": "root"},
+                {"name": "platform"},
+            ],
+        }
+        adrs = generate_adrs(arch, {})
+        mg_adr = next(a for a in adrs if a.title == "Management Group Hierarchy")
+        assert "2" in mg_adr.decision
+        assert "root" in mg_adr.decision
+
+
+# --- Export tests ---
+
+
+class TestExportAdrs:
+    """Tests for the export_adrs function."""
+
+    def test_combined_export_format(self):
+        """Combined export should contain all ADRs separated by ---."""
+        adrs = generate_adrs(SAMPLE_ARCHITECTURE, SAMPLE_ANSWERS)
+        md = export_adrs(adrs, format="combined")
+        assert "# Architecture Decision Records" in md
+        assert "---" in md
+        for adr in adrs:
+            assert adr.title in md
+
+    def test_individual_export_format(self):
+        """Individual export should contain only the first ADR."""
+        adrs = generate_adrs(SAMPLE_ARCHITECTURE, SAMPLE_ANSWERS)
+        md = export_adrs(adrs, format="individual")
+        assert adrs[0].title in md
+        # Should not contain the combined header
+        assert "# Architecture Decision Records" not in md
+
+    def test_export_empty_list(self):
+        """Exporting with no ADRs should return a placeholder message."""
+        md = export_adrs([], format="combined")
+        assert "No ADRs generated yet" in md
+
+    def test_export_markdown_structure(self):
+        """Each ADR should include Status, Date, Category, Context, Decision, Consequences."""
+        adrs = generate_adrs(SAMPLE_ARCHITECTURE, SAMPLE_ANSWERS)
+        md = export_adrs(adrs, format="combined")
+        assert "**Status:**" in md
+        assert "**Date:**" in md
+        assert "**Category:**" in md
+        assert "## Context" in md
+        assert "## Decision" in md
+        assert "## Consequences" in md
+
+
+# --- API route tests ---
+
+
+class TestADRRoutes:
+    """Tests for the ADR API endpoints."""
+
+    def test_generate_endpoint_returns_adrs(self):
+        """POST /api/architecture/adrs/generate should return ADR list."""
+        response = client.post(
+            "/api/architecture/adrs/generate",
+            json={
+                "architecture": SAMPLE_ARCHITECTURE,
+                "answers": SAMPLE_ANSWERS,
+            },
+        )
+        assert response.status_code == 200
+        data = response.json()
+        assert "adrs" in data
+        assert len(data["adrs"]) == 6
+
+    def test_generate_endpoint_with_project_id(self):
+        """Generate endpoint should echo back the project_id."""
+        response = client.post(
+            "/api/architecture/adrs/generate",
+            json={
+                "architecture": SAMPLE_ARCHITECTURE,
+                "answers": {},
+                "project_id": "proj-123",
+            },
+        )
+        assert response.status_code == 200
+        assert response.json()["project_id"] == "proj-123"
+
+    def test_generate_endpoint_with_ai_flag(self):
+        """Generate endpoint should accept use_ai flag without error."""
+        response = client.post(
+            "/api/architecture/adrs/generate",
+            json={
+                "architecture": SAMPLE_ARCHITECTURE,
+                "answers": SAMPLE_ANSWERS,
+                "use_ai": True,
+            },
+        )
+        assert response.status_code == 200
+        assert len(response.json()["adrs"]) == 6
+
+    def test_export_endpoint_combined(self):
+        """POST /api/architecture/adrs/export should return markdown content."""
+        adrs = generate_adrs(SAMPLE_ARCHITECTURE, SAMPLE_ANSWERS)
+        adr_dicts = [adr.model_dump() for adr in adrs]
+        response = client.post(
+            "/api/architecture/adrs/export",
+            json={"adrs": adr_dicts, "format": "combined"},
+        )
+        assert response.status_code == 200
+        data = response.json()
+        assert "content" in data
+        assert "Architecture Decision Records" in data["content"]
+
+    def test_export_endpoint_individual(self):
+        """Export with individual format returns first ADR only."""
+        adrs = generate_adrs(SAMPLE_ARCHITECTURE, SAMPLE_ANSWERS)
+        adr_dicts = [adr.model_dump() for adr in adrs]
+        response = client.post(
+            "/api/architecture/adrs/export",
+            json={"adrs": adr_dicts, "format": "individual"},
+        )
+        assert response.status_code == 200
+        content = response.json()["content"]
+        assert adrs[0].title in content

--- a/backend/tests/test_adr.py
+++ b/backend/tests/test_adr.py
@@ -163,12 +163,16 @@ class TestExportAdrs:
             assert adr.title in md
 
     def test_individual_export_format(self):
-        """Individual export should contain only the first ADR."""
+        """Individual export should contain all ADRs as separate markdown sections."""
         adrs = generate_adrs(SAMPLE_ARCHITECTURE, SAMPLE_ANSWERS)
         md = export_adrs(adrs, format="individual")
-        assert adrs[0].title in md
+        # Every ADR should be present in the output
+        for adr in adrs:
+            assert adr.title in md
         # Should not contain the combined header
         assert "# Architecture Decision Records" not in md
+        # ADRs should be separated by ---
+        assert "---" in md
 
     def test_export_empty_list(self):
         """Exporting with no ADRs should return a placeholder message."""
@@ -247,7 +251,7 @@ class TestADRRoutes:
         assert "Architecture Decision Records" in data["content"]
 
     def test_export_endpoint_individual(self):
-        """Export with individual format returns first ADR only."""
+        """Export with individual format returns all ADRs."""
         adrs = generate_adrs(SAMPLE_ARCHITECTURE, SAMPLE_ANSWERS)
         adr_dicts = [adr.model_dump() for adr in adrs]
         response = client.post(
@@ -256,4 +260,5 @@ class TestADRRoutes:
         )
         assert response.status_code == 200
         content = response.json()["content"]
-        assert adrs[0].title in content
+        for adr in adrs:
+            assert adr.title in content

--- a/frontend/src/components/visualizer/ADRPanel.test.tsx
+++ b/frontend/src/components/visualizer/ADRPanel.test.tsx
@@ -1,0 +1,195 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { FluentProvider, teamsLightTheme } from "@fluentui/react-components";
+import ADRPanel from "./ADRPanel";
+import type { ADRRecord } from "../../services/api";
+
+const mockAdrs: ADRRecord[] = [
+  {
+    id: "ADR-001",
+    title: "Management Group Hierarchy",
+    status: "Accepted",
+    context: "Need a management group hierarchy.",
+    decision: "Use CAF-aligned hierarchy.",
+    consequences: "Policies cascade down.",
+    category: "governance",
+    created_at: "2025-01-01",
+  },
+  {
+    id: "ADR-002",
+    title: "Network Topology",
+    status: "Accepted",
+    context: "Need network connectivity.",
+    decision: "Use hub-spoke topology.",
+    consequences: "Traffic routes through hub.",
+    category: "networking",
+    created_at: "2025-01-01",
+  },
+  {
+    id: "ADR-003",
+    title: "Identity Model",
+    status: "Accepted",
+    context: "Need identity strategy.",
+    decision: "Use centralized Entra ID.",
+    consequences: "Single audit trail.",
+    category: "identity",
+    created_at: "2025-01-01",
+  },
+];
+
+const mockGenerateAdrs = vi.fn();
+const mockExportAdrs = vi.fn();
+
+vi.mock("../../services/api", () => ({
+  api: {
+    architecture: {
+      generateAdrs: (...args: unknown[]) => mockGenerateAdrs(...args),
+      exportAdrs: (...args: unknown[]) => mockExportAdrs(...args),
+    },
+  },
+}));
+
+const defaultProps = {
+  architecture: { management_groups: {}, subscriptions: [] },
+  answers: { org_size: "small" },
+  projectId: "proj-1",
+};
+
+function renderPanel(props = defaultProps) {
+  return render(
+    <FluentProvider theme={teamsLightTheme}>
+      <ADRPanel {...props} />
+    </FluentProvider>,
+  );
+}
+
+describe("ADRPanel", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGenerateAdrs.mockResolvedValue({ adrs: mockAdrs, project_id: "proj-1" });
+    mockExportAdrs.mockResolvedValue({ content: "# ADRs\n\nContent here" });
+  });
+
+  it("renders with no ADRs and shows generate button", () => {
+    renderPanel();
+
+    expect(screen.getByText("Generate ADRs")).toBeInTheDocument();
+    expect(
+      screen.getByText(/No ADRs generated yet/),
+    ).toBeInTheDocument();
+  });
+
+  it("does not show export button when no ADRs exist", () => {
+    renderPanel();
+
+    expect(screen.queryByText("Export All")).not.toBeInTheDocument();
+  });
+
+  it("generates ADRs when button is clicked", async () => {
+    const user = userEvent.setup();
+    renderPanel();
+
+    await user.click(screen.getByText("Generate ADRs"));
+
+    await waitFor(() => {
+      expect(mockGenerateAdrs).toHaveBeenCalledWith(
+        defaultProps.architecture,
+        defaultProps.answers,
+        false,
+        defaultProps.projectId,
+      );
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText("Management Group Hierarchy")).toBeInTheDocument();
+      expect(screen.getByText("Network Topology")).toBeInTheDocument();
+      expect(screen.getByText("Identity Model")).toBeInTheDocument();
+    });
+  });
+
+  it("renders ADR list with titles and category badges", async () => {
+    const user = userEvent.setup();
+    renderPanel();
+
+    await user.click(screen.getByText("Generate ADRs"));
+
+    await waitFor(() => {
+      expect(screen.getByText("ADR-001")).toBeInTheDocument();
+      expect(screen.getByText("ADR-002")).toBeInTheDocument();
+      expect(screen.getByText("governance")).toBeInTheDocument();
+      expect(screen.getByText("networking")).toBeInTheDocument();
+    });
+  });
+
+  it("expands an ADR to show details", async () => {
+    const user = userEvent.setup();
+    renderPanel();
+
+    await user.click(screen.getByText("Generate ADRs"));
+
+    await waitFor(() => {
+      expect(screen.getByText("Management Group Hierarchy")).toBeInTheDocument();
+    });
+
+    // Click the accordion header to expand
+    await user.click(screen.getByText("Management Group Hierarchy"));
+
+    await waitFor(() => {
+      expect(screen.getByText("Need a management group hierarchy.")).toBeInTheDocument();
+      expect(screen.getByText("Use CAF-aligned hierarchy.")).toBeInTheDocument();
+      expect(screen.getByText("Policies cascade down.")).toBeInTheDocument();
+    });
+  });
+
+  it("shows export button after ADRs are generated", async () => {
+    const user = userEvent.setup();
+    renderPanel();
+
+    await user.click(screen.getByText("Generate ADRs"));
+
+    await waitFor(() => {
+      expect(screen.getByText("Export All")).toBeInTheDocument();
+    });
+  });
+
+  it("calls export API when Export All is clicked", async () => {
+    const user = userEvent.setup();
+    renderPanel();
+
+    await user.click(screen.getByText("Generate ADRs"));
+
+    await waitFor(() => {
+      expect(screen.getByText("Export All")).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByText("Export All"));
+
+    await waitFor(() => {
+      expect(mockExportAdrs).toHaveBeenCalledWith(mockAdrs, "combined");
+    });
+  });
+
+  it("shows error message when generation fails", async () => {
+    mockGenerateAdrs.mockRejectedValueOnce(new Error("Network error"));
+    const user = userEvent.setup();
+    renderPanel();
+
+    await user.click(screen.getByText("Generate ADRs"));
+
+    await waitFor(() => {
+      expect(screen.getByText("Network error")).toBeInTheDocument();
+    });
+  });
+
+  it("shows regenerate button after ADRs exist", async () => {
+    const user = userEvent.setup();
+    renderPanel();
+
+    await user.click(screen.getByText("Generate ADRs"));
+
+    await waitFor(() => {
+      expect(screen.getByText("Regenerate ADRs")).toBeInTheDocument();
+    });
+  });
+});

--- a/frontend/src/components/visualizer/ADRPanel.test.tsx
+++ b/frontend/src/components/visualizer/ADRPanel.test.tsx
@@ -69,6 +69,12 @@ describe("ADRPanel", () => {
     vi.clearAllMocks();
     mockGenerateAdrs.mockResolvedValue({ adrs: mockAdrs, project_id: "proj-1" });
     mockExportAdrs.mockResolvedValue({ content: "# ADRs\n\nContent here" });
+    // Stub blob URL APIs not available in jsdom
+    vi.stubGlobal("URL", {
+      ...URL,
+      createObjectURL: vi.fn().mockReturnValue("blob:test"),
+      revokeObjectURL: vi.fn(),
+    });
   });
 
   it("renders with no ADRs and shows generate button", () => {

--- a/frontend/src/components/visualizer/ADRPanel.tsx
+++ b/frontend/src/components/visualizer/ADRPanel.tsx
@@ -1,0 +1,192 @@
+import { useState, useCallback } from "react";
+import {
+  makeStyles,
+  tokens,
+  Card,
+  Body1,
+  Title2,
+  Badge,
+  Button,
+  Spinner,
+  Accordion,
+  AccordionItem,
+  AccordionHeader,
+  AccordionPanel,
+} from "@fluentui/react-components";
+import {
+  ArrowDownloadRegular,
+  DocumentBulletListRegular,
+} from "@fluentui/react-icons";
+import type { ADRRecord } from "../../services/api";
+import { api } from "../../services/api";
+
+interface ADRPanelProps {
+  architecture: Record<string, unknown>;
+  answers: Record<string, string | string[]>;
+  projectId?: string;
+}
+
+const useStyles = makeStyles({
+  container: {
+    marginTop: "24px",
+  },
+  header: {
+    display: "flex",
+    alignItems: "center",
+    justifyContent: "space-between",
+    marginBottom: "16px",
+  },
+  title: {
+    color: tokens.colorBrandForeground1,
+  },
+  actions: {
+    display: "flex",
+    gap: "8px",
+  },
+  emptyState: {
+    textAlign: "center" as const,
+    padding: "32px",
+  },
+  adrHeader: {
+    display: "flex",
+    alignItems: "center",
+    gap: "8px",
+  },
+  adrId: {
+    fontFamily: tokens.fontFamilyMonospace,
+    fontSize: tokens.fontSizeBase200,
+    color: tokens.colorNeutralForeground3,
+  },
+  section: {
+    marginBottom: "12px",
+  },
+  sectionTitle: {
+    fontWeight: tokens.fontWeightSemibold,
+    marginBottom: "4px",
+    color: tokens.colorBrandForeground1,
+  },
+  errorText: {
+    color: tokens.colorPaletteRedForeground1,
+    marginTop: "8px",
+  },
+});
+
+const categoryColors: Record<string, "brand" | "success" | "warning" | "informative" | "important"> = {
+  governance: "brand",
+  networking: "informative",
+  identity: "important",
+  compliance: "warning",
+};
+
+export default function ADRPanel({ architecture, answers, projectId }: ADRPanelProps) {
+  const styles = useStyles();
+  const [adrs, setAdrs] = useState<ADRRecord[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleGenerate = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const result = await api.architecture.generateAdrs(architecture, answers, false, projectId);
+      setAdrs(result.adrs);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Failed to generate ADRs");
+    } finally {
+      setLoading(false);
+    }
+  }, [architecture, answers, projectId]);
+
+  const handleExport = useCallback(async () => {
+    if (adrs.length === 0) return;
+    try {
+      const result = await api.architecture.exportAdrs(adrs, "combined");
+      const blob = new Blob([result.content], { type: "text/markdown" });
+      const url = URL.createObjectURL(blob);
+      const link = document.createElement("a");
+      link.href = url;
+      link.download = "architecture-decision-records.md";
+      link.click();
+      URL.revokeObjectURL(url);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Failed to export ADRs");
+    }
+  }, [adrs]);
+
+  return (
+    <Card className={styles.container}>
+      <div className={styles.header}>
+        <Title2 className={styles.title}>📋 Architecture Decision Records</Title2>
+        <div className={styles.actions}>
+          {adrs.length > 0 && (
+            <Button
+              appearance="secondary"
+              icon={<ArrowDownloadRegular />}
+              onClick={handleExport}
+            >
+              Export All
+            </Button>
+          )}
+          <Button
+            appearance="primary"
+            icon={loading ? <Spinner size="tiny" /> : <DocumentBulletListRegular />}
+            disabled={loading}
+            onClick={handleGenerate}
+          >
+            {loading ? "Generating..." : adrs.length > 0 ? "Regenerate ADRs" : "Generate ADRs"}
+          </Button>
+        </div>
+      </div>
+
+      {error && <Body1 className={styles.errorText}>{error}</Body1>}
+
+      {adrs.length === 0 && !loading && (
+        <div className={styles.emptyState}>
+          <Body1>
+            No ADRs generated yet. Click &quot;Generate ADRs&quot; to create architecture decision
+            records from your landing zone design.
+          </Body1>
+        </div>
+      )}
+
+      {adrs.length > 0 && (
+        <Accordion multiple collapsible>
+          {adrs.map((adr) => (
+            <AccordionItem key={adr.id} value={adr.id}>
+              <AccordionHeader>
+                <div className={styles.adrHeader}>
+                  <span className={styles.adrId}>{adr.id}</span>
+                  <span>{adr.title}</span>
+                  <Badge
+                    appearance="filled"
+                    color={categoryColors[adr.category] ?? "brand"}
+                    size="small"
+                  >
+                    {adr.category}
+                  </Badge>
+                  <Badge appearance="outline" size="small">
+                    {adr.status}
+                  </Badge>
+                </div>
+              </AccordionHeader>
+              <AccordionPanel>
+                <div className={styles.section}>
+                  <Body1 className={styles.sectionTitle}>Context</Body1>
+                  <Body1>{adr.context}</Body1>
+                </div>
+                <div className={styles.section}>
+                  <Body1 className={styles.sectionTitle}>Decision</Body1>
+                  <Body1>{adr.decision}</Body1>
+                </div>
+                <div className={styles.section}>
+                  <Body1 className={styles.sectionTitle}>Consequences</Body1>
+                  <Body1>{adr.consequences}</Body1>
+                </div>
+              </AccordionPanel>
+            </AccordionItem>
+          ))}
+        </Accordion>
+      )}
+    </Card>
+  );
+}

--- a/frontend/src/pages/ArchitecturePage.tsx
+++ b/frontend/src/pages/ArchitecturePage.tsx
@@ -75,6 +75,7 @@ export default function ArchitecturePage() {
   const navigate = useNavigate();
   const { projectId } = useParams<{ projectId: string }>();
   const [architecture, setArchitecture] = useState<Architecture | null>(null);
+  const [answers, setAnswers] = useState<Record<string, string | string[]>>({});
   const [costEstimation, setCostEstimation] = useState<CostEstimation | null>(null);
   const [costLoading, setCostLoading] = useState(false);
   const [costError, setCostError] = useState<string | null>(null);
@@ -87,10 +88,21 @@ export default function ArchitecturePage() {
           setArchitecture(data.architecture);
         }
       }).catch(console.error);
+      // Load saved questionnaire answers for project-scoped flows
+      api.questionnaire.loadState(projectId).then((data) => {
+        if (data.answers && Object.keys(data.answers).length > 0) {
+          setAnswers(data.answers);
+        }
+      }).catch(console.error);
     } else {
       const stored = sessionStorage.getItem("onramp_architecture");
       if (stored) {
         setArchitecture(JSON.parse(stored));
+      }
+      // Load answers saved by the wizard during generation
+      const storedAnswers = sessionStorage.getItem("onramp_answers");
+      if (storedAnswers) {
+        setAnswers(JSON.parse(storedAnswers));
       }
     }
   }, [projectId]);
@@ -313,7 +325,7 @@ export default function ArchitecturePage() {
 
       <ADRPanel
         architecture={architecture as Record<string, unknown>}
-        answers={{}}
+        answers={answers}
         projectId={projectId}
       />
     </div>

--- a/frontend/src/pages/ArchitecturePage.tsx
+++ b/frontend/src/pages/ArchitecturePage.tsx
@@ -21,6 +21,7 @@ import type { Architecture, CostEstimation } from "../services/api";
 import { api } from "../services/api";
 import ArchitectureDiagram from "../components/visualizer/ArchitectureDiagram";
 import ArchitectureChat from "../components/visualizer/ArchitectureChat";
+import ADRPanel from "../components/visualizer/ADRPanel";
 import { exportArchitectureJson, exportDesignDocument } from "../utils/exportUtils";
 
 const useStyles = makeStyles({
@@ -308,6 +309,12 @@ export default function ArchitecturePage() {
           setArchitecture(updated);
           sessionStorage.setItem("onramp_architecture", JSON.stringify(updated));
         }}
+      />
+
+      <ADRPanel
+        architecture={architecture as Record<string, unknown>}
+        answers={{}}
+        projectId={projectId}
       />
     </div>
   );

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -84,6 +84,26 @@ export const api = {
         "/api/architecture/estimate-costs",
         { method: "POST", body: JSON.stringify({ architecture }) }
       ),
+    generateAdrs: (
+      architecture: Record<string, unknown>,
+      answers: Record<string, string | string[]>,
+      useAi = false,
+      projectId?: string,
+    ) =>
+      fetchApi<ADRGenerateResponse>("/api/architecture/adrs/generate", {
+        method: "POST",
+        body: JSON.stringify({
+          architecture,
+          answers,
+          use_ai: useAi,
+          project_id: projectId,
+        }),
+      }),
+    exportAdrs: (adrs: ADRRecord[], format: "individual" | "combined" = "combined") =>
+      fetchApi<{ content: string }>("/api/architecture/adrs/export", {
+        method: "POST",
+        body: JSON.stringify({ adrs, format }),
+      }),
   },
   compliance: {
     getFrameworks: () => fetchApi<{ frameworks: Framework[] }>("/api/compliance/frameworks"),
@@ -650,4 +670,20 @@ export interface MoveWorkloadRequest {
   workload_id: string;
   target_wave_id: string;
   position?: number;
+}
+
+export interface ADRRecord {
+  id: string;
+  title: string;
+  status: string;
+  context: string;
+  decision: string;
+  consequences: string;
+  category: string;
+  created_at: string;
+}
+
+export interface ADRGenerateResponse {
+  adrs: ADRRecord[];
+  project_id: string | null;
 }


### PR DESCRIPTION
Closes #2

## Summary

Full-stack feature that generates ADRs from questionnaire answers and architecture data.

### Backend
- **adr_generator service** — Produces 6 ADRs per architecture (management groups, network, identity, compliance, regions, subscriptions). Template mode default, AI-enhanced when configured.
- **Schemas** — ADRRecord, ADRGenerateRequest, ADRGenerateResponse, ADRExportRequest
- **API routes** — POST /api/architecture/adrs/generate, POST /api/architecture/adrs/export
- **20 backend tests** — 11 service + 4 export + 5 route tests

### Frontend
- **ADRPanel component** — Fluent UI v9 Accordion with category badges, Generate/Export buttons
- **API methods** — generateAdrs, exportAdrs in architecture namespace
- **ArchitecturePage** — Integrated ADRPanel below existing content
- **9 frontend tests** — render states, generation, expansion, export

### Quality
- Backend lint clean, 20/20 tests passing
- Frontend lint clean, 9/9 tests passing