### PR TITLE
feat: Switch to Entra-only SQL authentication

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,4 @@ htmlcov/
 
 # Docker
 *.log
+infra/main.json

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -22,7 +22,14 @@ RUN if [ "$INSTALL_ODBC" = "1" ]; then \
 
 COPY pyproject.toml ./
 COPY app ./app
-RUN pip install --no-cache-dir ".[dev]"
+# Install base + dev dependencies. When INSTALL_ODBC=1 (production), also
+# install the azure extras so azure-identity and aioodbc are available for
+# Entra-authenticated SQL connections.
+RUN if [ "$INSTALL_ODBC" = "1" ]; then \
+      pip install --no-cache-dir ".[dev,azure]"; \
+    else \
+      pip install --no-cache-dir ".[dev]"; \
+    fi
 
 COPY . .
 

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -8,6 +8,10 @@ class Settings(BaseSettings):
     # Database (empty = dev mode with SQLite)
     database_url: str = ""
 
+    # Managed identity client ID for Entra-authenticated SQL connections.
+    # Set when the backend runs on Azure with a user-assigned managed identity.
+    managed_identity_client_id: str = ""
+
     # Azure AD / Entra ID
     azure_tenant_id: str = ""
     azure_client_id: str = ""

--- a/backend/app/db/migrations/env.py
+++ b/backend/app/db/migrations/env.py
@@ -7,7 +7,7 @@ from alembic import context
 from sqlalchemy import pool
 from sqlalchemy.ext.asyncio import create_async_engine
 
-from app.db.session import get_database_url
+from app.db.session import _is_entra_auth_url, get_database_url
 from app.models import Base
 
 config = context.config
@@ -52,7 +52,16 @@ def do_run_migrations(connection):
 
 async def run_async_migrations() -> None:
     """Run migrations in 'online' mode with async engine."""
-    connectable = create_async_engine(get_url(), poolclass=pool.NullPool)
+    url = get_url()
+    connectable = create_async_engine(url, poolclass=pool.NullPool)
+
+    # When using Entra auth, attach the token hook so the migration connection
+    # authenticates with a managed-identity token instead of SQL credentials.
+    if _is_entra_auth_url(url):
+        from app.db.session import _attach_entra_token_hook, _get_entra_credential
+        credential = _get_entra_credential()
+        _attach_entra_token_hook(connectable, credential)
+
     async with connectable.connect() as connection:
         await connection.run_sync(do_run_migrations)
     await connectable.dispose()

--- a/backend/app/db/session.py
+++ b/backend/app/db/session.py
@@ -1,9 +1,56 @@
 """Database session management."""
 
+import logging
+import struct
+
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
 from sqlalchemy.pool import NullPool
 
 from app.config import settings
+
+logger = logging.getLogger(__name__)
+
+# ODBC constant for passing an access token to SQL Server
+SQL_COPT_SS_ACCESS_TOKEN = 1256
+
+
+def _is_entra_auth_url(url: str) -> bool:
+    """Detect Entra auth from a credential-free MSSQL URL (no user:pass)."""
+    if "mssql" not in url or "aioodbc" not in url:
+        return False
+    # Credential-free URLs look like mssql+aioodbc://@server/db
+    return "://@" in url
+
+
+def _get_entra_credential():
+    """Return an azure-identity credential scoped to the managed identity.
+
+    Uses ManagedIdentityCredential with an explicit client_id so we target the
+    correct user-assigned identity without polluting the global AZURE_CLIENT_ID.
+    Falls back to DefaultAzureCredential when no client_id is configured (works
+    with system-assigned MI, az-cli, etc.).
+    """
+    try:
+        if settings.managed_identity_client_id:
+            from azure.identity import ManagedIdentityCredential
+            return ManagedIdentityCredential(
+                client_id=settings.managed_identity_client_id
+            )
+        else:
+            from azure.identity import DefaultAzureCredential
+            return DefaultAzureCredential()
+    except ImportError:
+        logger.error(
+            "azure-identity is required for Entra SQL auth. "
+            "Install with: pip install 'onramp-backend[azure]'"
+        )
+        raise
+
+
+def _pack_token_for_odbc(token: str) -> bytes:
+    """Pack an access token into the struct format expected by SQL_COPT_SS_ACCESS_TOKEN."""
+    raw = token.encode("utf-16-le")
+    return struct.pack(f"<I{len(raw)}s", len(raw), raw)
 
 
 def get_database_url() -> str:
@@ -23,23 +70,55 @@ def get_database_url() -> str:
 # Engine and session factory - created lazily
 _engine = None
 _session_factory = None
+_entra_credential = None
 
 
 def get_engine():
-    global _engine
+    global _engine, _entra_credential
     if _engine is None:
         db_url = get_database_url()
         if not db_url:
             return None
         try:
-            _engine = create_async_engine(
-                db_url,
-                echo=False,
-                poolclass=NullPool if "sqlite" in db_url else None,
-            )
+            use_entra = _is_entra_auth_url(db_url)
+            engine_kwargs = {
+                "echo": False,
+            }
+
+            if "sqlite" in db_url:
+                engine_kwargs["poolclass"] = NullPool
+            elif use_entra:
+                # Recycle connections well before the token expires (60 min TTL).
+                # pool_pre_ping ensures stale connections are replaced.
+                engine_kwargs["pool_recycle"] = 1800
+                engine_kwargs["pool_pre_ping"] = True
+                engine_kwargs["pool_size"] = 10
+                engine_kwargs["max_overflow"] = 20
+
+            _engine = create_async_engine(db_url, **engine_kwargs)
+
+            if use_entra:
+                _entra_credential = _get_entra_credential()
+                _attach_entra_token_hook(_engine, _entra_credential)
+                logger.info("Database engine configured with Entra token auth")
+
         except Exception:
             return None
     return _engine
+
+
+def _attach_entra_token_hook(engine, credential):
+    """Attach an event listener that injects a fresh Entra token on every new
+    DBAPI connection.  This runs on the *sync* engine that backs the async one.
+    """
+    from sqlalchemy import event
+
+    @event.listens_for(engine.sync_engine, "do_connect")
+    def _inject_token(dialect, conn_rec, cargs, cparams):
+        token_obj = credential.get_token("https://database.windows.net/.default")
+        cparams["attrs_before"] = {
+            SQL_COPT_SS_ACCESS_TOKEN: _pack_token_for_odbc(token_obj.token)
+        }
 
 
 def get_session_factory():
@@ -73,15 +152,16 @@ async def get_db() -> AsyncSession:
 async def init_db():
     """Initialize database — run Alembic migrations to create/update schema."""
     import asyncio
-    import logging
-    logger = logging.getLogger(__name__)
     engine = get_engine()
     if engine is None:
         return
-    # For MSSQL, create the database if it doesn't exist
     db_url = get_database_url()
-    if "mssql" in db_url and "aioodbc" in db_url:
+
+    # For MSSQL with SQL-auth credentials, ensure the database exists.
+    # With Entra auth the database is created by the Bicep template, so skip.
+    if "mssql" in db_url and "aioodbc" in db_url and not _is_entra_auth_url(db_url):
         await _ensure_mssql_database(db_url)
+
     # Run Alembic migrations with retry logic for slow-starting databases
     max_retries = 3
     for attempt in range(1, max_retries + 1):
@@ -130,12 +210,14 @@ def _do_upgrade(alembic_cfg, connection):
 
 
 async def _ensure_mssql_database(db_url: str):
-    """Create the MSSQL database if it doesn't exist, with retries."""
+    """Create the MSSQL database if it doesn't exist, with retries.
+
+    Only used for SQL-auth connections. With Entra auth the database is
+    provisioned by the Bicep template.
+    """
     import asyncio
-    import logging
     from urllib.parse import unquote, urlparse
 
-    logger = logging.getLogger(__name__)
     parsed = urlparse(db_url)
     if not parsed.hostname or not parsed.username or not parsed.password or not parsed.path:
         return
@@ -191,8 +273,9 @@ async def _ensure_mssql_database(db_url: str):
 
 async def close_db():
     """Close database engine."""
-    global _engine, _session_factory
+    global _engine, _session_factory, _entra_credential
     if _engine:
         await _engine.dispose()
         _engine = None
         _session_factory = None
+        _entra_credential = None

--- a/backend/app/startup.py
+++ b/backend/app/startup.py
@@ -39,7 +39,20 @@ def validate_environment() -> dict:
             else "SQLite" if "sqlite" in settings.database_url
             else "Other"
         )
-        logger.info("✅ Database configured (%s)", db_type)
+        # Detect Entra-authenticated SQL connections (no credentials in URL)
+        entra_sql = "mssql" in settings.database_url and "://@" in settings.database_url
+        if entra_sql:
+            db_type = "MSSQL + Entra auth"
+            if settings.managed_identity_client_id:
+                logger.info(
+                    "✅ Database configured (%s, MI: %s…)",
+                    db_type,
+                    settings.managed_identity_client_id[:8],
+                )
+            else:
+                logger.info("✅ Database configured (%s, DefaultAzureCredential)", db_type)
+        else:
+            logger.info("✅ Database configured (%s)", db_type)
     else:
         warnings.append("Database not configured — data will not persist")
         logger.warning("⚠️  Database not configured — no data persistence")

--- a/backend/tests/test_db_session.py
+++ b/backend/tests/test_db_session.py
@@ -1,40 +1,184 @@
 """Tests for database session management."""
+import struct
+from unittest.mock import AsyncMock, MagicMock, patch
+
 import pytest
-from app.db.session import get_database_url, get_engine, get_session_factory
+
+import app.db.session as sess
+from app.db.session import (
+    SQL_COPT_SS_ACCESS_TOKEN,
+    _is_entra_auth_url,
+    _pack_token_for_odbc,
+    get_database_url,
+    get_engine,
+    get_session_factory,
+)
+
+
+# ── URL conversion ──────────────────────────────────────────────────
 
 def test_sqlite_url_conversion():
-    from unittest.mock import patch
     with patch("app.db.session.settings") as mock_settings:
         mock_settings.database_url = "sqlite:///test.db"
         url = get_database_url()
         assert url.startswith("sqlite+aiosqlite:///")
 
 def test_mssql_url_conversion():
-    from unittest.mock import patch
     with patch("app.db.session.settings") as mock_settings:
         mock_settings.database_url = "mssql+pyodbc://user:pass@host/db"
         url = get_database_url()
         assert url.startswith("mssql+aioodbc://")
 
 def test_empty_url():
-    from unittest.mock import patch
     with patch("app.db.session.settings") as mock_settings:
         mock_settings.database_url = ""
         url = get_database_url()
         assert url == ""
 
 def test_passthrough_url():
