### PR TITLE
feat: restore app registration deployment script with keyless storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,20 +2,16 @@
 
 [![Deploy to Azure](https://aka.ms/deploytoazurebutton)](https://portal.azure.com/#create/Microsoft.Template/uri/https%3A%2F%2Fraw.githubusercontent.com%2FJoshLuedeman%2Fonramp%2Fmain%2Finfra%2Fazuredeploy.json)
 
-### ☁️ Deploy to Azure — Prerequisites
+### ☁️ Deploy to Azure
 
-Before clicking **Deploy to Azure**, you must create an **Entra ID app registration** for the application:
+By default, the template **automatically creates** an Entra ID app registration. This requires the bootstrap managed identity to have **Microsoft Graph `Application.ReadWrite.All`** permission (requires tenant admin consent).
 
-1. In the Azure portal, go to **Microsoft Entra ID** → **App registrations** → **New registration**
-2. Set the redirect URI to `https://<your-container-app-url>/.auth/login/aad/callback` (you can update this after deployment)
-3. Under **Certificates & secrets**, create a new client secret and note the value
-4. Note the **Application (client) ID** from the app overview page
-
-You will need the **client ID** and **client secret** as parameters when deploying the template.
+Alternatively, set `createAppRegistration` to `false` and provide an existing app registration's **client ID** and **client secret**.
 
 The deployment also requires:
-- An **Entra security group** that will serve as the SQL Server administrator
-- A **user-assigned managed identity** is created automatically by the template for bootstrap operations
+- An **Entra security group** that will serve as the SQL Server administrator (provide the group's Object ID and display name)
+
+> **Note:** All deployment infrastructure uses Entra-only authentication — no shared keys or storage account keys are used anywhere.
 
 **OnRamp** is an AI-powered web application that guides Azure customers through designing and deploying Cloud Adoption Framework (CAF) aligned landing zones. Answer questions about your organization, get an AI-generated architecture recommendation, review it visually, and deploy it to Azure with a single click.
 

--- a/infra/azuredeploy.json
+++ b/infra/azuredeploy.json
@@ -19,16 +19,25 @@
         "description": "Azure region for resources"
       }
     },
-    "entraClientId": {
-      "type": "string",
+    "createAppRegistration": {
+      "type": "bool",
+      "defaultValue": true,
       "metadata": {
-        "description": "Client (Application) ID of the Entra ID app registration for OnRamp. Create this before deployment — see README for instructions."
+        "description": "Set to true to create a new Entra ID app registration automatically, or false to use an existing one. Auto-create requires the bootstrap managed identity to have Microsoft Graph Application.ReadWrite.All permission."
       }
     },
-    "entraClientSecret": {
-      "type": "securestring",
+    "existingClientId": {
+      "type": "string",
+      "defaultValue": "",
       "metadata": {
-        "description": "Client secret for the Entra ID app registration."
+        "description": "If using an existing app registration (createAppRegistration=false), provide its Client (Application) ID. Must not be empty when createAppRegistration is false."
+      }
+    },
+    "existingClientSecret": {
+      "type": "securestring",
+      "defaultValue": "",
+      "metadata": {
+        "description": "If using an existing app registration (createAppRegistration=false), provide its client secret. Must not be empty when createAppRegistration is false."
       }
     },
     "ownerGroupObjectId": {
@@ -57,6 +66,7 @@
     "aciSubnetName": "aci-subnet",
     "peSubnetName": "pe-subnet",
     "scriptStorageName": "[concat('stds', variables('uniqueSuffix'))]",
+    "appRegScriptContent": "#!/bin/bash\n# OnRamp App Registration Setup Script\n# Runs as a deploymentScript in ARM to create or validate an Entra ID app registration.\n# Uses the bootstrap managed identity (requires Microsoft Graph Application.ReadWrite.All).\n\nset -euo pipefail\n\nAPP_NAME=\"${APP_NAME:-OnRamp}\"\nREDIRECT_URI=\"${REDIRECT_URI:-https://onramp.azurewebsites.net}\"\nCREATE_APP=\"${CREATE_APP:-true}\"\nEXISTING_CLIENT_ID=\"${EXISTING_CLIENT_ID:-}\"\nEXISTING_CLIENT_SECRET=\"${EXISTING_CLIENT_SECRET:-}\"\nOWNER_GROUP_OBJECT_ID=\"${OWNER_GROUP_OBJECT_ID:-}\"\nKV_NAME=\"${KV_NAME:-}\"\n\necho \"=== OnRamp App Registration Setup ===\"\necho \"App Name: $APP_NAME\"\necho \"Redirect URI: $REDIRECT_URI\"\necho \"Create New: $CREATE_APP\"\necho \"Owner Group: ${OWNER_GROUP_OBJECT_ID:-<not set>}\"\n\nif [ \"$CREATE_APP\" = \"false\" ] && [ -n \"$EXISTING_CLIENT_ID\" ]; then\n    echo \"Using existing app registration: $EXISTING_CLIENT_ID\"\n\n    # Validate it exists\n    APP_INFO=$(az ad app show --id \"$EXISTING_CLIENT_ID\" -o json 2>/dev/null) || {\n        echo \"ERROR: App registration $EXISTING_CLIENT_ID not found\"\n        exit 1\n    }\n\n    CLIENT_ID=\"$EXISTING_CLIENT_ID\"\n    APP_OBJECT_ID=$(echo \"$APP_INFO\" | jq -r '.id')\n    echo \"Validated existing app: $(echo \"$APP_INFO\" | jq -r '.displayName')\"\n\n    # Store existing client secret in Key Vault if provided\n    if [ -n \"$KV_NAME\" ] && [ -n \"$EXISTING_CLIENT_SECRET\" ]; then\n        az keyvault secret set --vault-name \"$KV_NAME\" --name entra-client-secret \\\n            --value \"$EXISTING_CLIENT_SECRET\" --output none\n        echo \"Stored existing client secret in Key Vault\"\n    fi\nelse\n    echo \"Creating new app registration...\"\n\n    # Verify we have Graph permissions before proceeding\n    az ad app list --top 1 -o none 2>/dev/null || {\n        echo \"ERROR: Bootstrap identity lacks Microsoft Graph permissions.\"\n        echo \"Grant Application.ReadWrite.All to the bootstrap managed identity,\"\n        echo \"or set createAppRegistration=false and provide an existing app registration.\"\n        exit 1\n    }\n\n    # Create the app registration\n    APP_INFO=$(az ad app create \\\n        --display-name \"$APP_NAME\" \\\n        --sign-in-audience \"AzureADMyOrg\" \\\n        --web-redirect-uris \"$REDIRECT_URI\" \"${REDIRECT_URI}/auth/callback\" \"http://localhost:5173\" \"http://localhost:5173/auth/callback\" \\\n        --enable-id-token-issuance true \\\n        --enable-access-token-issuance false \\\n        -o json)\n\n    CLIENT_ID=$(echo \"$APP_INFO\" | jq -r '.appId')\n    APP_OBJECT_ID=$(echo \"$APP_INFO\" | jq -r '.id')\n\n    echo \"Created app registration:\"\n    echo \"  Display Name: $APP_NAME\"\n    echo \"  Client ID: $CLIENT_ID\"\n    echo \"  Object ID: $APP_OBJECT_ID\"\n\n    # Configure the exposed API with identifier URI and access_as_user scope\n    echo \"Configuring exposed API scope...\"\n    az rest --method PATCH --url \"https://graph.microsoft.com/v1.0/applications/$APP_OBJECT_ID\" \\\n        --headers \"Content-Type=application/json\" \\\n        --body \"{\n            \\\"identifierUris\\\": [\\\"api://$CLIENT_ID\\\"],\n            \\\"api\\\": {\n                \\\"oauth2PermissionScopes\\\": [{\n                    \\\"id\\\": \\\"$(cat /proc/sys/kernel/random/uuid)\\\",\n                    \\\"adminConsentDisplayName\\\": \\\"Access OnRamp as user\\\",\n                    \\\"adminConsentDescription\\\": \\\"Allow the application to access OnRamp on behalf of the signed-in user.\\\",\n                    \\\"userConsentDisplayName\\\": \\\"Access OnRamp as user\\\",\n                    \\\"userConsentDescription\\\": \\\"Allow the application to access OnRamp on your behalf.\\\",\n                    \\\"isEnabled\\\": true,\n                    \\\"type\\\": \\\"User\\\",\n                    \\\"value\\\": \\\"access_as_user\\\"\n                }]\n            }\n        }\" --output none 2>/dev/null || echo \"Exposed API scope may already exist\"\n    echo \"  Configured api://$CLIENT_ID/access_as_user scope\"\n\n    # Create a service principal for the app\n    SP_INFO=$(az ad sp create --id \"$CLIENT_ID\" -o json 2>/dev/null) || {\n        echo \"Service principal may already exist, continuing...\"\n        SP_INFO=$(az ad sp show --id \"$CLIENT_ID\" -o json 2>/dev/null) || true\n    }\n    SP_OBJECT_ID=$(echo \"$SP_INFO\" | jq -r '.id // empty')\n\n    # Assign roles at subscription scope\n    SUBSCRIPTION_ID=$(az account show --query id -o tsv)\n    if [ -n \"$SP_OBJECT_ID\" ]; then\n        echo \"Assigning Contributor role to service principal...\"\n        az role assignment create \\\n            --assignee-object-id \"$SP_OBJECT_ID\" \\\n            --assignee-principal-type ServicePrincipal \\\n            --role \"Contributor\" \\\n            --scope \"/subscriptions/$SUBSCRIPTION_ID\" \\\n            2>/dev/null || echo \"Role assignment may already exist\"\n\n        echo \"Assigning User Access Administrator role...\"\n        az role assignment create \\\n            --assignee-object-id \"$SP_OBJECT_ID\" \\\n            --assignee-principal-type ServicePrincipal \\\n            --role \"User Access Administrator\" \\\n            --scope \"/subscriptions/$SUBSCRIPTION_ID\" \\\n            2>/dev/null || echo \"Role assignment may already exist\"\n\n        echo \"  Assigned Contributor and User Access Administrator roles\"\n    else\n        echo \"  Could not determine SP object ID \u00e2\u20ac\u201d assign roles manually\"\n    fi\n\n    # Add required API permissions\n    echo \"Adding Microsoft Graph User.Read permission...\"\n    az ad app permission add \\\n        --id \"$CLIENT_ID\" \\\n        --api 00000003-0000-0000-c000-000000000000 \\\n        --api-permissions e1fe6dd8-ba31-4d61-89e7-88639da4683d=Scope \\\n        2>/dev/null || echo \"Permission may already exist\"\n\n    echo \"Adding Azure Management user_impersonation permission...\"\n    az ad app permission add \\\n        --id \"$CLIENT_ID\" \\\n        --api 797f4846-ba00-4fd7-ba43-dac1f8f63013 \\\n        --api-permissions 41094075-9dad-400e-a0bd-54e686782033=Scope \\\n        2>/dev/null || echo \"Permission may already exist\"\n\n    # Create a client secret\n    echo \"Creating client secret...\"\n    SECRET_INFO=$(az ad app credential reset \\\n        --id \"$CLIENT_ID\" \\\n        --display-name \"OnRamp Deployment\" \\\n        --years 2 \\\n        -o json)\n\n    CLIENT_SECRET=$(echo \"$SECRET_INFO\" | jq -r '.password')\n\n    # Store client secret in Key Vault\n    if [ -n \"$KV_NAME\" ]; then\n        az keyvault secret set --vault-name \"$KV_NAME\" --name entra-client-secret \\\n            --value \"$CLIENT_SECRET\" --output none\n        echo \"Stored client secret in Key Vault\"\n    fi\n\n    echo \"\"\n    echo \"  App Registration Created: $CLIENT_ID\"\n    echo \"  Exposed API: api://$CLIENT_ID/access_as_user\"\n    echo \"  Grant admin consent in Entra ID > App registrations for:\"\n    echo \"    - Microsoft Graph: User.Read\"\n    echo \"    - Azure Service Management: user_impersonation\"\n    echo \"\"\nfi\n\n# Get tenant ID\nTENANT_ID=$(az account show --query tenantId -o tsv)\n\n# Store client ID and tenant ID in Key Vault\nif [ -n \"$KV_NAME\" ]; then\n    az keyvault secret set --vault-name \"$KV_NAME\" --name entra-client-id \\\n        --value \"$CLIENT_ID\" --output none\n    az keyvault secret set --vault-name \"$KV_NAME\" --name entra-tenant-id \\\n        --value \"$TENANT_ID\" --output none\n    echo \"Stored client ID and tenant ID in Key Vault\"\nfi\n\n# Output results as JSON for ARM template to consume\ncat <<EOF > $AZ_SCRIPTS_OUTPUT_DIRECTORY/result.json\n{\n    \"clientId\": \"$CLIENT_ID\",\n    \"tenantId\": \"$TENANT_ID\",\n    \"appObjectId\": \"${APP_OBJECT_ID:-}\"\n}\nEOF\n\necho \"=== App Registration Setup Complete ===\"\n",
     "appUrl": "[concat('https://', parameters('appName'), '-', variables('uniqueSuffix'), '.', parameters('location'), '.azurecontainerapps.io')]"
   },
   "resources": [
@@ -119,34 +129,53 @@
         "roleDefinitionId": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'b86a8fe4-44ce-4948-aee5-eccb2c155cd7')]",
         "principalId": "[reference(resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', variables('identityName'))).principalId]",
         "principalType": "ServicePrincipal",
-        "description": "Allow deployment script identity to write secrets to Key Vault"
+        "description": "Allow app identity to read/write secrets in Key Vault"
+      }
+    },
+    {
+      "type": "Microsoft.Authorization/roleAssignments",
+      "apiVersion": "2022-04-01",
+      "name": "[guid(variables('keyVaultName'), variables('bootstrapIdentityName'), 'KVSecretsOfficer')]",
+      "dependsOn": [
+        "[resourceId('Microsoft.KeyVault/vaults', variables('keyVaultName'))]",
+        "[resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', variables('bootstrapIdentityName'))]"
+      ],
+      "scope": "[concat('Microsoft.KeyVault/vaults/', variables('keyVaultName'))]",
+      "properties": {
+        "roleDefinitionId": "[subscriptionResourceId('Microsoft.Authorization/roleDefinitions', 'b86a8fe4-44ce-4948-aee5-eccb2c155cd7')]",
+        "principalId": "[reference(resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', variables('bootstrapIdentityName'))).principalId]",
+        "principalType": "ServicePrincipal",
+        "description": "Allow bootstrap identity to write secrets to Key Vault during deployment"
       }
     },
     {
       "type": "Microsoft.KeyVault/vaults/secrets",
       "apiVersion": "2023-07-01",
+      "condition": "[not(parameters('createAppRegistration'))]",
       "name": "[concat(variables('keyVaultName'), '/entra-client-id')]",
       "dependsOn": [
         "[resourceId('Microsoft.KeyVault/vaults', variables('keyVaultName'))]"
       ],
       "properties": {
-        "value": "[parameters('entraClientId')]"
+        "value": "[parameters('existingClientId')]"
       }
     },
     {
       "type": "Microsoft.KeyVault/vaults/secrets",
       "apiVersion": "2023-07-01",
+      "condition": "[not(parameters('createAppRegistration'))]",
       "name": "[concat(variables('keyVaultName'), '/entra-client-secret')]",
       "dependsOn": [
         "[resourceId('Microsoft.KeyVault/vaults', variables('keyVaultName'))]"
       ],
       "properties": {
-        "value": "[parameters('entraClientSecret')]"
+        "value": "[parameters('existingClientSecret')]"
       }
     },
     {
       "type": "Microsoft.KeyVault/vaults/secrets",
       "apiVersion": "2023-07-01",
+      "condition": "[not(parameters('createAppRegistration'))]",
       "name": "[concat(variables('keyVaultName'), '/entra-tenant-id')]",
       "dependsOn": [
         "[resourceId('Microsoft.KeyVault/vaults', variables('keyVaultName'))]"
@@ -380,6 +409,63 @@
     {
       "type": "Microsoft.Resources/deploymentScripts",
       "apiVersion": "2023-08-01",
+      "name": "setupAppRegistration",
+      "location": "[parameters('location')]",
+      "kind": "AzureCLI",
+      "condition": "[parameters('createAppRegistration')]",
+      "dependsOn": [
+        "[resourceId('Microsoft.KeyVault/vaults', variables('keyVaultName'))]",
+        "[resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', variables('bootstrapIdentityName'))]",
+        "[guid(variables('keyVaultName'), variables('bootstrapIdentityName'), 'KVSecretsOfficer')]",
+        "[guid(variables('scriptStorageName'), variables('bootstrapIdentityName'), 'StorageFileDataPrivilegedContributor')]",
+        "[resourceId('Microsoft.Network/privateEndpoints/privateDnsZoneGroups', concat(variables('scriptStorageName'), '-file-pe'), 'default')]",
+        "[resourceId('Microsoft.Network/privateDnsZones/virtualNetworkLinks', concat('privatelink.file.', environment().suffixes.storage), concat(variables('vnetName'), '-file-link'))]"
+      ],
+      "identity": {
+        "type": "UserAssigned",
+        "userAssignedIdentities": {
+          "[resourceId('Microsoft.ManagedIdentity/userAssignedIdentities', variables('bootstrapIdentityName'))]": {}
+        }
+      },
+      "properties": {
+        "azCliVersion": "2.60.0",
+        "retentionInterval": "P1D",
+        "timeout": "PT10M",
+        "storageAccountSettings": {
+          "storageAccountName": "[variables('scriptStorageName')]"
+        },
+        "containerSettings": {
+          "subnetIds": [
+            {
+              "id": "[resourceId('Microsoft.Network/virtualNetworks/subnets', variables('vnetName'), variables('aciSubnetName'))]"
+            }
+          ]
+        },
+        "environmentVariables": [
+          {
+            "name": "APP_NAME",
+            "value": "[concat('OnRamp-', variables('uniqueSuffix'))]"
+          },
+          { "name": "REDIRECT_URI", "value": "[variables('appUrl')]" },
+          {
+            "name": "CREATE_APP",
+            "value": "[string(parameters('createAppRegistration'))]"
+          },
+          { "name": "EXISTING_CLIENT_ID", "value": "[parameters('existingClientId')]" },
+          {
+            "name": "EXISTING_CLIENT_SECRET",
+            "secureValue": "[parameters('existingClientSecret')]"
+          },
+          { "name": "OWNER_GROUP_OBJECT_ID", "value": "[parameters('ownerGroupObjectId')]" },
+          { "name": "KV_NAME", "value": "[variables('keyVaultName')]" }
+        ],
+        "scriptContent": "[variables('appRegScriptContent')]",
+        "cleanupPreference": "OnSuccess"
+      }
+    },
+    {
+      "type": "Microsoft.Resources/deploymentScripts",
+      "apiVersion": "2023-08-01",
       "name": "setupSqlEntraUser",
       "location": "[parameters('location')]",
       "kind": "AzureCLI",
@@ -474,11 +560,11 @@
     },
     "entraClientId": {
       "type": "string",
-      "value": "[parameters('entraClientId')]"
+      "value": "[if(parameters('createAppRegistration'), reference('setupAppRegistration').outputs.clientId, parameters('existingClientId'))]"
     },
     "entraSetupNotes": {
       "type": "string",
-      "value": "App registration must be created before deployment. See README for instructions."
+      "value": "[if(parameters('createAppRegistration'), 'App registration created automatically. Grant admin consent for API permissions in Entra ID > App registrations.', 'Using existing app registration.')]"
     }
   }
 }

