### PR TITLE
docs: Add architecture diagrams and screenshot framework (#3)

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,37 @@
+name: "CodeQL"
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    - cron: "30 6 * * 1"
+
+jobs:
+  analyze:
+    name: Analyze
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [javascript-typescript, python]
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: ${{ matrix.language }}
+
+      - name: Autobuild
+        uses: github/codeql-action/autobuild@v3
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: "/language:${{ matrix.language }}"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -28,8 +28,32 @@ jobs:
         with:
           languages: ${{ matrix.language }}
 
-      - name: Autobuild
-        uses: github/codeql-action/autobuild@v3
+      - name: Set up Node.js
+        if: matrix.language == 'javascript-typescript'
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24
+
+      - name: Install frontend dependencies
+        if: matrix.language == 'javascript-typescript'
+        working-directory: frontend
+        run: npm ci
+
+      - name: Build frontend
+        if: matrix.language == 'javascript-typescript'
+        working-directory: frontend
+        run: npm run build
+
+      - name: Set up Python
+        if: matrix.language == 'python'
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install backend dependencies
+        if: matrix.language == 'python'
+        working-directory: backend
+        run: pip install -e ".[dev]"
 
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@v3

--- a/README.md
+++ b/README.md
@@ -16,7 +16,15 @@
 
 ## 📸 Screenshots
 
-> **Screenshots coming soon.** Want to help? See [`docs/screenshots/README.md`](docs/screenshots/README.md) for capture instructions.
+The application includes a guided questionnaire, an interactive architecture visualizer, compliance scoring dashboards, and one-click Azure deployment. See [`docs/screenshots/README.md`](docs/screenshots/README.md) for instructions on capturing screenshots of each page.
+
+```mermaid
+flowchart LR
+    Wizard[🧭 Questionnaire] --> Arch[🏗️ Architecture Visualizer]
+    Arch --> Compliance[📋 Compliance Scoring]
+    Compliance --> Bicep[📝 Bicep Preview]
+    Bicep --> Deploy[🚀 One-Click Deploy]
+```
 
 ## 🏗️ System Architecture
 

--- a/README.md
+++ b/README.md
@@ -14,15 +14,39 @@
 - **🚀 One-Click Deploy** — Deploy your entire landing zone to Azure subscriptions
 - **📊 Deployment Tracking** — Real-time progress, audit logging, and rollback support
 
-## 🏛️ Architecture
+## 📸 Screenshots
 
-```
-React + Fluent UI v9  →  FastAPI (Python)  →  Azure SQL
-                                           →  Azure AI Foundry
-                                           →  Customer Subscriptions (Bicep)
+> **Screenshots coming soon.** Want to help? See [`docs/screenshots/README.md`](docs/screenshots/README.md) for capture instructions.
+
+## 🏗️ System Architecture
+
+```mermaid
+flowchart LR
+    subgraph Frontend
+        React[React + Fluent UI v9]
+    end
+
+    subgraph Backend
+        FastAPI[FastAPI — Python]
+    end
+
+    subgraph Services
+        DB[(Azure SQL)]
+        AI[Azure AI Foundry]
+        ARM[Azure Resource Manager]
+    end
+
+    React -- REST API --> FastAPI
+    React -- MSAL --> EntraID[Entra ID]
+    EntraID -- Token --> FastAPI
+    FastAPI --> DB
+    FastAPI --> AI
+    FastAPI -- Bicep --> ARM
 ```
 
 Hosted on **Azure Container Apps** with **Entra ID** authentication.
+
+> For the full architecture breakdown, see [`docs/architecture.md`](docs/architecture.md).
 
 ## 🚀 Quick Start
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -6,6 +6,57 @@ OnRamp is an AI-powered Azure Landing Zone Architect & Deployer. It guides custo
 
 ## System Architecture
 
+```mermaid
+flowchart TB
+    subgraph Frontend["Frontend (React + Fluent UI v9)"]
+        UI[Web App — Vite + React 19 + TypeScript]
+        MSAL_JS[MSAL.js]
+    end
+
+    subgraph Auth["Authentication"]
+        EntraID[Microsoft Entra ID]
+    end
+
+    subgraph Backend["Backend (Python FastAPI)"]
+        API[FastAPI — REST API]
+        TokenVal[Token Validation — MSAL Python]
+        Questionnaire[Questionnaire Service]
+        ArchGen[Architecture Generator]
+        CompScorer[Compliance Scorer]
+        BicepGen[Bicep Generator]
+        DeployOrch[Deployment Orchestrator]
+    end
+
+    subgraph Data["Data & AI"]
+        DB[(Azure SQL / SQLite)]
+        AIFoundry[Azure AI Foundry]
+        KeyVault[Azure Key Vault]
+    end
+
+    subgraph Azure["Customer Azure Environment"]
+        ARM[Azure Resource Manager]
+        Subscriptions[Customer Subscriptions]
+    end
+
+    UI -- REST API --> API
+    MSAL_JS -- OAuth 2.0 --> EntraID
+    EntraID -- Access Token --> TokenVal
+    API --> Questionnaire
+    API --> ArchGen
+    API --> CompScorer
+    API --> BicepGen
+    API --> DeployOrch
+    Questionnaire --> DB
+    ArchGen --> AIFoundry
+    ArchGen --> DB
+    CompScorer --> AIFoundry
+    BicepGen --> AIFoundry
+    BicepGen --> DB
+    DeployOrch -- Bicep Templates --> ARM
+    ARM --> Subscriptions
+    API --> KeyVault
+```
+
 ```
 Frontend (React + Fluent UI v9)
   ↓ REST API

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -58,7 +58,7 @@ flowchart TB
 ```
 
 ```
-Frontend (React + Fluent UI v9)
+Frontend (React 19 + Fluent UI v9)
   ↓ REST API
 Backend (Python FastAPI)
   ↓
@@ -70,7 +70,7 @@ Customer Azure Subscriptions (Bicep deployments)
 ## Components
 
 ### Frontend
-- **React 18** with TypeScript and Vite
+- **React 19** with TypeScript and Vite
 - **Fluent UI v9** for Microsoft-standard UI components
 - **MSAL.js** for Entra ID authentication
 - Pages: Home, Wizard (questionnaire), Architecture (visualization), Deploy
@@ -78,7 +78,7 @@ Customer Azure Subscriptions (Bicep deployments)
 ### Backend
 - **FastAPI** (Python 3.12+) with async support
 - **SQLAlchemy 2.0** ORM with Azure SQL
-- **MSAL Python** for token validation
+- **PyJWT + JWKS** for Entra ID token validation
 - Services: Questionnaire, AI Foundry, Archetypes, Bicep Generator, Compliance Scoring, Deployment Orchestrator
 
 ### AI Integration

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -8,7 +8,7 @@ OnRamp is an AI-powered Azure Landing Zone Architect & Deployer. It guides custo
 
 ```mermaid
 flowchart TB
-    subgraph Frontend["Frontend (React + Fluent UI v9)"]
+    subgraph Frontend["Frontend (React 19 + Fluent UI v9)"]
         UI[Web App — Vite + React 19 + TypeScript]
         MSAL_JS[MSAL.js]
     end
@@ -19,7 +19,7 @@ flowchart TB
 
     subgraph Backend["Backend (Python FastAPI)"]
         API[FastAPI — REST API]
-        TokenVal[Token Validation — MSAL Python]
+        TokenVal[Token Validation — PyJWT / JWKS]
         Questionnaire[Questionnaire Service]
         ArchGen[Architecture Generator]
         CompScorer[Compliance Scorer]

--- a/docs/screenshots/README.md
+++ b/docs/screenshots/README.md
@@ -19,6 +19,23 @@ This starts the frontend at `http://localhost:5173` and the backend at `http://l
 - **Theme:** Use the default Fluent UI light theme
 - **Data:** Ensure sample data is loaded (the dev environment includes mock data)
 
+### 2b. Create a Sample Project
+
+The dev database does not create projects by default. Before capturing `home.png`, create one:
+
+1. Open the app at `http://localhost:5173`
+2. Click **"New Project"** on the dashboard
+3. Enter a name (e.g., "Contoso Landing Zone") and save
+4. The project now appears on the dashboard and is available for subsequent pages
+
+Alternatively, use the API directly:
+
+```bash
+curl -X POST http://localhost:8000/api/projects \
+  -H "Content-Type: application/json" \
+  -d '{"name": "Contoso Landing Zone", "description": "Sample project for screenshots"}'
+```
+
 ### 3. Screenshots Needed
 
 | File | Page / Route | What to Show |

--- a/docs/screenshots/README.md
+++ b/docs/screenshots/README.md
@@ -1,0 +1,48 @@
+# Screenshots
+
+This directory holds screenshots of the OnRamp application for use in documentation. Screenshots are not checked in yet — this README explains how to capture them.
+
+## How to Capture Screenshots
+
+### 1. Start the Application
+
+```bash
+./dev.sh
+```
+
+This starts the frontend at `http://localhost:5173` and the backend at `http://localhost:8000`.
+
+### 2. Recommended Settings
+
+- **Resolution:** 1280×720 (browser viewport)
+- **Browser:** Microsoft Edge or Google Chrome
+- **Theme:** Use the default Fluent UI light theme
+- **Data:** Ensure sample data is loaded (the dev environment includes mock data)
+
+### 3. Screenshots Needed
+
+| File | Page / Route | What to Show |
+|------|-------------|--------------|
+| `home.png` | `/` | Dashboard with the project list showing at least one project |
+| `wizard.png` | `/wizard` | Wizard page with a questionnaire question visible and a recommended option highlighted |
+| `architecture.png` | `/architecture` | Architecture visualizer with the landing zone diagram rendered |
+| `compliance.png` | `/compliance` | Compliance scoring results showing framework scores (e.g., SOC 2, HIPAA) |
+| `bicep.png` | `/bicep` | Bicep code preview panel with generated Infrastructure as Code |
+| `deploy.png` | `/deploy` | Deployment status page showing deployment progress or completion |
+
+### 4. Capture Steps
+
+1. Navigate to each page listed above
+2. Resize the browser viewport to **1280×720**
+3. Take a screenshot of the full viewport (no browser chrome)
+4. Save the file with the exact name from the table above
+5. Place the PNG file in this directory (`docs/screenshots/`)
+
+### 5. When to Update
+
+Screenshots should be updated when:
+
+- The UI layout changes significantly
+- New major features are added to a page
+- The design system or theme is updated
+- Existing screenshots no longer represent the current state of the app


### PR DESCRIPTION
Closes #3

## Summary

Adds visual content framework and code scanning to the repository.

### Changes
- **docs/screenshots/README.md** - Instructions for capturing screenshots with sample project setup
- **docs/architecture.md** - Mermaid flowchart diagram; fixed React 19 and PyJWT labels
- **README.md** - Screenshots section with workflow diagram
- **.github/workflows/codeql.yml** - CodeQL analysis for JS/TS and Python

### Notes
- Mermaid diagrams render natively on GitHub
- CodeQL uses explicit build steps for monorepo