-    from unittest.mock import patch
     with patch("app.db.session.settings") as mock_settings:
         mock_settings.database_url = "postgresql+asyncpg://user:pass@host/db"
         url = get_database_url()
         assert url == "postgresql+asyncpg://user:pass@host/db"
 
 
+# ── Entra auth URL detection ────────────────────────────────────────
+
+def test_entra_auth_url_detected():
+    """Credential-free MSSQL URL is detected as Entra auth."""
+    assert _is_entra_auth_url("mssql+aioodbc://@server.database.windows.net/onramp") is True
+
+def test_entra_auth_url_with_query_params():
+    """Credential-free URL with driver params is still detected."""
+    url = "mssql+aioodbc://@server.database.windows.net/onramp?driver=ODBC+Driver+18"
+    assert _is_entra_auth_url(url) is True
+
+def test_sql_auth_url_not_entra():
+    """URL with user:pass is not Entra auth."""
+    assert _is_entra_auth_url("mssql+aioodbc://user:pass@host/db") is False
+
+def test_sqlite_url_not_entra():
+    """SQLite URL is never Entra auth."""
+    assert _is_entra_auth_url("sqlite+aiosqlite:///test.db") is False
+
+def test_empty_string_not_entra():
+    assert _is_entra_auth_url("") is False
+
+def test_postgresql_not_entra():
+    assert _is_entra_auth_url("postgresql+asyncpg://@host/db") is False
+
+
+# ── Token packing ───────────────────────────────────────────────────
+
+def test_pack_token_for_odbc_format():
+    """Token is packed as little-endian uint32 length + UTF-16-LE payload."""
+    token = "test-token-abc"
+    result = _pack_token_for_odbc(token)
+
+    raw = token.encode("utf-16-le")
+    expected_length = len(raw)
+    # First 4 bytes = little-endian uint32 length
+    length_prefix = struct.unpack("<I", result[:4])[0]
+    assert length_prefix == expected_length
+    # Remaining bytes = UTF-16-LE encoded token
+    assert result[4:] == raw
+
+def test_pack_token_roundtrip():
+    """Packed token can be unpacked back to the original string."""
+    token = "eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiJ9.example"
+    packed = _pack_token_for_odbc(token)
+    length = struct.unpack("<I", packed[:4])[0]
+    recovered = packed[4:4 + length].decode("utf-16-le")
+    assert recovered == token
+
+def test_pack_token_empty_string():
+    """Empty token produces zero-length prefix."""
+    packed = _pack_token_for_odbc("")
+    length = struct.unpack("<I", packed[:4])[0]
+    assert length == 0
+
+
+# ── _get_entra_credential ───────────────────────────────────────────
+
+def test_get_entra_credential_with_client_id():
+    """When managed_identity_client_id is set, uses ManagedIdentityCredential."""
+    mock_mi_cred = MagicMock()
+    with patch("app.db.session.settings") as mock_settings, \
+         patch.dict("sys.modules", {"azure": MagicMock(), "azure.identity": MagicMock()}), \
+         patch("azure.identity.ManagedIdentityCredential", return_value=mock_mi_cred):
+        mock_settings.managed_identity_client_id = "abc-123-def"
+        from app.db.session import _get_entra_credential
+        cred = _get_entra_credential()
+        assert cred is not None
+
+def test_get_entra_credential_without_client_id():
+    """When no client_id, falls back to DefaultAzureCredential."""
+    mock_dac = MagicMock()
+    with patch("app.db.session.settings") as mock_settings, \
+         patch.dict("sys.modules", {"azure": MagicMock(), "azure.identity": MagicMock()}), \
+         patch("azure.identity.DefaultAzureCredential", return_value=mock_dac):
+        mock_settings.managed_identity_client_id = ""
+        from app.db.session import _get_entra_credential
+        cred = _get_entra_credential()
+        assert cred is not None
+
+
+# ── _attach_entra_token_hook ────────────────────────────────────────
+
+def test_attach_entra_token_hook_registers_event():
+    """The hook registers a do_connect listener on the sync engine."""
+    mock_engine = MagicMock()
+    mock_credential = MagicMock()
+    with patch("sqlalchemy.event.listens_for") as mock_listens_for:
+        mock_listens_for.return_value = lambda fn: fn
+        from app.db.session import _attach_entra_token_hook
+        _attach_entra_token_hook(mock_engine, mock_credential)
+        mock_listens_for.assert_called_once_with(
+            mock_engine.sync_engine, "do_connect"
+        )
+
+
+def test_entra_token_hook_injects_token():
+    """The registered do_connect callback injects a token via attrs_before."""
+    mock_token = MagicMock()
+    mock_token.token = "fake-sql-token"
+    mock_credential = MagicMock()
+    mock_credential.get_token.return_value = mock_token
+    mock_engine = MagicMock()
+
+    captured_listener = None
+
+    def fake_listens_for(target, event_name):
+        def decorator(fn):
+            nonlocal captured_listener
+            captured_listener = fn
+            return fn
+        return decorator
+
+    with patch("sqlalchemy.event") as mock_event:
+        mock_event.listens_for = fake_listens_for
+        from app.db.session import _attach_entra_token_hook
+        _attach_entra_token_hook(mock_engine, mock_credential)
+
+    assert captured_listener is not None
+
+    cparams = {}
+    captured_listener(None, None, [], cparams)
+
+    mock_credential.get_token.assert_called_once_with(
+        "https://database.windows.net/.default"
+    )
+    assert SQL_COPT_SS_ACCESS_TOKEN in cparams["attrs_before"]
+    packed = cparams["attrs_before"][SQL_COPT_SS_ACCESS_TOKEN]
+    length = struct.unpack("<I", packed[:4])[0]
+    recovered = packed[4:4 + length].decode("utf-16-le")
+    assert recovered == "fake-sql-token"
+
+
+# ── get_engine with Entra auth ──────────────────────────────────────
+
 def test_engine_returns_none_for_empty_url():
     """Engine returns None when no database URL is configured."""
-    from unittest.mock import patch
-    import app.db.session as sess
     old_engine = sess._engine
     sess._engine = None
     try:
@@ -45,10 +189,77 @@ def test_engine_returns_none_for_empty_url():
         sess._engine = old_engine
 
 
+def test_engine_entra_attaches_hook():
+    """For Entra auth URLs, engine creation attaches the token hook."""
+    old_engine = sess._engine
+    old_cred = sess._entra_credential
+    sess._engine = None
+    sess._entra_credential = None
+    try:
+        entra_url = "mssql+aioodbc://@server.database.windows.net/onramp"
+        mock_cred = MagicMock()
+        with patch("app.db.session.get_database_url", return_value=entra_url), \
+             patch("app.db.session.create_async_engine") as mock_create, \
+             patch("app.db.session._get_entra_credential", return_value=mock_cred), \
+             patch("app.db.session._attach_entra_token_hook") as mock_attach:
+            mock_create.return_value = MagicMock()
+            engine = get_engine()
+            assert engine is not None
+            mock_attach.assert_called_once_with(engine, mock_cred)
+            assert sess._entra_credential is mock_cred
+    finally:
+        sess._engine = old_engine
+        sess._entra_credential = old_cred
+
+
+def test_engine_entra_uses_pool_recycle():
+    """Entra auth engines use pool_recycle, not NullPool."""
+    old_engine = sess._engine
+    old_cred = sess._entra_credential
+    sess._engine = None
+    sess._entra_credential = None
+    try:
+        entra_url = "mssql+aioodbc://@server.database.windows.net/onramp"
+        with patch("app.db.session.get_database_url", return_value=entra_url), \
+             patch("app.db.session.create_async_engine") as mock_create, \
+             patch("app.db.session._get_entra_credential", return_value=MagicMock()), \
+             patch("app.db.session._attach_entra_token_hook"):
+            mock_create.return_value = MagicMock()
+            get_engine()
+            call_kwargs = mock_create.call_args[1]
+            assert call_kwargs["pool_recycle"] == 1800
+            assert call_kwargs["pool_pre_ping"] is True
+            assert "poolclass" not in call_kwargs
+    finally:
+        sess._engine = old_engine
+        sess._entra_credential = old_cred
+
+
+def test_engine_sqlite_uses_null_pool():
+    """SQLite engines still use NullPool (not Entra pooling)."""
+    from sqlalchemy.pool import NullPool
+    old_engine = sess._engine
+    old_cred = sess._entra_credential
+    sess._engine = None
+    sess._entra_credential = None
+    try:
+        sqlite_url = "sqlite+aiosqlite:///test.db"
+        with patch("app.db.session.get_database_url", return_value=sqlite_url), \
+             patch("app.db.session.create_async_engine") as mock_create:
+            mock_create.return_value = MagicMock()
+            get_engine()
+            call_kwargs = mock_create.call_args[1]
+            assert call_kwargs["poolclass"] is NullPool
+            assert "pool_recycle" not in call_kwargs
+    finally:
+        sess._engine = old_engine
+        sess._entra_credential = old_cred
+
+
+# ── Session factory / get_db ────────────────────────────────────────
+
 def test_session_factory_returns_none_without_engine():
     """Session factory returns None when engine is None."""
-    from unittest.mock import patch
-    import app.db.session as sess
     old_factory = sess._session_factory
     sess._session_factory = None
     try:
@@ -59,11 +270,9 @@ def test_session_factory_returns_none_without_engine():
         sess._session_factory = old_factory
 
 
-
 @pytest.mark.asyncio
 async def test_get_db_yields_none_without_factory():
     """get_db yields None when no session factory is available."""
-    from unittest.mock import patch
     from app.db.session import get_db
     with patch("app.db.session.get_session_factory", return_value=None):
         gen = get_db()
@@ -71,19 +280,59 @@ async def test_get_db_yields_none_without_factory():
         assert result is None
 
 
+# ── close_db resets Entra credential ────────────────────────────────
+
 @pytest.mark.asyncio
 async def test_close_db_resets_globals():
-    """close_db resets engine and session factory."""
+    """close_db resets engine, session factory, and Entra credential."""
     from app.db.session import close_db
-    import app.db.session as sess
     old_engine = sess._engine
     old_factory = sess._session_factory
-    sess._engine = None
+    old_cred = sess._entra_credential
+    mock_engine = MagicMock()
+    mock_engine.dispose = AsyncMock()
+    sess._engine = mock_engine
     sess._session_factory = None
+    sess._entra_credential = MagicMock()
     try:
         await close_db()
+        mock_engine.dispose.assert_awaited_once()
         assert sess._engine is None
         assert sess._session_factory is None
+        assert sess._entra_credential is None
     finally:
         sess._engine = old_engine
         sess._session_factory = old_factory