--- a/infra/scripts/setup-app-registration.sh
+++ b/infra/scripts/setup-app-registration.sh
@@ -1,15 +1,17 @@
 #!/bin/bash
 # OnRamp App Registration Setup Script
 # Runs as a deploymentScript in ARM to create or validate an Entra ID app registration.
-# Uses the deploying user's identity (via managedIdentity or user-assigned identity).
+# Uses the bootstrap managed identity (requires Microsoft Graph Application.ReadWrite.All).
 
-set -e
+set -euo pipefail
 
 APP_NAME="${APP_NAME:-OnRamp}"
 REDIRECT_URI="${REDIRECT_URI:-https://onramp.azurewebsites.net}"
 CREATE_APP="${CREATE_APP:-true}"
 EXISTING_CLIENT_ID="${EXISTING_CLIENT_ID:-}"
+EXISTING_CLIENT_SECRET="${EXISTING_CLIENT_SECRET:-}"
 OWNER_GROUP_OBJECT_ID="${OWNER_GROUP_OBJECT_ID:-}"
+KV_NAME="${KV_NAME:-}"
 
 echo "=== OnRamp App Registration Setup ==="
 echo "App Name: $APP_NAME"
@@ -17,41 +19,74 @@ echo "Redirect URI: $REDIRECT_URI"
 echo "Create New: $CREATE_APP"
 echo "Owner Group: ${OWNER_GROUP_OBJECT_ID:-<not set>}"
 
-# Install az cli extensions if needed
-az extension add --name account 2>/dev/null || true
-
 if [ "$CREATE_APP" = "false" ] && [ -n "$EXISTING_CLIENT_ID" ]; then
     echo "Using existing app registration: $EXISTING_CLIENT_ID"
-    
+
     # Validate it exists
     APP_INFO=$(az ad app show --id "$EXISTING_CLIENT_ID" -o json 2>/dev/null) || {
         echo "ERROR: App registration $EXISTING_CLIENT_ID not found"
         exit 1
     }
-    
+
     CLIENT_ID="$EXISTING_CLIENT_ID"
     APP_OBJECT_ID=$(echo "$APP_INFO" | jq -r '.id')
     echo "Validated existing app: $(echo "$APP_INFO" | jq -r '.displayName')"
+
+    # Store existing client secret in Key Vault if provided
+    if [ -n "$KV_NAME" ] && [ -n "$EXISTING_CLIENT_SECRET" ]; then
+        az keyvault secret set --vault-name "$KV_NAME" --name entra-client-secret \
+            --value "$EXISTING_CLIENT_SECRET" --output none
+        echo "Stored existing client secret in Key Vault"
+    fi
 else
     echo "Creating new app registration..."
-    
+
+    # Verify we have Graph permissions before proceeding
+    az ad app list --top 1 -o none 2>/dev/null || {
+        echo "ERROR: Bootstrap identity lacks Microsoft Graph permissions."
+        echo "Grant Application.ReadWrite.All to the bootstrap managed identity,"
+        echo "or set createAppRegistration=false and provide an existing app registration."
+        exit 1
+    }
+
     # Create the app registration
     APP_INFO=$(az ad app create \
         --display-name "$APP_NAME" \
         --sign-in-audience "AzureADMyOrg" \
         --web-redirect-uris "$REDIRECT_URI" "${REDIRECT_URI}/auth/callback" "http://localhost:5173" "http://localhost:5173/auth/callback" \
         --enable-id-token-issuance true \
-        --enable-access-token-issuance true \
+        --enable-access-token-issuance false \
         -o json)