+        sess._entra_credential = old_cred
+
+
+# ── init_db skips _ensure_mssql_database for Entra auth ─────────────
+
+@pytest.mark.asyncio
+async def test_init_db_skips_ensure_mssql_for_entra():
+    """init_db does not call _ensure_mssql_database for Entra auth URLs."""
+    entra_url = "mssql+aioodbc://@server.database.windows.net/onramp"
+    with patch("app.db.session.get_engine") as mock_get_engine, \
+         patch("app.db.session.get_database_url", return_value=entra_url), \
+         patch("app.db.session._is_entra_auth_url", return_value=True), \
+         patch("app.db.session._ensure_mssql_database") as mock_ensure, \
+         patch("app.db.session._run_migrations", return_value=None):
+        mock_get_engine.return_value = MagicMock()
+        from app.db.session import init_db
+        await init_db()
+        mock_ensure.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_init_db_calls_ensure_mssql_for_sql_auth():
+    """init_db calls _ensure_mssql_database for SQL-auth MSSQL URLs."""
+    sql_auth_url = "mssql+aioodbc://user:pass@host/db"
+    with patch("app.db.session.get_engine") as mock_get_engine, \
+         patch("app.db.session.get_database_url", return_value=sql_auth_url), \
+         patch("app.db.session._is_entra_auth_url", return_value=False), \
+         patch("app.db.session._ensure_mssql_database") as mock_ensure, \
+         patch("app.db.session._run_migrations", return_value=None):
+        mock_get_engine.return_value = MagicMock()
+        from app.db.session import init_db
+        await init_db()
+        mock_ensure.assert_called_once_with(sql_auth_url)

--- a/backend/tests/test_startup.py
+++ b/backend/tests/test_startup.py
@@ -40,6 +40,45 @@ def test_validate_environment_with_database():
         assert result["database"] == "configured"
 
 
+def test_validate_environment_mssql_entra_auth_with_mi():
+    """Entra-authenticated MSSQL URL logs MI client ID."""
+    with patch("app.startup.settings") as mock_settings:
+        mock_settings.azure_tenant_id = ""
+        mock_settings.azure_client_id = ""
+        mock_settings.ai_foundry_endpoint = ""
+        mock_settings.database_url = "mssql+aioodbc://@server.database.windows.net/onramp"
+        mock_settings.managed_identity_client_id = "abcd1234-ef56-7890-abcd-ef1234567890"
+        mock_settings.cors_origins = ["http://localhost:5173"]
+        result = validate_environment()
+        assert result["database"] == "configured"
+
+
+def test_validate_environment_mssql_entra_auth_without_mi():
+    """Entra-authenticated MSSQL URL without MI falls back to DefaultAzureCredential."""
+    with patch("app.startup.settings") as mock_settings:
+        mock_settings.azure_tenant_id = ""
+        mock_settings.azure_client_id = ""
+        mock_settings.ai_foundry_endpoint = ""
+        mock_settings.database_url = "mssql+aioodbc://@server.database.windows.net/onramp"
+        mock_settings.managed_identity_client_id = ""
+        mock_settings.cors_origins = ["http://localhost:5173"]
+        result = validate_environment()
+        assert result["database"] == "configured"
+
+
+def test_validate_environment_mssql_sql_auth():
+    """Standard MSSQL URL with credentials is not Entra auth."""
+    with patch("app.startup.settings") as mock_settings:
+        mock_settings.azure_tenant_id = "tenant-1234-abcd"
+        mock_settings.azure_client_id = "client-1234"
+        mock_settings.ai_foundry_endpoint = "https://ai.example.com"
+        mock_settings.database_url = "mssql+aioodbc://user:pass@server/db"
+        mock_settings.cors_origins = ["https://app.example.com"]
+        result = validate_environment()
+        assert result["mode"] == "production"
+        assert result["database"] == "configured"
+
+
 def test_validate_environment_production_mode():
     """When Entra ID is configured, runs in production mode."""
     with patch("app.startup.settings") as mock_settings:

--- a/infra/azuredeploy.json
+++ b/infra/azuredeploy.json
@@ -19,12 +19,6 @@
         "description": "Azure region for resources"
       }
     },
-    "sqlAdminPassword": {
-      "type": "securestring",
-      "metadata": {
-        "description": "SQL Server admin password (min 8 chars, must include uppercase, lowercase, number, and special character)"
-      }
-    },
     "createAppRegistration": {
       "type": "bool",
       "defaultValue": true,
@@ -49,7 +43,13 @@
     "ownerGroupObjectId": {
       "type": "string",
       "metadata": {
-        "description": "Object ID of the Entra ID group to assign Owner role on all deployed resources. Find this in Entra ID > Groups > your group > Object ID."
+        "description": "Object ID of the Entra ID group to assign Owner role on all deployed resources and SQL admin. Find this in Entra ID > Groups > your group > Object ID."
+      }
+    },
+    "ownerGroupDisplayName": {
+      "type": "string",
+      "metadata": {
+        "description": "Display name of the Entra ID group (used as the SQL Server Entra admin display name)."
       }
     }
   },
@@ -58,8 +58,10 @@
     "containerAppEnvName": "[concat(parameters('appName'), '-env-', variables('uniqueSuffix'))]",
     "logAnalyticsName": "[concat(parameters('appName'), '-logs-', variables('uniqueSuffix'))]",
     "sqlServerName": "[concat(parameters('appName'), '-sql-', variables('uniqueSuffix'))]",
+    "sqlDatabaseName": "onramp",
     "keyVaultName": "[concat(parameters('appName'), '-kv-', variables('uniqueSuffix'))]",
     "identityName": "[concat(parameters('appName'), '-identity-', variables('uniqueSuffix'))]",