-    
+
     CLIENT_ID=$(echo "$APP_INFO" | jq -r '.appId')
     APP_OBJECT_ID=$(echo "$APP_INFO" | jq -r '.id')
-    
+
     echo "Created app registration:"
     echo "  Display Name: $APP_NAME"
     echo "  Client ID: $CLIENT_ID"
     echo "  Object ID: $APP_OBJECT_ID"
-    
+
+    # Configure the exposed API with identifier URI and access_as_user scope
+    echo "Configuring exposed API scope..."
+    az rest --method PATCH --url "https://graph.microsoft.com/v1.0/applications/$APP_OBJECT_ID" \
+        --headers "Content-Type=application/json" \
+        --body "{
+            \"identifierUris\": [\"api://$CLIENT_ID\"],
+            \"api\": {
+                \"oauth2PermissionScopes\": [{
+                    \"id\": \"$(cat /proc/sys/kernel/random/uuid)\",
+                    \"adminConsentDisplayName\": \"Access OnRamp as user\",
+                    \"adminConsentDescription\": \"Allow the application to access OnRamp on behalf of the signed-in user.\",
+                    \"userConsentDisplayName\": \"Access OnRamp as user\",
+                    \"userConsentDescription\": \"Allow the application to access OnRamp on your behalf.\",
+                    \"isEnabled\": true,
+                    \"type\": \"User\",
+                    \"value\": \"access_as_user\"
+                }]
+            }
+        }" --output none 2>/dev/null || echo "Exposed API scope may already exist"
+    echo "  Configured api://$CLIENT_ID/access_as_user scope"
+
     # Create a service principal for the app
     SP_INFO=$(az ad sp create --id "$CLIENT_ID" -o json 2>/dev/null) || {
         echo "Service principal may already exist, continuing..."
@@ -59,10 +94,10 @@ else
     }
     SP_OBJECT_ID=$(echo "$SP_INFO" | jq -r '.id // empty')
 
-    # Assign Contributor role at subscription scope so the SP can deploy resources
+    # Assign roles at subscription scope
     SUBSCRIPTION_ID=$(az account show --query id -o tsv)
     if [ -n "$SP_OBJECT_ID" ]; then
-        echo "Assigning Contributor role to service principal at subscription scope..."
+        echo "Assigning Contributor role to service principal..."
         az role assignment create \
             --assignee-object-id "$SP_OBJECT_ID" \
             --assignee-principal-type ServicePrincipal \
@@ -70,7 +105,6 @@ else
             --scope "/subscriptions/$SUBSCRIPTION_ID" \
             2>/dev/null || echo "Role assignment may already exist"
 
-        # Also assign User Access Administrator so it can manage RBAC for landing zones
         echo "Assigning User Access Administrator role..."
         az role assignment create \
             --assignee-object-id "$SP_OBJECT_ID" \
@@ -79,30 +113,26 @@ else
             --scope "/subscriptions/$SUBSCRIPTION_ID" \
             2>/dev/null || echo "Role assignment may already exist"
 
-        echo "  ✅ Contributor role assigned (create resource groups, deploy resources)"
-        echo "  ✅ User Access Administrator role assigned (assign RBAC in landing zones)"
+        echo "  Assigned Contributor and User Access Administrator roles"
     else