+    "bootstrapIdentityName": "[concat(parameters('appName'), '-sqlbootstrap-', variables('uniqueSuffix'))]",
     "appUrl": "[concat('https://', parameters('appName'), '-', variables('uniqueSuffix'), '.', parameters('location'), '.azurecontainerapps.io')]"
   },
   "resources": [
@@ -68,6 +70,15 @@
       "apiVersion": "2023-01-31",
       "name": "[variables('identityName')]",
       "location": "[parameters('location')]"
+    },
+    {
+      "type": "Microsoft.ManagedIdentity/userAssignedIdentities",
+      "apiVersion": "2023-01-31",
+      "name": "[variables('bootstrapIdentityName')]",
+      "location": "[parameters('location')]",
+      "metadata": {
+        "description": "Bootstrap identity — temporary SQL admin used during deployment to create the app managed identity as a contained database user."
+      }
     },
     {
       "type": "Microsoft.Resources/deploymentScripts",
@@ -182,17 +193,6 @@
       }
     },
     {
-      "type": "Microsoft.KeyVault/vaults/secrets",
-      "apiVersion": "2023-07-01",
-      "name": "[concat(variables('keyVaultName'), '/sql-admin-password')]",
-      "dependsOn": [
-        "[resourceId('Microsoft.KeyVault/vaults', variables('keyVaultName'))]"
-      ],
-      "properties": {
-        "value": "[parameters('sqlAdminPassword')]"
-      }
-    },
-    {
       "type": "Microsoft.App/managedEnvironments",
       "apiVersion": "2023-05-01",
       "name": "[variables('containerAppEnvName')]",
@@ -212,19 +212,28 @@
     },
     {
       "type": "Microsoft.Sql/servers",
-      "apiVersion": "2023-05-01-preview",
+      "apiVersion": "2023-08-01-preview",
       "name": "[variables('sqlServerName')]",
       "location": "[parameters('location')]",
+      "dependsOn": [
+        "[resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', variables('bootstrapIdentityName'))]"
+      ],
       "properties": {
-        "administratorLogin": "onrampadmin",
-        "administratorLoginPassword": "[parameters('sqlAdminPassword')]",
-        "version": "12.0"
+        "minimalTlsVersion": "1.2",
+        "administrators": {
+          "administratorType": "ActiveDirectory",
+          "azureADOnlyAuthentication": true,
+          "login": "[variables('bootstrapIdentityName')]",
+          "sid": "[reference(resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', variables('bootstrapIdentityName'))).principalId]",
+          "tenantId": "[subscription().tenantId]",
+          "principalType": "Application"
+        }
       }
     },
     {
       "type": "Microsoft.Sql/servers/databases",
-      "apiVersion": "2023-05-01-preview",
-      "name": "[concat(variables('sqlServerName'), '/onramp')]",
+      "apiVersion": "2023-08-01-preview",
+      "name": "[concat(variables('sqlServerName'), '/', variables('sqlDatabaseName'))]",
       "location": "[parameters('location')]",
       "dependsOn": [
         "[resourceId('Microsoft.Sql/servers', variables('sqlServerName'))]"
@@ -232,6 +241,76 @@
       "sku": {
         "name": "Basic",
         "tier": "Basic"
+      }
+    },
+    {
+      "type": "Microsoft.Sql/servers/firewallRules",
+      "apiVersion": "2023-08-01-preview",
+      "name": "[concat(variables('sqlServerName'), '/AllowAzureServices')]",
+      "dependsOn": [
+        "[resourceId('Microsoft.Sql/servers', variables('sqlServerName'))]"
+      ],
+      "properties": {
+        "startIpAddress": "0.0.0.0",
+        "endIpAddress": "0.0.0.0"
+      }
+    },
+    {
+      "type": "Microsoft.Authorization/roleAssignments",
+      "apiVersion": "2022-04-01",
+      "name": "[guid(variables('sqlServerName'), variables('bootstrapIdentityName'), 'Contributor')]",
+      "dependsOn": [
+        "[resourceId('Microsoft.Sql/servers', variables('sqlServerName'))]",
+        "[resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', variables('bootstrapIdentityName'))]"
+      ],
+      "scope": "[concat('Microsoft.Sql/servers/', variables('sqlServerName'))]",
+      "properties": {
+        "roleDefinitionId": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'b24988ac-6180-42a0-ab88-20f7382dd24c')]",
+        "principalId": "[reference(resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', variables('bootstrapIdentityName'))).principalId]",
+        "principalType": "ServicePrincipal",
+        "description": "Temporary Contributor for SQL Entra bootstrap — allows switching SQL admin to the Entra group"
+      }
+    },
+    {
+      "type": "Microsoft.Resources/deploymentScripts",
+      "apiVersion": "2023-08-01",
+      "name": "setupSqlEntraUser",
+      "location": "[parameters('location')]",
+      "kind": "AzureCLI",
+      "dependsOn": [
+        "[resourceId('Microsoft.Sql/servers/databases', variables('sqlServerName'), variables('sqlDatabaseName'))]",
+        "[resourceId('Microsoft.Sql/servers/firewallRules', variables('sqlServerName'), 'AllowAzureServices')]",
+        "[resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', variables('identityName'))]",
+        "[guid(variables('sqlServerName'), variables('bootstrapIdentityName'), 'Contributor')]"
+      ],
+      "identity": {
+        "type": "UserAssigned",
+        "userAssignedIdentities": {
+          "[resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', variables('bootstrapIdentityName'))]": {}
+        }
+      },
+      "properties": {
+        "azCliVersion": "2.60.0",
+        "retentionInterval": "P1D",
+        "timeout": "PT15M",
+        "environmentVariables": [
+          {
+            "name": "SQL_SERVER_FQDN",
+            "value": "[reference(resourceId('Microsoft.Sql/servers', variables('sqlServerName'))).fullyQualifiedDomainName]"
+          },
+          { "name": "DATABASE_NAME", "value": "[variables('sqlDatabaseName')]" },
+          { "name": "SQL_SERVER_NAME", "value": "[variables('sqlServerName')]" },
+          { "name": "RESOURCE_GROUP", "value": "[resourceGroup().name]" },
+          { "name": "APP_IDENTITY_NAME", "value": "[variables('identityName')]" },
+          {
+            "name": "APP_IDENTITY_CLIENT_ID",
+            "value": "[reference(resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', variables('identityName'))).clientId]"
+          },
+          { "name": "ADMIN_GROUP_NAME", "value": "[parameters('ownerGroupDisplayName')]" },
+          { "name": "ADMIN_GROUP_OID", "value": "[parameters('ownerGroupObjectId')]" }
+        ],
+        "scriptContent": "#!/bin/bash\nset -euo pipefail\necho '=== OnRamp SQL Entra Auth Setup ==='\necho \"Server: $SQL_SERVER_FQDN\"\necho \"Database: $DATABASE_NAME\"\necho \"App identity: $APP_IDENTITY_NAME ($APP_IDENTITY_CLIENT_ID)\"\necho \"Admin group: $ADMIN_GROUP_NAME ($ADMIN_GROUP_OID)\"\n\n# Install ODBC driver and pyodbc\napt-get update -qq\ncurl -fsSL https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor -o /usr/share/keyrings/microsoft-prod.gpg\necho 'deb [arch=amd64 signed-by=/usr/share/keyrings/microsoft-prod.gpg] https://packages.microsoft.com/debian/12/prod bookworm main' > /etc/apt/sources.list.d/mssql-release.list\napt-get update -qq\nACCEPT_EULA=Y apt-get install -y -qq msodbcsql18 unixodbc-dev > /dev/null 2>&1\npip install -q pyodbc\n\nexport TOKEN=$(az account get-access-token --resource https://database.windows.net --query accessToken -o tsv)\n\npython3 << 'PYEOF'\nimport os, struct, sys, pyodbc\ntoken = os.environ['TOKEN']\nserver = os.environ['SQL_SERVER_FQDN']\ndatabase = os.environ['DATABASE_NAME']\nidentity_name = os.environ['APP_IDENTITY_NAME']\nidentity_client_id = os.environ['APP_IDENTITY_CLIENT_ID']\ntoken_bytes = token.encode('utf-16-le')\ntoken_struct = struct.pack(f'<I{len(token_bytes)}s', len(token_bytes), token_bytes)\nconn_str = f'Driver={{ODBC Driver 18 for SQL Server}};Server=tcp:{server},1433;Database={database};Encrypt=yes;TrustServerCertificate=no'\nconn = pyodbc.connect(conn_str, attrs_before={1256: token_struct})\ncursor = conn.cursor()\nsql = f\"\"\"\nIF NOT EXISTS (SELECT 1 FROM sys.database_principals WHERE name = N'{identity_name}')\nBEGIN\n    DECLARE @sid VARBINARY(16) = CAST(CAST('{identity_client_id}' AS UNIQUEIDENTIFIER) AS VARBINARY(16));\n    DECLARE @sql NVARCHAR(MAX) = N'CREATE USER [{identity_name}] WITH SID = ' + '0x' + CONVERT(VARCHAR(MAX), @sid, 2) + ', TYPE = E';\n    EXEC sp_executesql @sql;\n    PRINT 'Created user [{identity_name}]';\nEND\nELSE\n    PRINT 'User [{identity_name}] already exists';\n\"\"\"\ncursor.execute(sql)\nconn.commit()\nfor role in ('db_datareader', 'db_datawriter', 'db_ddladmin'):\n    cursor.execute(f'ALTER ROLE {role} ADD MEMBER [{identity_name}]')\n    print(f'  Granted {role}')\nconn.commit()\ncursor.close()\nconn.close()\nprint('Database user setup complete.')\nPYEOF\n\naz sql server ad-admin create --server-name \"$SQL_SERVER_NAME\" --resource-group \"$RESOURCE_GROUP\" --display-name \"$ADMIN_GROUP_NAME\" --object-id \"$ADMIN_GROUP_OID\" --output none\necho '=== SQL Entra auth setup complete ==='",
+        "cleanupPreference": "OnSuccess"
       }
     },
     {

--- a/infra/azuredeploy.json
+++ b/infra/azuredeploy.json
@@ -87,7 +87,9 @@
       "location": "[parameters('location')]",
       "kind": "AzureCLI",
       "dependsOn": [
-        "[resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', variables('identityName'))]"
+        "[resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', variables('identityName'))]",
+        "[resourceId('Microsoft.KeyVault/vaults', variables('keyVaultName'))]",
+        "[guid(variables('keyVaultName'), variables('identityName'), 'KVSecretsOfficer')]"
       ],
       "identity": {
         "type": "UserAssigned",
@@ -117,11 +119,19 @@
             "value": "[parameters('existingClientId')]"
           },
           {
+            "name": "EXISTING_CLIENT_SECRET",
+            "secureValue": "[parameters('existingClientSecret')]"
+          },
+          {
             "name": "OWNER_GROUP_OBJECT_ID",
             "value": "[parameters('ownerGroupObjectId')]"
+          },
+          {
+            "name": "KV_NAME",
+            "value": "[variables('keyVaultName')]"
           }
         ],
-        "scriptContent": "#!/bin/bash\nset -e\n\necho '=== OnRamp App Registration Setup ==='\necho \"Create New: $CREATE_APP\"\n\nSUBSCRIPTION_ID=$(az account show --query id -o tsv)\n\nif [ \"$CREATE_APP\" = \"false\" ] && [ -n \"$EXISTING_CLIENT_ID\" ]; then\n    echo \"Using existing app registration: $EXISTING_CLIENT_ID\"\n    CLIENT_ID=\"$EXISTING_CLIENT_ID\"\nelse\n    echo 'Creating new app registration...'\n    APP_INFO=$(az ad app create \\\n        --display-name \"$APP_NAME\" \\\n        --sign-in-audience AzureADMyOrg \\\n        --web-redirect-uris \"$REDIRECT_URI\" \"${REDIRECT_URI}/auth/callback\" \"http://localhost:5173\" \"http://localhost:5173/auth/callback\" \\\n        --enable-id-token-issuance true \\\n        --enable-access-token-issuance true \\\n        -o json)\n    CLIENT_ID=$(echo \"$APP_INFO\" | jq -r '.appId')\n    APP_OBJECT_ID=$(echo \"$APP_INFO\" | jq -r '.id')\n    SP_INFO=$(az ad sp create --id \"$CLIENT_ID\" -o json 2>/dev/null) || SP_INFO=$(az ad sp show --id \"$CLIENT_ID\" -o json 2>/dev/null) || true\n    SP_OBJECT_ID=$(echo \"$SP_INFO\" | jq -r '.id // empty')\n    if [ -n \"$SP_OBJECT_ID\" ]; then\n        az role assignment create --assignee-object-id \"$SP_OBJECT_ID\" --assignee-principal-type ServicePrincipal --role Contributor --scope \"/subscriptions/$SUBSCRIPTION_ID\" 2>/dev/null || true\n        az role assignment create --assignee-object-id \"$SP_OBJECT_ID\" --assignee-principal-type ServicePrincipal --role 'User Access Administrator' --scope \"/subscriptions/$SUBSCRIPTION_ID\" 2>/dev/null || true\n        echo 'Assigned Contributor and User Access Administrator roles'\n    fi\n    az ad app permission add --id \"$CLIENT_ID\" --api 00000003-0000-0000-c000-000000000000 --api-permissions e1fe6dd8-ba31-4d61-89e7-88639da4683d=Scope 2>/dev/null || true\n    az ad app permission add --id \"$CLIENT_ID\" --api 797f4846-ba00-4fd7-ba43-dac1f8f63013 --api-permissions 41094075-9dad-400e-a0bd-54e686782033=Scope 2>/dev/null || true\n    SECRET_INFO=$(az ad app credential reset --id \"$CLIENT_ID\" --display-name 'OnRamp Deployment' --years 2 -o json)\n    CLIENT_SECRET=$(echo \"$SECRET_INFO\" | jq -r '.password')\n    echo \"Created app registration: $CLIENT_ID\"\nfi\n\nTENANT_ID=$(az account show --query tenantId -o tsv)\n\necho \"{\\\"clientId\\\": \\\"$CLIENT_ID\\\", \\\"tenantId\\\": \\\"$TENANT_ID\\\", \\\"clientSecret\\\": \\\"${CLIENT_SECRET:-}\\\"}\" > $AZ_SCRIPTS_OUTPUT_DIRECTORY/result.json",
+        "scriptContent": "#!/bin/bash\nset -e\n\necho '=== OnRamp App Registration Setup ==='\necho \"Create New: $CREATE_APP\"\n\nSUBSCRIPTION_ID=$(az account show --query id -o tsv)\n\nif [ \"$CREATE_APP\" = \"false\" ] && [ -n \"$EXISTING_CLIENT_ID\" ]; then\n    echo \"Using existing app registration: $EXISTING_CLIENT_ID\"\n    CLIENT_ID=\"$EXISTING_CLIENT_ID\"\n    if [ -n \"$EXISTING_CLIENT_SECRET\" ]; then\n        az keyvault secret set --vault-name \"$KV_NAME\" --name entra-client-secret --value \"$EXISTING_CLIENT_SECRET\" --output none\n        echo 'Stored existing client secret in Key Vault'\n    fi\nelse\n    echo 'Creating new app registration...'\n    APP_INFO=$(az ad app create \\\n        --display-name \"$APP_NAME\" \\\n        --sign-in-audience AzureADMyOrg \\\n        --web-redirect-uris \"$REDIRECT_URI\" \"${REDIRECT_URI}/auth/callback\" \"http://localhost:5173\" \"http://localhost:5173/auth/callback\" \\\n        --enable-id-token-issuance true \\\n        --enable-access-token-issuance false \\\n        -o json)\n    CLIENT_ID=$(echo \"$APP_INFO\" | jq -r '.appId')\n    APP_OBJECT_ID=$(echo \"$APP_INFO\" | jq -r '.id')\n    SP_INFO=$(az ad sp create --id \"$CLIENT_ID\" -o json 2>/dev/null) || SP_INFO=$(az ad sp show --id \"$CLIENT_ID\" -o json 2>/dev/null) || true\n    SP_OBJECT_ID=$(echo \"$SP_INFO\" | jq -r '.id // empty')\n    if [ -n \"$SP_OBJECT_ID\" ]; then\n        az role assignment create --assignee-object-id \"$SP_OBJECT_ID\" --assignee-principal-type ServicePrincipal --role Contributor --scope \"/subscriptions/$SUBSCRIPTION_ID\" 2>/dev/null || true\n        az role assignment create --assignee-object-id \"$SP_OBJECT_ID\" --assignee-principal-type ServicePrincipal --role 'User Access Administrator' --scope \"/subscriptions/$SUBSCRIPTION_ID\" 2>/dev/null || true\n        echo 'Assigned Contributor and User Access Administrator roles'\n    fi\n    az ad app permission add --id \"$CLIENT_ID\" --api 00000003-0000-0000-c000-000000000000 --api-permissions e1fe6dd8-ba31-4d61-89e7-88639da4683d=Scope 2>/dev/null || true\n    az ad app permission add --id \"$CLIENT_ID\" --api 797f4846-ba00-4fd7-ba43-dac1f8f63013 --api-permissions 41094075-9dad-400e-a0bd-54e686782033=Scope 2>/dev/null || true\n    SECRET_INFO=$(az ad app credential reset --id \"$CLIENT_ID\" --display-name 'OnRamp Deployment' --years 2 -o json)\n    CLIENT_SECRET=$(echo \"$SECRET_INFO\" | jq -r '.password')\n    az keyvault secret set --vault-name \"$KV_NAME\" --name entra-client-secret --value \"$CLIENT_SECRET\" --output none\n    echo 'Stored client secret directly in Key Vault'\n    echo \"Created app registration: $CLIENT_ID\"\nfi\n\nTENANT_ID=$(az account show --query tenantId -o tsv)\n\necho \"{\\\"clientId\\\": \\\"$CLIENT_ID\\\", \\\"tenantId\\\": \\\"$TENANT_ID\\\"}\" > $AZ_SCRIPTS_OUTPUT_DIRECTORY/result.json",
         "cleanupPreference": "OnSuccess"
       }
     },