-        echo "  ⚠️  Could not determine SP object ID — assign roles manually:"
-        echo "     az role assignment create --assignee $CLIENT_ID --role Contributor --scope /subscriptions/$SUBSCRIPTION_ID"
+        echo "  Could not determine SP object ID — assign roles manually"
     fi
 
     # Add required API permissions
-    # Microsoft Graph - User.Read (delegated)
     echo "Adding Microsoft Graph User.Read permission..."
     az ad app permission add \
         --id "$CLIENT_ID" \
         --api 00000003-0000-0000-c000-000000000000 \
         --api-permissions e1fe6dd8-ba31-4d61-89e7-88639da4683d=Scope \
         2>/dev/null || echo "Permission may already exist"
-    
-    # Azure Service Management - user_impersonation (delegated)
+
     echo "Adding Azure Management user_impersonation permission..."
     az ad app permission add \
         --id "$CLIENT_ID" \
         --api 797f4846-ba00-4fd7-ba43-dac1f8f63013 \
         --api-permissions 41094075-9dad-400e-a0bd-54e686782033=Scope \
         2>/dev/null || echo "Permission may already exist"
-    
+
     # Create a client secret
     echo "Creating client secret..."
     SECRET_INFO=$(az ad app credential reset \
@@ -110,58 +140,35 @@ else
         --display-name "OnRamp Deployment" \
         --years 2 \
         -o json)