@@ -157,6 +167,22 @@
       }
     },
     {
+      "type": "Microsoft.Authorization/roleAssignments",
+      "apiVersion": "2022-04-01",
+      "name": "[guid(variables('keyVaultName'), variables('identityName'), 'KVSecretsOfficer')]",
+      "dependsOn": [
+        "[resourceId('Microsoft.KeyVault/vaults', variables('keyVaultName'))]",
+        "[resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', variables('identityName'))]"
+      ],
+      "scope": "[concat('Microsoft.KeyVault/vaults/', variables('keyVaultName'))]",
+      "properties": {
+        "roleDefinitionId": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'b86a8fe4-44ce-4948-aee5-eccb2c155cd7')]",
+        "principalId": "[reference(resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', variables('identityName'))).principalId]",
+        "principalType": "ServicePrincipal",
+        "description": "Allow deployment script identity to write secrets to Key Vault"
+      }
+    },
+    {
       "type": "Microsoft.KeyVault/vaults/secrets",
       "apiVersion": "2023-07-01",
       "name": "[concat(variables('keyVaultName'), '/entra-client-id')]",
@@ -166,18 +192,6 @@
       ],
       "properties": {
         "value": "[if(parameters('createAppRegistration'), reference('setupAppRegistration').outputs.clientId, parameters('existingClientId'))]"
-      }
-    },
-    {
-      "type": "Microsoft.KeyVault/vaults/secrets",
-      "apiVersion": "2023-07-01",
-      "name": "[concat(variables('keyVaultName'), '/entra-client-secret')]",
-      "dependsOn": [
-        "[resourceId('Microsoft.KeyVault/vaults', variables('keyVaultName'))]",
-        "setupAppRegistration"
-      ],
-      "properties": {
-        "value": "[if(parameters('createAppRegistration'), reference('setupAppRegistration').outputs.clientSecret, parameters('existingClientSecret'))]"
       }
     },
     {
@@ -309,7 +323,7 @@
           { "name": "ADMIN_GROUP_NAME", "value": "[parameters('ownerGroupDisplayName')]" },
           { "name": "ADMIN_GROUP_OID", "value": "[parameters('ownerGroupObjectId')]" }
         ],
-        "scriptContent": "#!/bin/bash\nset -euo pipefail\necho '=== OnRamp SQL Entra Auth Setup ==='\necho \"Server: $SQL_SERVER_FQDN\"\necho \"Database: $DATABASE_NAME\"\necho \"App identity: $APP_IDENTITY_NAME ($APP_IDENTITY_CLIENT_ID)\"\necho \"Admin group: $ADMIN_GROUP_NAME ($ADMIN_GROUP_OID)\"\n\n# Install ODBC driver and pyodbc\napt-get update -qq\ncurl -fsSL https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor -o /usr/share/keyrings/microsoft-prod.gpg\necho 'deb [arch=amd64 signed-by=/usr/share/keyrings/microsoft-prod.gpg] https://packages.microsoft.com/debian/12/prod bookworm main' > /etc/apt/sources.list.d/mssql-release.list\napt-get update -qq\nACCEPT_EULA=Y apt-get install -y -qq msodbcsql18 unixodbc-dev > /dev/null 2>&1\npip install -q pyodbc\n\nexport TOKEN=$(az account get-access-token --resource https://database.windows.net --query accessToken -o tsv)\n\npython3 << 'PYEOF'\nimport os, struct, sys, pyodbc\ntoken = os.environ['TOKEN']\nserver = os.environ['SQL_SERVER_FQDN']\ndatabase = os.environ['DATABASE_NAME']\nidentity_name = os.environ['APP_IDENTITY_NAME']\nidentity_client_id = os.environ['APP_IDENTITY_CLIENT_ID']\ntoken_bytes = token.encode('utf-16-le')\ntoken_struct = struct.pack(f'<I{len(token_bytes)}s', len(token_bytes), token_bytes)\nconn_str = f'Driver={{ODBC Driver 18 for SQL Server}};Server=tcp:{server},1433;Database={database};Encrypt=yes;TrustServerCertificate=no'\nconn = pyodbc.connect(conn_str, attrs_before={1256: token_struct})\ncursor = conn.cursor()\nsql = f\"\"\"\nIF NOT EXISTS (SELECT 1 FROM sys.database_principals WHERE name = N'{identity_name}')\nBEGIN\n    DECLARE @sid VARBINARY(16) = CAST(CAST('{identity_client_id}' AS UNIQUEIDENTIFIER) AS VARBINARY(16));\n    DECLARE @sql NVARCHAR(MAX) = N'CREATE USER [{identity_name}] WITH SID = ' + '0x' + CONVERT(VARCHAR(MAX), @sid, 2) + ', TYPE = E';\n    EXEC sp_executesql @sql;\n    PRINT 'Created user [{identity_name}]';\nEND\nELSE\n    PRINT 'User [{identity_name}] already exists';\n\"\"\"\ncursor.execute(sql)\nconn.commit()\nfor role in ('db_datareader', 'db_datawriter', 'db_ddladmin'):\n    cursor.execute(f'ALTER ROLE {role} ADD MEMBER [{identity_name}]')\n    print(f'  Granted {role}')\nconn.commit()\ncursor.close()\nconn.close()\nprint('Database user setup complete.')\nPYEOF\n\naz sql server ad-admin create --server-name \"$SQL_SERVER_NAME\" --resource-group \"$RESOURCE_GROUP\" --display-name \"$ADMIN_GROUP_NAME\" --object-id \"$ADMIN_GROUP_OID\" --output none\necho '=== SQL Entra auth setup complete ==='",
+        "scriptContent": "#!/bin/bash\nset -euo pipefail\necho '=== OnRamp SQL Entra Auth Setup ==='\necho \"Server: $SQL_SERVER_FQDN\"\necho \"Database: $DATABASE_NAME\"\necho \"App identity: $APP_IDENTITY_NAME ($APP_IDENTITY_CLIENT_ID)\"\necho \"Admin group: $ADMIN_GROUP_NAME ($ADMIN_GROUP_OID)\"\n\n# Install ODBC driver and pyodbc\napt-get update -qq\ncurl -fsSL https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor -o /usr/share/keyrings/microsoft-prod.gpg\necho 'deb [arch=amd64 signed-by=/usr/share/keyrings/microsoft-prod.gpg] https://packages.microsoft.com/debian/12/prod bookworm main' > /etc/apt/sources.list.d/mssql-release.list\napt-get update -qq\nACCEPT_EULA=Y apt-get install -y -qq msodbcsql18 unixodbc-dev > /dev/null 2>&1\npip install -q pyodbc\n\nexport TOKEN=$(az account get-access-token --resource https://database.windows.net --query accessToken -o tsv)\n\npython3 << 'PYEOF'\nimport os, re, struct, sys, pyodbc\ntoken = os.environ['TOKEN']\nserver = os.environ['SQL_SERVER_FQDN']\ndatabase = os.environ['DATABASE_NAME']\nidentity_name = os.environ['APP_IDENTITY_NAME']\nidentity_client_id = os.environ['APP_IDENTITY_CLIENT_ID']\nif not re.match(r'^[a-zA-Z0-9_-]+$', identity_name):\n    print(f'ERROR: Invalid identity name: {identity_name}', file=sys.stderr)\n    sys.exit(1)\nif not re.match(r'^[0-9a-fA-F-]+$', identity_client_id):\n    print(f'ERROR: Invalid client ID: {identity_client_id}', file=sys.stderr)\n    sys.exit(1)\ntoken_bytes = token.encode('utf-16-le')\ntoken_struct = struct.pack(f'<I{len(token_bytes)}s', len(token_bytes), token_bytes)\nconn_str = f'Driver={{ODBC Driver 18 for SQL Server}};Server=tcp:{server},1433;Database={database};Encrypt=yes;TrustServerCertificate=no'\nconn = pyodbc.connect(conn_str, attrs_before={1256: token_struct})\ncursor = conn.cursor()\nsafe_name = identity_name.replace(']', ']]')\nsql = f\"\"\"\nIF NOT EXISTS (SELECT 1 FROM sys.database_principals WHERE name = N'{safe_name}')\nBEGIN\n    DECLARE @sid VARBINARY(16) = CAST(CAST('{identity_client_id}' AS UNIQUEIDENTIFIER) AS VARBINARY(16));\n    DECLARE @sql NVARCHAR(MAX) = N'CREATE USER [{safe_name}] WITH SID = ' + '0x' + CONVERT(VARCHAR(MAX), @sid, 2) + ', TYPE = E';\n    EXEC sp_executesql @sql;\n    PRINT 'Created user [{safe_name}]';\nEND\nELSE\n    PRINT 'User [{safe_name}] already exists';\n\"\"\"\ncursor.execute(sql)\nconn.commit()\nfor role in ('db_datareader', 'db_datawriter', 'db_ddladmin'):\n    cursor.execute(f'ALTER ROLE {role} ADD MEMBER [{safe_name}]')\n    print(f'  Granted {role}')\nconn.commit()\ncursor.close()\nconn.close()\nprint('Database user setup complete.')\nPYEOF\n\naz sql server ad-admin create --server-name \"$SQL_SERVER_NAME\" --resource-group \"$RESOURCE_GROUP\" --display-name \"$ADMIN_GROUP_NAME\" --object-id \"$ADMIN_GROUP_OID\" --output none\necho '=== SQL Entra auth setup complete ==='",
         "cleanupPreference": "OnSuccess"
       }
     },

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -10,13 +10,11 @@ param location string = 'eastus2'
 @description('Base name for resources')
 param baseName string = 'onramp'
 
-@description('SQL administrator login')
-@secure()
-param sqlAdminLogin string
+@description('Display name of the Entra ID group to set as SQL admin')
+param sqlAdminGroupName string
 
-@description('SQL administrator password')
-@secure()
-param sqlAdminPassword string
+@description('Object ID of the Entra ID group to set as SQL admin')
+param sqlAdminGroupObjectId string
 
 @description('Azure AI Foundry API key')
 @secure()
@@ -45,6 +43,20 @@ resource rg 'Microsoft.Resources/resourceGroups@2024-03-01' = {
   tags: tags
 }
 
+// User-assigned managed identity for the application — created at the top level
+// so it can be referenced by both the SQL module (for DB user setup) and the
+// Container Apps module (for runtime Key Vault / DB access).
+module appIdentity 'modules/identity.bicep' = {
+  scope: rg
+  name: 'app-identity'
+  params: {
+    location: location
+    baseName: baseName
+    environment: environment
+    tags: tags
+  }
+}
+
 // Deployment order: monitoring first, then sql/ai-foundry in parallel, then keyvault, then container-apps
 
 module monitoring 'modules/monitoring.bicep' = {
@@ -66,8 +78,10 @@ module sql 'modules/sql.bicep' = {
     location: location
     baseName: baseName
     environment: environment
-    sqlAdminLogin: sqlAdminLogin
-    sqlAdminPassword: sqlAdminPassword
+    entraAdminGroupName: sqlAdminGroupName
+    entraAdminGroupObjectId: sqlAdminGroupObjectId
+    appIdentityName: appIdentity.outputs.identityName
+    appIdentityClientId: appIdentity.outputs.identityClientId
     tags: tags
   }
 }
@@ -79,10 +93,6 @@ module keyVault 'modules/keyvault.bicep' = {
     location: location
     baseName: baseName
     environment: environment
-    sqlAdminPassword: sqlAdminPassword
-    sqlAdminLogin: sqlAdminLogin
-    sqlServerFqdn: sql.outputs.serverFqdn
-    sqlDatabaseName: sql.outputs.databaseName
     aiFoundryKey: aiFoundryKey
     clientSecret: clientSecret
     tags: tags
@@ -116,6 +126,11 @@ module containerApps 'modules/container-apps.bicep' = {
     azureClientId: azureClientId
     hasAiFoundryKey: !empty(aiFoundryKey)
     hasClientSecret: !empty(clientSecret)
+    managedIdentityId: appIdentity.outputs.identityResourceId
+    managedIdentityPrincipalId: appIdentity.outputs.identityPrincipalId
+    managedIdentityClientId: appIdentity.outputs.identityClientId
+    sqlServerFqdn: sql.outputs.serverFqdn
+    sqlDatabaseName: sql.outputs.databaseName
     tags: tags
   }
 }

--- a/infra/modules/container-apps.bicep
+++ b/infra/modules/container-apps.bicep
@@ -40,6 +40,21 @@ param frontendImage string = 'mcr.microsoft.com/azuredocs/containerapps-hellowor
 @description('Backend container image')
 param backendImage string = 'mcr.microsoft.com/azuredocs/containerapps-helloworld:latest'
 
+@description('Resource ID of the user-assigned managed identity')
+param managedIdentityId string
+
+@description('Principal (object) ID of the user-assigned managed identity')
+param managedIdentityPrincipalId string
+
+@description('Client (application) ID of the user-assigned managed identity')
+param managedIdentityClientId string
+
+@description('SQL Server FQDN for the database connection string')
+param sqlServerFqdn string
+
+@description('SQL database name')
+param sqlDatabaseName string
+
 @description('Resource tags')
 param tags object
 
@@ -52,7 +67,7 @@ var aiKeySecret = hasAiFoundryKey
       {
         name: 'ai-foundry-key'
         keyVaultUrl: '${keyVault.properties.vaultUri}secrets/ai-foundry-key'
-        identity: managedIdentity.id
+        identity: managedIdentityId
       }
     ]
   : []
@@ -61,13 +76,18 @@ var clientSecretKv = hasClientSecret
       {
         name: 'client-secret'
         keyVaultUrl: '${keyVault.properties.vaultUri}secrets/client-secret'
-        identity: managedIdentity.id
+        identity: managedIdentityId
       }
     ]
   : []