-    
+
     CLIENT_SECRET=$(echo "$SECRET_INFO" | jq -r '.password')
-    
+
+    # Store client secret in Key Vault
+    if [ -n "$KV_NAME" ]; then
+        az keyvault secret set --vault-name "$KV_NAME" --name entra-client-secret \
+            --value "$CLIENT_SECRET" --output none
+        echo "Stored client secret in Key Vault"
+    fi
+
     echo ""
-    echo "============================================"
-    echo "  App Registration Created Successfully"
-    echo "============================================"
-    echo ""
-    echo "  Client ID:     $CLIENT_ID"
-    echo "  Tenant ID:     $(az account show --query tenantId -o tsv)"
-    echo ""
-    echo "  Required Permissions (grant admin consent in portal):"
+    echo "  App Registration Created: $CLIENT_ID"
+    echo "  Exposed API: api://$CLIENT_ID/access_as_user"
+    echo "  Grant admin consent in Entra ID > App registrations for:"
     echo "    - Microsoft Graph: User.Read"
     echo "    - Azure Service Management: user_impersonation"
-    echo ""
-    echo "  Azure RBAC Roles (assigned at subscription scope):"
-    echo "    - Contributor: create resource groups and deploy resources"
-    echo "    - User Access Administrator: assign RBAC roles in landing zones"
-    echo ""
-    echo "  The app registration allows OnRamp to:"
-    echo "    1. Sign in users with their Entra ID identity"
-    echo "    2. Read basic user profile information"
-    echo "    3. Deploy Azure resources (resource groups, VNets, policies, etc.)"
-    echo "    4. Assign RBAC roles within deployed landing zones"
-    echo ""
-    echo "  Redirect URIs configured:"
-    echo "    - $REDIRECT_URI"
-    echo "    - ${REDIRECT_URI}/auth/callback"
-    echo "    - http://localhost:5173 (development)"
-    echo "    - http://localhost:5173/auth/callback (development)"
     echo ""
 fi
 
 # Get tenant ID
 TENANT_ID=$(az account show --query tenantId -o tsv)
-SUBSCRIPTION_ID=$(az account show --query id -o tsv)
 
-# Assign Owner role to the specified Entra group on the subscription
-if [ -n "$OWNER_GROUP_OBJECT_ID" ]; then
-    echo ""
-    echo "Assigning Owner role to Entra group $OWNER_GROUP_OBJECT_ID..."
-    az role assignment create \
-        --assignee-object-id "$OWNER_GROUP_OBJECT_ID" \
-        --assignee-principal-type Group \
-        --role "Owner" \
-        --scope "/subscriptions/$SUBSCRIPTION_ID" \
-        2>/dev/null || echo "Owner role assignment may already exist"
-    echo "  ✅ Owner role assigned to group on subscription $SUBSCRIPTION_ID"
-else
-    echo ""
-    echo "  ⚠️  No owner group specified. Assign Owner manually to an Entra group:"
-    echo "     az role assignment create --assignee-object-id <GROUP_OBJECT_ID> --assignee-principal-type Group --role Owner --scope /subscriptions/$SUBSCRIPTION_ID"
+# Store client ID and tenant ID in Key Vault
+if [ -n "$KV_NAME" ]; then
+    az keyvault secret set --vault-name "$KV_NAME" --name entra-client-id \
+        --value "$CLIENT_ID" --output none
+    az keyvault secret set --vault-name "$KV_NAME" --name entra-tenant-id \
+        --value "$TENANT_ID" --output none
+    echo "Stored client ID and tenant ID in Key Vault"
 fi
 
 # Output results as JSON for ARM template to consume
@@ -169,9 +176,8 @@ cat <<EOF > $AZ_SCRIPTS_OUTPUT_DIRECTORY/result.json
 {
     "clientId": "$CLIENT_ID",
     "tenantId": "$TENANT_ID",
-    "appObjectId": "${APP_OBJECT_ID:-}",
-    "clientSecret": "${CLIENT_SECRET:-}"
+    "appObjectId": "${APP_OBJECT_ID:-}"
 }
 EOF
 
-echo "Setup complete. Results written for deployment pipeline."
+echo "=== App Registration Setup Complete ==="


### PR DESCRIPTION
## Summary

Restores the setupAppRegistration deployment script that was removed in v0.11.1. Now uses the same VNet-isolated keyless storage infrastructure as the SQL setup script.

## Changes

- Restored setupAppRegistration deployment script with createAppRegistration parameter (default: true)
- Added KV Secrets Officer for bootstrap identity (enables script to write secrets to Key Vault)
- Updated script to configure api://clientId/access_as_user exposed API scope (required by frontend MSAL)
- Fail-fast if bootstrap MI lacks Microsoft Graph permissions
- Conditional KV secrets: when auto-creating, script writes to KV; when using existing, ARM resources set them
- No secrets in ARM outputs - client secret is stored directly in KV by the script
- Both scripts share the same VNet/PE/storage infrastructure (no additional resources)

## Prerequisites for Auto-Create Mode

The bootstrap managed identity needs Microsoft Graph Application.ReadWrite.All app role (requires tenant admin consent).