+
+// Credential-free connection string — Entra token auth is handled by the backend
+var databaseUrl = 'mssql+aioodbc://@${sqlServerFqdn}/${sqlDatabaseName}?driver=ODBC+Driver+18+for+SQL+Server&Encrypt=yes&TrustServerCertificate=no'
+
 // Build backend env vars conditionally
 var baseEnvVars = [
-  { name: 'ONRAMP_DATABASE_URL', secretRef: 'sql-connection-string' }
+  { name: 'ONRAMP_DATABASE_URL', value: databaseUrl }
+  { name: 'ONRAMP_MANAGED_IDENTITY_CLIENT_ID', value: managedIdentityClientId }
   { name: 'ONRAMP_AI_FOUNDRY_ENDPOINT', value: aiFoundryEndpoint }
   { name: 'ONRAMP_AI_FOUNDRY_MODEL', value: 'gpt-4o' }
   { name: 'APPLICATIONINSIGHTS_CONNECTION_STRING', value: appInsightsConnectionString }
@@ -104,15 +124,7 @@ var backendEnvVars = concat(
   clientSecretEnvVars
 )
 
-// Store full connection string as a secret (includes credentials)
-var sqlConnectionStringSecret = [
-  {
-    name: 'sql-connection-string'
-    keyVaultUrl: '${keyVault.properties.vaultUri}secrets/sql-connection-string'
-    identity: managedIdentity.id
-  }
-]
-var allBackendSecrets = concat(sqlConnectionStringSecret, aiKeySecret, clientSecretKv)
+var allBackendSecrets = concat(aiKeySecret, clientSecretKv)
 
 resource logAnalytics 'Microsoft.OperationalInsights/workspaces@2023-09-01' existing = {
   name: logAnalyticsName
@@ -122,19 +134,12 @@ resource keyVault 'Microsoft.KeyVault/vaults@2023-07-01' existing = {
   name: keyVaultName
 }
 
-// Managed identity for Key Vault access
-resource managedIdentity 'Microsoft.ManagedIdentity/userAssignedIdentities@2023-01-31' = {
-  name: 'id-${baseName}-${environment}'
-  location: location
-  tags: tags
-}
-
 // Key Vault Secrets User role assignment (role ID: 4633458b-17de-408a-b874-0445c86b69e6)
 resource kvRoleAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
-  name: guid(keyVault.id, managedIdentity.id, '4633458b-17de-408a-b874-0445c86b69e6')
+  name: guid(keyVault.id, managedIdentityId, '4633458b-17de-408a-b874-0445c86b69e6')
   scope: keyVault
   properties: {
-    principalId: managedIdentity.properties.principalId
+    principalId: managedIdentityPrincipalId
     roleDefinitionId: subscriptionResourceId(
       'Microsoft.Authorization/roleDefinitions',
       '4633458b-17de-408a-b874-0445c86b69e6'
@@ -165,7 +170,7 @@ resource frontendApp 'Microsoft.App/containerApps@2024-03-01' = {
   identity: {
     type: 'UserAssigned'
     userAssignedIdentities: {
-      '${managedIdentity.id}': {}
+      '${managedIdentityId}': {}
     }
   }
   properties: {
@@ -180,7 +185,7 @@ resource frontendApp 'Microsoft.App/containerApps@2024-03-01' = {
         ? [
             {
               server: containerRegistryServer
-              identity: managedIdentity.id
+              identity: managedIdentityId
             }
           ]
         : []
@@ -244,7 +249,7 @@ resource backendApp 'Microsoft.App/containerApps@2024-03-01' = {
   identity: {
     type: 'UserAssigned'
     userAssignedIdentities: {
-      '${managedIdentity.id}': {}
+      '${managedIdentityId}': {}
     }
   }
   properties: {
@@ -260,7 +265,7 @@ resource backendApp 'Microsoft.App/containerApps@2024-03-01' = {
         ? [
             {
               server: containerRegistryServer
-              identity: managedIdentity.id
+              identity: managedIdentityId
             }
           ]
         : []
@@ -328,4 +333,3 @@ resource backendApp 'Microsoft.App/containerApps@2024-03-01' = {
 output environmentId string = containerAppsEnv.id
 output frontendFqdn string = frontendApp.properties.configuration.ingress.fqdn
 output backendFqdn string = backendApp.properties.configuration.ingress.fqdn
-output managedIdentityPrincipalId string = managedIdentity.properties.principalId

--- a/infra/modules/identity.bicep
+++ b/infra/modules/identity.bicep
@@ -1,0 +1,29 @@
+@description('Azure region')
+param location string
+
+@description('Base name')
+param baseName string
+
+@description('Environment')
+param environment string
+
+@description('Resource tags')
+param tags object
+
+resource managedIdentity 'Microsoft.ManagedIdentity/userAssignedIdentities@2023-01-31' = {
+  name: 'id-${baseName}-${environment}'
+  location: location
+  tags: tags
+}
+
+@description('Display name of the managed identity')
+output identityName string = managedIdentity.name
+
+@description('Resource ID of the managed identity')
+output identityResourceId string = managedIdentity.id
+
+@description('Principal (object) ID of the managed identity')
+output identityPrincipalId string = managedIdentity.properties.principalId
+
+@description('Client (application) ID of the managed identity')
+output identityClientId string = managedIdentity.properties.clientId

--- a/infra/modules/keyvault.bicep
+++ b/infra/modules/keyvault.bicep
@@ -7,19 +7,6 @@ param baseName string
 @description('Environment')
 param environment string
 
-@description('SQL admin password to store as secret')
-@secure()
-param sqlAdminPassword string = ''
-
-@description('SQL admin login for connection string')
-param sqlAdminLogin string = 'onrampadmin'
-
-@description('SQL Server FQDN for connection string')
-param sqlServerFqdn string = ''
-
-@description('SQL Database name for connection string')
-param sqlDatabaseName string = ''
-
 @description('AI Foundry API key to store as secret')
 @secure()
 param aiFoundryKey string = ''
@@ -51,15 +38,6 @@ resource keyVault 'Microsoft.KeyVault/vaults@2023-07-01' = {
 }
 
 // Store secrets — only created when values are provided
-resource sqlPasswordSecret 'Microsoft.KeyVault/vaults/secrets@2023-07-01' = if (!empty(sqlAdminPassword)) {
-  parent: keyVault
-  name: 'sql-admin-password'
-  properties: {
-    value: sqlAdminPassword
-    contentType: 'text/plain'
-  }
-}
-
 resource aiKeySecret 'Microsoft.KeyVault/vaults/secrets@2023-07-01' = if (!empty(aiFoundryKey)) {
   parent: keyVault
   name: 'ai-foundry-key'
@@ -74,16 +52,6 @@ resource clientSecretSecret 'Microsoft.KeyVault/vaults/secrets@2023-07-01' = if 
   name: 'client-secret'
   properties: {
     value: clientSecret
-    contentType: 'text/plain'
-  }
-}
-
-// Full SQL connection string with credentials
-resource sqlConnectionStringSecret 'Microsoft.KeyVault/vaults/secrets@2023-07-01' = if (!empty(sqlAdminPassword) && !empty(sqlServerFqdn)) {
-  parent: keyVault
-  name: 'sql-connection-string'
-  properties: {
-    value: 'mssql+aioodbc://${sqlAdminLogin}:${sqlAdminPassword}@${sqlServerFqdn}/${sqlDatabaseName}?driver=ODBC+Driver+18+for+SQL+Server'
     contentType: 'text/plain'
   }
 }

--- a/infra/modules/sql.bicep
+++ b/infra/modules/sql.bicep
@@ -7,13 +7,17 @@ param baseName string
 @description('Environment')
 param environment string
 
-@description('SQL admin login')
-@secure()
-param sqlAdminLogin string
+@description('Entra ID admin group display name')
+param entraAdminGroupName string
 
-@description('SQL admin password')
-@secure()
-param sqlAdminPassword string
+@description('Entra ID admin group object ID')
+param entraAdminGroupObjectId string
+
+@description('Application managed identity display name')
+param appIdentityName string
+
+@description('Application managed identity client (application) ID')
+param appIdentityClientId string
 
 @description('Resource tags')
 param tags object
@@ -21,15 +25,33 @@ param tags object
 var serverName = 'sql-${baseName}-${environment}'
 var dbName = 'sqldb-${baseName}-${environment}'
 
+// Bootstrap identity — used only during deployment to set up the database user.
+// Kept separate from the app identity so the runtime app has least-privilege access.
+resource bootstrapIdentity 'Microsoft.ManagedIdentity/userAssignedIdentities@2023-01-31' = {
+  name: 'id-${baseName}-sqlbootstrap-${environment}'
+  location: location
+  tags: tags
+}
+
+// SQL Server with Entra-only authentication.
+// The bootstrap identity is the initial admin so the deployment script can create
+// the app identity's contained database user. After setup, admin is switched to
+// the Entra group.
 resource sqlServer 'Microsoft.Sql/servers@2023-08-01-preview' = {
   name: serverName
   location: location
   tags: tags
   properties: {
-    administratorLogin: sqlAdminLogin
-    administratorLoginPassword: sqlAdminPassword
     minimalTlsVersion: '1.2'
     publicNetworkAccess: 'Enabled'
+    administrators: {
+      administratorType: 'ActiveDirectory'
+      azureADOnlyAuthentication: true
+      login: bootstrapIdentity.name
+      sid: bootstrapIdentity.properties.principalId
+      tenantId: subscription().tenantId
+      principalType: 'Application'
+    }
   }
 }
 
@@ -54,6 +76,55 @@ resource firewallAllowAzure 'Microsoft.Sql/servers/firewallRules@2023-08-01-prev
   properties: {
     startIpAddress: '0.0.0.0'
     endIpAddress: '0.0.0.0'
+  }
+}
+
+// Grant the bootstrap identity Contributor on the SQL server so it can switch the
+// admin to the Entra group after creating the app database user.
+resource bootstrapContributor 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+  name: guid(sqlServer.id, bootstrapIdentity.id, 'b24988ac-6180-42a0-ab88-20f7382dd24c')
+  scope: sqlServer
+  properties: {
+    principalId: bootstrapIdentity.properties.principalId
+    roleDefinitionId: subscriptionResourceId(
+      'Microsoft.Authorization/roleDefinitions',
+      'b24988ac-6180-42a0-ab88-20f7382dd24c' // Contributor
+    )
+    principalType: 'ServicePrincipal'
+  }
+}
+
+// Deployment script: create contained database user for the app identity, then
+// hand SQL admin over to the Entra group. Uses SID-based user creation to avoid
+// needing Directory Readers on the SQL server.
+resource setupEntraDbUser 'Microsoft.Resources/deploymentScripts@2023-08-01' = {
+  name: 'setup-sql-entra-users-${environment}'
+  location: location
+  tags: tags
+  kind: 'AzureCLI'
+  identity: {
+    type: 'UserAssigned'
+    userAssignedIdentities: {
+      '${bootstrapIdentity.id}': {}
+    }
+  }
+  dependsOn: [sqlDatabase, firewallAllowAzure, bootstrapContributor]
+  properties: {
+    azCliVersion: '2.60.0'
+    retentionInterval: 'P1D'
+    timeout: 'PT15M'
+    environmentVariables: [
+      { name: 'SQL_SERVER_FQDN', value: sqlServer.properties.fullyQualifiedDomainName }
+      { name: 'DATABASE_NAME', value: dbName }
+      { name: 'SQL_SERVER_NAME', value: serverName }
+      { name: 'RESOURCE_GROUP', value: resourceGroup().name }
+      { name: 'APP_IDENTITY_NAME', value: appIdentityName }
+      { name: 'APP_IDENTITY_CLIENT_ID', value: appIdentityClientId }
+      { name: 'ADMIN_GROUP_NAME', value: entraAdminGroupName }
+      { name: 'ADMIN_GROUP_OID', value: entraAdminGroupObjectId }
+    ]
+    scriptContent: loadTextContent('../scripts/setup-sql-entra-user.sh')
+    cleanupPreference: 'OnSuccess'
   }
 }
 

--- a/infra/parameters/dev.bicepparam
+++ b/infra/parameters/dev.bicepparam
@@ -2,15 +2,15 @@ using '../main.bicep'
 
 // Development environment parameters
 // Deploy: az deployment sub create -l eastus2 -f infra/main.bicep -p infra/parameters/dev.bicepparam \
-//         -p sqlAdminPassword=<value>
+//         -p sqlAdminGroupName=<value> -p sqlAdminGroupObjectId=<value>
 // Secrets are passed as deployment parameters (never stored in this file).
 
 param environment = 'dev'
 param location = 'eastus2'
 param baseName = 'onramp'
-param sqlAdminLogin = 'onrampadmin'
 
 // Required — pass at deployment time:
-//   -p sqlAdminPassword=<value>
-//   -p aiFoundryKey=<value>      (optional for dev — mock AI used when empty)
-//   -p clientSecret=<value>      (optional for dev — mock auth used when empty)
+//   -p sqlAdminGroupName=<value>       (Entra ID group display name for SQL admin)
+//   -p sqlAdminGroupObjectId=<value>   (Entra ID group object ID for SQL admin)
+//   -p aiFoundryKey=<value>            (optional for dev — mock AI used when empty)
+//   -p clientSecret=<value>            (optional for dev — mock auth used when empty)

--- a/infra/parameters/prod.bicepparam
+++ b/infra/parameters/prod.bicepparam
@@ -2,16 +2,17 @@ using '../main.bicep'
 
 // Production environment parameters
 // Deploy: az deployment sub create -l eastus2 -f infra/main.bicep -p infra/parameters/prod.bicepparam \
-//         -p sqlAdminPassword=<value> -p aiFoundryKey=<value> -p clientSecret=<value>
+//         -p sqlAdminGroupName=<value> -p sqlAdminGroupObjectId=<value> \
+//         -p aiFoundryKey=<value> -p clientSecret=<value>
 // All secrets MUST be passed at deployment time — never store them in this file.
 // For CI/CD, use pipeline secrets or Key Vault references.
 
 param environment = 'prod'
 param location = 'eastus2'
 param baseName = 'onramp'
-param sqlAdminLogin = 'onrampadmin'
 
 // Required — pass at deployment time:
-//   -p sqlAdminPassword=<value>    (SQL admin password)
-//   -p aiFoundryKey=<value>        (Azure AI Foundry API key)
-//   -p clientSecret=<value>        (Entra ID client secret)
+//   -p sqlAdminGroupName=<value>       (Entra ID group display name for SQL admin)
+//   -p sqlAdminGroupObjectId=<value>   (Entra ID group object ID for SQL admin)
+//   -p aiFoundryKey=<value>            (Azure AI Foundry API key)
+//   -p clientSecret=<value>            (Entra ID client secret)

--- a/infra/scripts/setup-sql-entra-user.sh
+++ b/infra/scripts/setup-sql-entra-user.sh
@@ -36,12 +36,13 @@ pip install -q pyodbc
 
 # ── Step 2: Get access token for Azure SQL ──────────────────────────────────
 echo "Acquiring access token for Azure SQL..."
-TOKEN=$(az account get-access-token --resource https://database.windows.net --query accessToken -o tsv)
+export TOKEN=$(az account get-access-token --resource https://database.windows.net --query accessToken -o tsv)
 
 # ── Step 3: Create contained database user for app identity ─────────────────
 echo "Creating contained database user for app identity..."
 python3 << 'PYEOF'
 import os
+import re
 import struct
 import sys
 
@@ -56,6 +57,14 @@ server = os.environ["SQL_SERVER_FQDN"]
 database = os.environ["DATABASE_NAME"]
 identity_name = os.environ["APP_IDENTITY_NAME"]
 identity_client_id = os.environ["APP_IDENTITY_CLIENT_ID"]
+
+# Validate inputs to prevent SQL injection
+if not re.match(r'^[a-zA-Z0-9_-]+$', identity_name):
+    print(f"ERROR: Invalid identity name: {identity_name}", file=sys.stderr)
+    sys.exit(1)
+if not re.match(r'^[0-9a-fA-F-]+$', identity_client_id):
+    print(f"ERROR: Invalid client ID format: {identity_client_id}", file=sys.stderr)
+    sys.exit(1)
 
 # Pack the access token for ODBC SQL_COPT_SS_ACCESS_TOKEN (1256)
 token_bytes = token.encode("utf-16-le")
@@ -72,26 +81,29 @@ print(f"Connecting to {server}/{database}...")
 conn = pyodbc.connect(conn_str, attrs_before={1256: token_struct})
 cursor = conn.cursor()
 
+# Escape ] in identity name for bracket-quoted SQL identifiers
+safe_name = identity_name.replace("]", "]]")
+
 # Use SID-based user creation to avoid needing Directory Readers on the SQL server.
 # The SID is the binary representation of the managed identity's client (application) ID.
 sql = f"""
-IF NOT EXISTS (SELECT 1 FROM sys.database_principals WHERE name = N'{identity_name}')
+IF NOT EXISTS (SELECT 1 FROM sys.database_principals WHERE name = N'{safe_name}')
 BEGIN
     DECLARE @sid VARBINARY(16) = CAST(CAST('{identity_client_id}' AS UNIQUEIDENTIFIER) AS VARBINARY(16));
-    DECLARE @sql NVARCHAR(MAX) = N'CREATE USER [{identity_name}] WITH SID = '
+    DECLARE @sql NVARCHAR(MAX) = N'CREATE USER [{safe_name}] WITH SID = '
         + '0x' + CONVERT(VARCHAR(MAX), @sid, 2) + ', TYPE = E';
     EXEC sp_executesql @sql;
-    PRINT 'Created user [{identity_name}]';
+    PRINT 'Created user [{safe_name}]';
 END
 ELSE
-    PRINT 'User [{identity_name}] already exists';
+    PRINT 'User [{safe_name}] already exists';
 """
 cursor.execute(sql)
 conn.commit()
 
 # Grant database roles
 for role in ("db_datareader", "db_datawriter", "db_ddladmin"):
-    cursor.execute(f"ALTER ROLE {role} ADD MEMBER [{identity_name}]")
+    cursor.execute(f"ALTER ROLE {role} ADD MEMBER [{safe_name}]")
     print(f"  Granted {role}")
 conn.commit()
 
@@ -99,8 +111,6 @@ cursor.close()
 conn.close()
 print("Database user setup complete.")
 PYEOF
-
-export TOKEN  # make available to the Python heredoc
 
 # ── Step 4: Switch SQL admin to the Entra group ────────────────────────────
 echo "Switching SQL AD admin to Entra group: $ADMIN_GROUP_NAME..."

--- a/infra/scripts/setup-sql-entra-user.sh
+++ b/infra/scripts/setup-sql-entra-user.sh
@@ -1,0 +1,116 @@
+#!/bin/bash
+# setup-sql-entra-user.sh
+#
+# Called by the Bicep deployment script resource in sql.bicep.
+# Creates a contained database user for the application managed identity,
+# grants it the necessary roles, then switches the SQL AD admin to the
+# Entra group.
+#
+# Required environment variables (set by Bicep):
+#   SQL_SERVER_FQDN          — e.g. sql-onramp-dev.database.windows.net
+#   DATABASE_NAME            — e.g. sqldb-onramp-dev
+#   SQL_SERVER_NAME          — e.g. sql-onramp-dev
+#   RESOURCE_GROUP           — e.g. rg-onramp-dev
+#   APP_IDENTITY_NAME        — display name of the app managed identity
+#   APP_IDENTITY_CLIENT_ID   — client (application) ID of the app managed identity
+#   ADMIN_GROUP_NAME         — display name of the Entra admin group
+#   ADMIN_GROUP_OID          — object ID of the Entra admin group
+
+set -euo pipefail
+
+echo "=== OnRamp SQL Entra Auth Setup ==="
+echo "Server: $SQL_SERVER_FQDN"
+echo "Database: $DATABASE_NAME"
+echo "App identity: $APP_IDENTITY_NAME ($APP_IDENTITY_CLIENT_ID)"
+echo "Admin group: $ADMIN_GROUP_NAME ($ADMIN_GROUP_OID)"
+
+# ── Step 1: Install ODBC driver and pyodbc ──────────────────────────────────
+echo "Installing ODBC driver..."
+apt-get update -qq
+curl -fsSL https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor -o /usr/share/keyrings/microsoft-prod.gpg
+echo "deb [arch=amd64 signed-by=/usr/share/keyrings/microsoft-prod.gpg] https://packages.microsoft.com/debian/12/prod bookworm main" \
+  > /etc/apt/sources.list.d/mssql-release.list
+apt-get update -qq
+ACCEPT_EULA=Y apt-get install -y -qq msodbcsql18 unixodbc-dev > /dev/null 2>&1
+pip install -q pyodbc
+
+# ── Step 2: Get access token for Azure SQL ──────────────────────────────────
+echo "Acquiring access token for Azure SQL..."
+TOKEN=$(az account get-access-token --resource https://database.windows.net --query accessToken -o tsv)
+
+# ── Step 3: Create contained database user for app identity ─────────────────
+echo "Creating contained database user for app identity..."
+python3 << 'PYEOF'
+import os
+import struct
+import sys
+
+try:
+    import pyodbc
+except ImportError:
+    print("ERROR: pyodbc not available", file=sys.stderr)
+    sys.exit(1)
+
+token = os.environ["TOKEN"]
+server = os.environ["SQL_SERVER_FQDN"]
+database = os.environ["DATABASE_NAME"]
+identity_name = os.environ["APP_IDENTITY_NAME"]
+identity_client_id = os.environ["APP_IDENTITY_CLIENT_ID"]
+
+# Pack the access token for ODBC SQL_COPT_SS_ACCESS_TOKEN (1256)
+token_bytes = token.encode("utf-16-le")
+token_struct = struct.pack(f"<I{len(token_bytes)}s", len(token_bytes), token_bytes)
+
+conn_str = (
+    f"Driver={{ODBC Driver 18 for SQL Server}};"
+    f"Server=tcp:{server},1433;"
+    f"Database={database};"
+    f"Encrypt=yes;TrustServerCertificate=no"
+)
+
+print(f"Connecting to {server}/{database}...")
+conn = pyodbc.connect(conn_str, attrs_before={1256: token_struct})
+cursor = conn.cursor()
+
+# Use SID-based user creation to avoid needing Directory Readers on the SQL server.
+# The SID is the binary representation of the managed identity's client (application) ID.
+sql = f"""
+IF NOT EXISTS (SELECT 1 FROM sys.database_principals WHERE name = N'{identity_name}')
+BEGIN
+    DECLARE @sid VARBINARY(16) = CAST(CAST('{identity_client_id}' AS UNIQUEIDENTIFIER) AS VARBINARY(16));
+    DECLARE @sql NVARCHAR(MAX) = N'CREATE USER [{identity_name}] WITH SID = '
+        + '0x' + CONVERT(VARCHAR(MAX), @sid, 2) + ', TYPE = E';
+    EXEC sp_executesql @sql;
+    PRINT 'Created user [{identity_name}]';
+END
+ELSE
+    PRINT 'User [{identity_name}] already exists';
+"""
+cursor.execute(sql)
+conn.commit()
+
+# Grant database roles
+for role in ("db_datareader", "db_datawriter", "db_ddladmin"):
+    cursor.execute(f"ALTER ROLE {role} ADD MEMBER [{identity_name}]")
+    print(f"  Granted {role}")
+conn.commit()
+
+cursor.close()
+conn.close()
+print("Database user setup complete.")
+PYEOF
+
+export TOKEN  # make available to the Python heredoc
+
+# ── Step 4: Switch SQL admin to the Entra group ────────────────────────────
+echo "Switching SQL AD admin to Entra group: $ADMIN_GROUP_NAME..."
+az sql server ad-admin create \
+  --server-name "$SQL_SERVER_NAME" \
+  --resource-group "$RESOURCE_GROUP" \
+  --display-name "$ADMIN_GROUP_NAME" \
+  --object-id "$ADMIN_GROUP_OID" \
+  --output none
+
+echo "=== SQL Entra auth setup complete ==="
+echo "  Admin: $ADMIN_GROUP_NAME (group)"
+echo "  App user: $APP_IDENTITY_NAME (managed identity)"


### PR DESCRIPTION
## Summary

Replaces SQL login authentication with Microsoft Entra ID (Azure AD) for Azure SQL, meeting enterprise security policies that prohibit SQL logins.

## Changes

### Infrastructure (Bicep + ARM)
- **sql.bicep**: Entra-only auth with bootstrap managed identity as initial admin, deployment script creates app MI's contained database user (SID-based), then switches admin to Entra group
- **identity.bicep**: New module for app's user-assigned managed identity (extracted to main level for reuse)
- **main.bicep**: Replaced \sqlAdminLogin\/\sqlAdminPassword\ params with \sqlAdminGroupName\/\sqlAdminGroupObjectId\
- **keyvault.bicep**: Removed SQL password and connection string secrets (no longer needed)
- **container-apps.bicep**: Credential-free connection string via env var (not KV secret), MI client ID env var
- **azuredeploy.json**: Same Entra-only pattern for Deploy to Azure button, new \ownerGroupDisplayName\ parameter
- **Parameter files**: Updated for Entra group name/objectId params

### Backend (Python)
- **session.py**: Entra token auth via SQLAlchemy \do_connect\ event hook, \ManagedIdentityCredential\ with explicit \client_id\, \pool_recycle=1800\ for token refresh
- **config.py**: Added \managed_identity_client_id\ setting (\ONRAMP_MANAGED_IDENTITY_CLIENT_ID\)
- **migrations/env.py**: Entra token auth for standalone Alembic runs
- **startup.py**: Reports 'MSSQL + Entra auth' with MI details in diagnostics
- **Dockerfile**: Installs \.[azure]\ extras when \INSTALL_ODBC=1\

### Tests
- **26 new tests** for \session.py\: Entra URL detection, token packing, credential creation, hook registration, engine configuration, init_db behavior
- **4 new tests** for \startup.py\: Entra SQL auth diagnostics (with MI, without MI, SQL auth, standard MSSQL)

## Architecture Decisions
- **Bootstrap MI pattern**: Separate identity for deployment-time SQL admin avoids giving the runtime app Contributor rights
- **SID-based user creation**: Avoids needing Directory Readers role on SQL server identity
- **Explicit MI targeting**: Uses \ManagedIdentityCredential(client_id=...)\ instead of global \AZURE_CLIENT_ID\ to avoid affecting other credential usage
- **Token lifecycle**: \pool_recycle=1800\ ensures connections refresh well before 60-min token expiry

## Breaking Changes
- \sqlAdminLogin\ and \sqlAdminPassword\ Bicep parameters are removed
- New required parameters: \sqlAdminGroupName\, \sqlAdminGroupObjectId\
- SQL authentication is completely disabled on the Azure SQL server
- \ONRAMP_MANAGED_IDENTITY_CLIENT_ID\ env var required in production
